### PR TITLE
Add Google Site Verification meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Tokyo Private Tour Guide - Licensed Professional Walking Tours</title>
     <meta name="description" content="Experience authentic Tokyo with a licensed professional tour guide. Private walking tours of Asakusa, Yanaka, Shibuya, and more. Book your personalized Tokyo adventure today." />
     <meta name="author" content="Manabu - Tokyo Tour Guide" />
+    <meta name="google-site-verification" content="VnhwzF1aG0HWEowI9D68NkcX69nlmLf4n4dM2aeaBRE" />
 
     <meta property="og:title" content="Tokyo Private Tour Guide - Licensed Professional Walking Tours" />
     <meta property="og:description" content="Experience authentic Tokyo with a licensed professional tour guide. Private walking tours of Asakusa, Yanaka, Shibuya, and more." />


### PR DESCRIPTION
## Summary
Added Google Site Verification meta tag to the HTML head section to enable Google Search Console verification for the Tokyo tour guide website.

## Changes
- Added `<meta name="google-site-verification" content="VnhwzF1aG0HWEowI9D68NkcX69nlmLf4n4dM2aeaBRE" />` to the document head in `index.html`

## Details
This meta tag is required by Google Search Console to verify ownership of the domain. Once verified, it will allow access to search performance data, indexing status, and other SEO insights for the Tokyo Private Tour Guide website.

https://claude.ai/code/session_012W4dHmJz5KhoSuF7FHVjaw