### PR TITLE
Enhance SEO and rebrand to Tanuki Tabi Travel with credibility updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,19 +3,22 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tokyo Private Tour Guide - Licensed Professional Walking Tours</title>
-    <meta name="description" content="Experience authentic Tokyo with a licensed professional tour guide. Private walking tours of Asakusa, Yanaka, Shibuya, and more. Book your personalized Tokyo adventure today." />
-    <meta name="author" content="Manabu - Tokyo Tour Guide" />
+    <title>Tokyo Private Tour Guide | Licensed Walking Tours | Tanuki Tabi Travel</title>
+    <meta name="description" content="Explore Tokyo with a government-licensed private tour guide. 516+ tours completed with 4.86★ rating. Custom walking tours of Asakusa, Shibuya, Ginza & more. Book your personal Tokyo experience." />
+    <meta name="author" content="Manabu - Government-Licensed Tour Guide" />
     <meta name="google-site-verification" content="VnhwzF1aG0HWEowI9D68NkcX69nlmLf4n4dM2aeaBRE" />
 
-    <meta property="og:title" content="Tokyo Private Tour Guide - Licensed Professional Walking Tours" />
-    <meta property="og:description" content="Experience authentic Tokyo with a licensed professional tour guide. Private walking tours of Asakusa, Yanaka, Shibuya, and more." />
+    <meta property="og:title" content="Tokyo Private Tour Guide | Licensed Walking Tours | Tanuki Tabi Travel" />
+    <meta property="og:description" content="Explore Tokyo with a government-licensed private tour guide. 516+ tours completed with 4.86★ rating. Custom walking tours of Asakusa, Shibuya, Ginza & more." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta property="og:url" content="https://tanuki-tabi-travel.com" />
+    <meta property="og:site_name" content="Tanuki Tabi Travel" />
+    <meta property="og:image" content="https://tanuki-tabi-travel.com/og-image.png" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@Lovable" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta name="twitter:title" content="Tokyo Private Tour Guide | Licensed Walking Tours | Tanuki Tabi Travel" />
+    <meta name="twitter:description" content="Explore Tokyo with a government-licensed private tour guide. 516+ tours completed with 4.86★ rating." />
+    <meta name="twitter:image" content="https://tanuki-tabi-travel.com/og-image.png" />
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^2.0.5",
         "react-hook-form": "^7.61.1",
         "react-resizable-panels": "^2.1.9",
         "react-router-dom": "^6.30.1",
@@ -4409,6 +4410,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5626,6 +5636,26 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.61.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
@@ -5960,6 +5990,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.61.1",
     "react-resizable-panels": "^2.1.9",
     "react-router-dom": "^6.30.1",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,7 +4,6 @@
 User-agent: *
 Allow: /
 Disallow: /api/
-Disallow: /_next/
 Disallow: /assets/
 
 # Google

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,12 +8,6 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://tanuki-tabi-travel.com/tours</loc>
-    <lastmod>2026-02-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://tanuki-tabi-travel.com/about</loc>
     <lastmod>2026-02-25</lastmod>
     <changefreq>monthly</changefreq>
@@ -23,13 +17,19 @@
     <loc>https://tanuki-tabi-travel.com/contact</loc>
     <lastmod>2026-02-25</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://tanuki-tabi-travel.com/faq</loc>
+    <loc>https://tanuki-tabi-travel.com/privacy-policy</loc>
     <lastmod>2026-02-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/tour-policies</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
   </url>
 
   <!-- Tour Detail Pages -->
@@ -67,6 +67,6 @@
     <loc>https://tanuki-tabi-travel.com/tours/custom</loc>
     <lastmod>2026-02-25</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.9</priority>
   </url>
 </urlset>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,42 @@
+import { Helmet } from "react-helmet-async";
+
+interface SEOProps {
+  title: string;
+  description: string;
+  canonicalPath: string;
+  ogImage?: string;
+}
+
+const BASE_URL = "https://tanuki-tabi-travel.com";
+const DEFAULT_OG_IMAGE = `${BASE_URL}/og-image.png`;
+
+export const SEO = ({
+  title,
+  description,
+  canonicalPath,
+  ogImage = DEFAULT_OG_IMAGE,
+}: SEOProps) => {
+  const canonicalUrl = `${BASE_URL}${canonicalPath}`;
+
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={canonicalUrl} />
+
+      {/* Open Graph */}
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content={ogImage} />
+      <meta property="og:site_name" content="Tanuki Tabi Travel" />
+
+      {/* Twitter Card */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={ogImage} />
+    </Helmet>
+  );
+};

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -7,30 +7,69 @@ export const Footer = () => {
       <div className="container-section py-16">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-12">
           {/* Brand */}
-          <div className="md:col-span-2">
+          <div>
             <Link to="/" className="inline-block">
               <span className="font-serif text-2xl font-semibold">
-                Tokyo<span className="text-accent">Guide</span>
+                Tanuki<span className="text-accent">Tabi</span>
               </span>
             </Link>
             <p className="mt-4 text-primary-foreground/70 max-w-sm leading-relaxed">
-              Experience authentic Tokyo with a local professional guide. 
-              Discover hidden gems, cultural insights, and local stories.
+              Private walking tours of Tokyo with a government-licensed guide.
+              516+ tours completed. 4.86★ average rating.
             </p>
             <div className="flex items-center gap-4 mt-6">
               <a
                 href="mailto:info@tanuki-tabi-travel.com"
                 className="p-2 rounded-full bg-primary-foreground/10 hover:bg-primary-foreground/20 transition-colors"
+                aria-label="Email us"
               >
                 <Mail className="w-5 h-5" />
               </a>
               <a
                 href="#"
                 className="p-2 rounded-full bg-primary-foreground/10 hover:bg-primary-foreground/20 transition-colors"
+                aria-label="Follow us on Instagram"
               >
                 <Instagram className="w-5 h-5" />
               </a>
             </div>
+          </div>
+
+          {/* Tours */}
+          <div>
+            <h4 className="font-serif text-lg font-medium mb-4">Tours</h4>
+            <ul className="space-y-3">
+              <li>
+                <Link to="/tours/asakusa" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Asakusa Tour
+                </Link>
+              </li>
+              <li>
+                <Link to="/tours/yanaka" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Yanaka Tour
+                </Link>
+              </li>
+              <li>
+                <Link to="/tours/shibuya-harajuku" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Shibuya & Harajuku
+                </Link>
+              </li>
+              <li>
+                <Link to="/tours/tsukiji-ginza" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Tsukiji & Ginza
+                </Link>
+              </li>
+              <li>
+                <Link to="/tours/imperial-palace" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Imperial Palace
+                </Link>
+              </li>
+              <li>
+                <Link to="/tours/custom" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Custom Tour
+                </Link>
+              </li>
+            </ul>
           </div>
 
           {/* Quick Links */}
@@ -54,7 +93,7 @@ export const Footer = () => {
               </li>
               <li>
                 <Link to="/contact" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
-                  Contact
+                  Contact / Book
                 </Link>
               </li>
             </ul>
@@ -80,8 +119,8 @@ export const Footer = () => {
 
         <div className="mt-12 pt-8 border-t border-primary-foreground/10">
           <div className="flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-primary-foreground/50">
-            <p>© 2024 Tokyo Guide by Manabu. All rights reserved.</p>
-            <p>Private Tour Guide · Tokyo, Japan</p>
+            <p>&copy; {new Date().getFullYear()} Tanuki Tabi Travel by Manabu. All rights reserved.</p>
+            <p>Government-Licensed Private Tour Guide · Tokyo, Japan</p>
           </div>
         </div>
       </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,7 +21,7 @@ export const Header = () => {
           {/* Logo */}
           <Link to="/" className="flex items-center gap-2">
             <span className="font-serif text-xl md:text-2xl font-semibold text-foreground">
-              Tokyo<span className="text-accent">Guide</span>
+              Tanuki<span className="text-accent">Tabi</span>
             </span>
           </Link>
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
+import { HelmetProvider } from "react-helmet-async";
 import App from "./App.tsx";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <HelmetProvider>
+    <App />
+  </HelmetProvider>
+);

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,31 +1,32 @@
 import { Link } from "react-router-dom";
-import { Award, Globe, Briefcase, Heart, MapPin, Languages } from "lucide-react";
+import { Award, Globe, Briefcase, Heart, MapPin, Languages, Shield, Users, BookOpen, Utensils, Star } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
 import guidePortrait from "@/assets/About_page_Manabu_team_photo.webp";
 import heroImage from "@/assets/hero-asakusa.jpg";
 
 const stats = [
-  { label: "Years Guiding", value: "3+" },
-  { label: "Happy Guests", value: "100+" },
+  { label: "Tours Completed", value: "516+" },
+  { label: "Average Rating", value: "4.86★" },
   { label: "Languages", value: "3" },
   { label: "Tour Areas", value: "5+" },
 ];
 
 const credentials = [
   {
-    icon: Award,
-    title: "Deep Japan Knowledge",
-    description: "Born in Kanazawa, raised in Kyoto, now based in Tokyo. I bring unique insights from Japan's most culturally rich regions.",
+    icon: Shield,
+    title: "Government-Licensed Guide",
+    description: "National Government Licensed Guide Interpreter (全国通訳案内士) — the highest professional guiding certification in Japan, requiring extensive knowledge of history, culture, geography, and fluency in English.",
   },
   {
     icon: Globe,
     title: "International Experience",
-    description: "Extensive overseas work experience bringing global perspective and cross-cultural communication skills.",
+    description: "Extensive overseas work experience bringing global perspective and cross-cultural communication skills to every tour.",
   },
   {
     icon: Briefcase,
     title: "Business Background",
-    description: "Professional business experience ensures smooth, well-organized tours with excellent communication.",
+    description: "Professional business experience ensures smooth, well-organized tours with excellent communication and attention to detail.",
   },
   {
     icon: Languages,
@@ -34,9 +35,91 @@ const credentials = [
   },
 ];
 
+const whyChooseGuide = [
+  {
+    icon: Users,
+    title: "Your Pace, Your Way",
+    description: "Private tours mean no waiting for strangers. Walk at your speed, linger where you're curious, and skip what doesn't interest you.",
+  },
+  {
+    icon: Shield,
+    title: "Certified Quality",
+    description: "A nationally licensed guide has passed rigorous government exams covering Japanese history, geography, culture, and language proficiency.",
+  },
+  {
+    icon: BookOpen,
+    title: "Beyond the Guidebook",
+    description: "Discover hidden temples, local-only shops, and neighborhood stories that you won't find in any travel app or blog.",
+  },
+  {
+    icon: Utensils,
+    title: "Full Travel Support",
+    description: "From restaurant reservations and train navigation to cultural etiquette tips — your guide handles the details so you can enjoy the journey.",
+  },
+];
+
+const platforms = [
+  {
+    name: "GuruWalk",
+    url: "https://www.guruwalk.com/",
+    description: "Free walking tour platform",
+  },
+  {
+    name: "GetYourGuide",
+    url: "https://www.getyourguide.com/",
+    description: "Global tours and activities",
+  },
+  {
+    name: "GoWithGuide",
+    url: "https://www.gowithguide.com/",
+    description: "Licensed private guide booking",
+  },
+];
+
+const allReviews = [
+  {
+    text: "We did 3 tours in Tokyo and Manabu's was by far the most informative and engaging. He was very clear in his delivery and offered interesting cultural insights as sidebars to each venue we visited. Highly recommended!",
+    author: "Couple visiting Tokyo",
+  },
+  {
+    text: "Manabu's tour was one of the best I've been on — he is professional, kind, very knowledgeable and an awesome story-teller. His route is well-planned and offers fun experiences. You can tell he is a full-time tour guide because of the effort he puts in.",
+    author: "Solo traveler",
+  },
+  {
+    text: "This was an excellent tour. Manabu was entertaining, charismatic and knowledgeable. All places visited were awesome and he provided very interesting tips. A great start to our Japan trip.",
+    author: "First-time visitors to Japan",
+  },
+  {
+    text: "Manabu was simply amazing! He speaks a very good level of English, so he's very clear in the explanations. He shared interesting insights about Japanese culture that I really appreciated. The tour points of interest are the ones to be seen and with him I was able to notice things I'd have never understood.",
+    author: "Traveler from Italy",
+  },
+  {
+    text: "We are from Europe and enjoyed a lot of walking tours. Here in Japan they are not so spread yet, but Manabu's is one of the best we ever had! Perfect length and rhythm, with great tips about food, local culture, and curiosities about Asakusa. Extremely recommended.",
+    author: "Couple from Europe",
+  },
+  {
+    text: "Our family did a walking tour with Manabu and it was a fantastic experience. The route is very child friendly, mostly on flat ground and suitable for prams. We have learned a lot about Japan and the Japanese people. He made sure he gave his attention to everyone in the group. Highly recommended.",
+    author: "Family group",
+  },
+  {
+    text: "As a group with a wheelchair user in our party, he really made sure to take the time to make sure we had got back to the group, especially in areas like Senso-ji which was very crowded. As a result, we felt included and that we didn't miss out on any information either! 10/10",
+    author: "Group from the UK",
+  },
+  {
+    text: "This is my second tour with Manabu so that's saying something! Really enjoyed his engaging, cultural anecdotes. He was very professional and easy to listen to.",
+    author: "Repeat visitor",
+  },
+];
+
 const About = () => {
   return (
     <Layout>
+      <SEO
+        title="About Your Guide Manabu | Licensed Tokyo Tour Guide | Tanuki Tabi Travel"
+        description="Meet Manabu, a government-licensed tour guide (全国通訳案内士) with 516+ tours and 4.86★ rating. Discover why travelers trust Tanuki Tabi Travel."
+        canonicalPath="/about"
+      />
+
       {/* Hero Section */}
       <section className="relative py-20 bg-secondary/30">
         <div className="container-section">
@@ -44,19 +127,22 @@ const About = () => {
             <div>
               <p className="text-label text-accent mb-3">About Your Guide</p>
               <h1 className="heading-display text-foreground">
-                Hello, I'm <span className="text-accent">Manabu</span>
+                Meet Your Guide: <span className="text-accent">Manabu</span>
               </h1>
               <p className="mt-6 text-lg text-muted-foreground leading-relaxed">
-                I'm a professional tour guide based in Tokyo. Born in Kanazawa,
-                raised in Kyoto, and now living in Tokyo—I bring a unique perspective
-                from Japan's most culturally rich regions to share with visitors
-                from around the world.
+                I'm Manabu, a National Government Licensed Guide Interpreter
+                (全国通訳案内士) based in Tokyo. This is a national certification
+                issued by the Japanese government, requiring extensive knowledge
+                of Japanese history, culture, geography, and fluency in English.
+                Only certified guides are legally recognized as professional
+                tour guides in Japan.
               </p>
               <p className="mt-4 text-muted-foreground leading-relaxed">
-                My journey to becoming a guide started with my own curiosity about
-                the stories behind Tokyo's temples, neighborhoods, and traditions.
-                Combined with my international business experience and passion for
-                cross-cultural exchange, guiding became my calling.
+                Born in Kanazawa, raised in Kyoto, and now living in Tokyo — I
+                bring a unique perspective from Japan's most culturally rich
+                regions. With over 516 tours completed and a 4.86-star average
+                rating, I'm passionate about sharing Japan's stories with
+                travelers from around the world.
               </p>
 
               <div className="mt-8 grid grid-cols-2 sm:grid-cols-4 gap-6">
@@ -73,7 +159,7 @@ const About = () => {
               <div className="aspect-[3/4] rounded-lg overflow-hidden shadow-[var(--shadow-medium)]">
                 <img
                   src={guidePortrait}
-                  alt="Manabu - Tokyo Tour Guide"
+                  alt="Manabu, government-licensed Tokyo private tour guide"
                   className="w-full h-full object-cover"
                 />
               </div>
@@ -82,38 +168,70 @@ const About = () => {
         </div>
       </section>
 
-      {/* Why I Became a Guide */}
+      {/* My Guiding Philosophy */}
       <section className="py-20">
         <div className="container-section">
           <div className="max-w-3xl mx-auto text-center">
-            <p className="text-label text-accent mb-3">My Story</p>
+            <p className="text-label text-accent mb-3">My Approach</p>
             <h2 className="heading-section text-foreground">
-              Why I Became a Guide
+              How I Guide
             </h2>
             <div className="mt-8 text-muted-foreground leading-relaxed space-y-4 text-left">
               <p>
-                Growing up in Japan, I always felt a deep connection to the traditions
-                and stories passed down through generations. But it wasn't until I
-                started working internationally that I truly understood how unique
-                and fascinating Japanese culture appears to people from other countries.
+                My guiding philosophy is built on one principle: <strong className="text-foreground">every traveler
+                is different</strong>. In the first 30 minutes of every tour, I pay close
+                attention to what excites you — whether it's architecture, street
+                food, historical trivia, or photography — and I adapt the route
+                in real time.
+              </p>
+              <p>
+                I don't deliver scripted monologues. My tours are conversations.
+                I'll share stories and cultural context, but I also want to hear
+                your questions, your observations, and what surprises you about
+                Japan. That back-and-forth is what makes the experience memorable.
               </p>
               <p>
                 My years in business gave me the opportunity to travel and work with
                 people from diverse backgrounds. I noticed how visitors to Japan often
-                missed the context and meaning behind what they were seeing—the "why"
-                that makes experiences truly memorable.
-              </p>
-              <p>
-                That's when I decided to combine my professional skills with my passion
-                for sharing Japan. I dedicated myself to creating authentic, insightful
-                experiences that go beyond typical sightseeing.
+                missed the context and meaning behind what they were seeing — the "why"
+                that makes experiences truly meaningful.
               </p>
               <p className="font-medium text-foreground">
                 Today, nothing brings me more joy than seeing the moment of understanding
-                in a guest's eyes—when a temple isn't just old stones, but a living
+                in a guest's eyes — when a temple isn't just old stones, but a living
                 connection to centuries of belief and craftsmanship.
               </p>
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose a Licensed Private Guide */}
+      <section className="py-20 bg-secondary/30">
+        <div className="container-section">
+          <div className="text-center max-w-2xl mx-auto mb-12">
+            <p className="text-label text-accent mb-3">Advantages</p>
+            <h2 className="heading-section text-foreground">
+              Why Choose a Licensed Private Guide?
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-8">
+            {whyChooseGuide.map((item) => (
+              <div key={item.title} className="flex gap-5 p-6 bg-card border border-border rounded-lg">
+                <div className="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center shrink-0">
+                  <item.icon className="w-6 h-6 text-accent" />
+                </div>
+                <div>
+                  <h3 className="font-serif text-lg font-medium text-foreground">
+                    {item.title}
+                  </h3>
+                  <p className="mt-2 text-muted-foreground leading-relaxed">
+                    {item.description}
+                  </p>
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       </section>
@@ -148,15 +266,50 @@ const About = () => {
         </div>
       </section>
 
-      {/* Tour Areas */}
+      {/* Where I've Been Featured / My Platforms */}
       <section className="py-20">
+        <div className="container-section">
+          <div className="text-center max-w-2xl mx-auto mb-12">
+            <p className="text-label text-accent mb-3">Featured On</p>
+            <h2 className="heading-section text-foreground">
+              Where You Can Find Me
+            </h2>
+            <p className="mt-4 text-body">
+              I'm active on multiple booking platforms. You can read reviews and
+              book tours on any of these:
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-3 gap-8">
+            {platforms.map((platform) => (
+              <a
+                key={platform.name}
+                href={platform.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block p-6 bg-card border border-border rounded-lg text-center hover:border-accent/50 hover:shadow-[var(--shadow-card)] transition-all"
+              >
+                <h3 className="font-serif text-xl font-medium text-foreground mb-2">
+                  {platform.name}
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  {platform.description}
+                </p>
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Tour Areas */}
+      <section className="py-20 bg-secondary/30">
         <div className="container-section">
           <div className="grid lg:grid-cols-2 gap-16 items-center">
             <div className="order-2 lg:order-1">
               <div className="aspect-video rounded-lg overflow-hidden shadow-[var(--shadow-medium)]">
                 <img
                   src={heroImage}
-                  alt="Tokyo tour experience"
+                  alt="Historic Asakusa district in Tokyo with Senso-ji temple and traditional architecture"
                   className="w-full h-full object-cover"
                 />
               </div>
@@ -174,11 +327,23 @@ const About = () => {
               </p>
 
               <div className="mt-8 space-y-4">
-                {["Asakusa & Sumida", "Ueno & Yanaka", "Nihonbashi & Ginza", "Shibuya & Harajuku", "Custom Areas Available"].map((area) => (
-                  <div key={area} className="flex items-center gap-3">
+                {[
+                  { area: "Asakusa & Sumida", link: "/tours/asakusa" },
+                  { area: "Ueno & Yanaka", link: "/tours/yanaka" },
+                  { area: "Tsukiji & Ginza", link: "/tours/tsukiji-ginza" },
+                  { area: "Shibuya & Harajuku", link: "/tours/shibuya-harajuku" },
+                  { area: "Imperial Palace & Marunouchi", link: "/tours/imperial-palace" },
+                ].map((item) => (
+                  <Link
+                    key={item.area}
+                    to={item.link}
+                    className="flex items-center gap-3 group"
+                  >
                     <MapPin className="w-5 h-5 text-accent" />
-                    <span className="text-foreground">{area}</span>
-                  </div>
+                    <span className="text-foreground group-hover:text-accent transition-colors">
+                      {item.area}
+                    </span>
+                  </Link>
                 ))}
               </div>
 
@@ -187,6 +352,53 @@ const About = () => {
               </Link>
             </div>
           </div>
+        </div>
+      </section>
+
+      {/* Testimonials */}
+      <section className="py-20">
+        <div className="container-section">
+          <div className="text-center max-w-2xl mx-auto mb-12">
+            <p className="text-label text-accent mb-3">Guest Reviews</p>
+            <h2 className="heading-section text-foreground">What Travelers Say</h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-6">
+            {allReviews.map((review) => (
+              <blockquote
+                key={review.author}
+                className="bg-card border border-border rounded-lg p-6"
+              >
+                <div className="flex gap-1 mb-3">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <Star
+                      key={i}
+                      className="w-4 h-4 fill-gold text-gold"
+                    />
+                  ))}
+                </div>
+                <p className="text-muted-foreground leading-relaxed mb-4 text-sm">
+                  "{review.text}"
+                </p>
+                <footer>
+                  <cite className="not-italic font-medium text-foreground text-sm">
+                    — {review.author}
+                  </cite>
+                </footer>
+              </blockquote>
+            ))}
+          </div>
+
+          <p className="mt-8 text-center text-sm text-muted-foreground">
+            <a
+              href="https://www.guruwalk.com/guruwalkers/manabu"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent hover:underline"
+            >
+              500+ five-star reviews on GuruWalk →
+            </a>
+          </p>
         </div>
       </section>
 
@@ -199,11 +411,39 @@ const About = () => {
             I look forward to sharing my favorite places and the stories that
             make Tokyo such a special city. Let's create memories together.
           </p>
-          <Link to="/contact" className="btn-accent mt-8 inline-flex">
-            Get in Touch
-          </Link>
+          <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+            <Link to="/tours" className="btn-accent">
+              Browse Tours
+            </Link>
+            <Link to="/tours/custom" className="inline-flex items-center justify-center px-6 py-3 border-2 border-primary-foreground/30 text-primary-foreground font-medium rounded-md transition-all duration-200 hover:bg-primary-foreground/10">
+              Book a Custom Tour
+            </Link>
+          </div>
         </div>
       </section>
+
+      {/* JSON-LD Review Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "LocalBusiness",
+            "name": "Tanuki Tabi Travel",
+            "url": "https://tanuki-tabi-travel.com",
+            "review": allReviews.map((r) => ({
+              "@type": "Review",
+              "reviewBody": r.text,
+              "author": { "@type": "Person", "name": r.author },
+              "reviewRating": {
+                "@type": "Rating",
+                "ratingValue": "5",
+                "bestRating": "5",
+              },
+            })),
+          }),
+        }}
+      />
     </Layout>
   );
 };

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Mail, MapPin, Send, Check } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
 import { useToast } from "@/hooks/use-toast";
 
 const Contact = () => {
@@ -76,12 +77,18 @@ const Contact = () => {
 
   return (
     <Layout>
+      <SEO
+        title="Book a Tour | Contact Tanuki Tabi Travel | Tokyo Private Tours"
+        description="Ready to explore Tokyo? Contact us to book your private walking tour or ask questions. Fast response guaranteed."
+        canonicalPath="/contact"
+      />
+
       {/* Header */}
       <section className="pt-16 pb-12 bg-secondary/30">
         <div className="container-section">
           <div className="max-w-2xl">
             <p className="text-label text-accent mb-3">Get in Touch</p>
-            <h1 className="heading-display text-foreground">Book Your Tour</h1>
+            <h1 className="heading-display text-foreground">Contact Us / Book a Tour</h1>
             <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
               Ready to explore Tokyo? Fill out the form below and I'll get back 
               to you within 24 hours to confirm your booking or answer any questions.

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
 import { Link } from "react-router-dom";
 
 const faqs = [
@@ -55,6 +56,12 @@ const FAQ = () => {
 
   return (
     <Layout>
+      <SEO
+        title="FAQ | Tokyo Private Tour Questions | Tanuki Tabi Travel"
+        description="Answers to common questions about private Tokyo walking tours: cancellation policy, payment, weather, accessibility, and custom tour options."
+        canonicalPath="/faq"
+      />
+
       {/* Header */}
       <section className="pt-16 pb-12 bg-secondary/30">
         <div className="container-section">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
-import { ArrowRight, Award, Users, Globe, Heart } from "lucide-react";
+import { ArrowRight, Award, Users, Shield, Star } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
 import { TourCard } from "@/components/tours/TourCard";
 import {
   Carousel,
@@ -75,38 +76,62 @@ const tours = [
   },
 ];
 
-const features = [
+const trustSignals = [
+  {
+    icon: Shield,
+    title: "Government-Licensed Guide",
+    description: "National Government Licensed Guide Interpreter (全国通訳案内士) — the highest guiding credential in Japan.",
+  },
+  {
+    icon: Star,
+    title: "516+ Tours Completed",
+    description: "Trusted by hundreds of travelers from around the world on GuruWalk, GetYourGuide, and GoWithGuide.",
+  },
   {
     icon: Award,
-    title: "Deep Japan Knowledge",
-    description: "Born in Kanazawa, raised in Kyoto, now living in Tokyo. I bring insights from across Japan's rich regions.",
+    title: "4.86★ Average Rating",
+    description: "Consistently top-rated across multiple booking platforms for quality and guest satisfaction.",
   },
   {
     icon: Users,
-    title: "Private Tours",
-    description: "Intimate private tours for a personalized experience tailored to your interests.",
+    title: "Private & Personalized",
+    description: "Every tour is exclusively yours. No strangers, no rigid schedules — just your group and your guide.",
+  },
+];
+
+const testimonials = [
+  {
+    text: "We did 3 tours in Tokyo and Manabu's was by far the most informative and engaging. He was very clear in his delivery and offered interesting cultural insights as sidebars to each venue we visited. Highly recommended!",
+    author: "Couple visiting Tokyo",
+    rating: 5,
   },
   {
-    icon: Globe,
-    title: "Multilingual",
-    description: "Fluent in English and Spanish, ensuring seamless communication for guests worldwide.",
+    text: "Manabu's tour was one of the best I've been on — he is professional, kind, very knowledgeable and an awesome story-teller. His route is well-planned and offers fun experiences. You can tell he is a full-time tour guide because of the effort he puts in.",
+    author: "Solo traveler",
+    rating: 5,
   },
   {
-    icon: Heart,
-    title: "Local Insights",
-    description: "Discover hidden gems, local stories, and cultural context beyond the guidebooks.",
+    text: "This was an excellent tour. Manabu was entertaining, charismatic and knowledgeable. All places visited were awesome and he provided very interesting tips. A great start to our Japan trip.",
+    author: "First-time visitors to Japan",
+    rating: 5,
   },
 ];
 
 const Index = () => {
   return (
     <Layout>
+      <SEO
+        title="Tokyo Private Tour Guide | Licensed Walking Tours | Tanuki Tabi Travel"
+        description="Explore Tokyo with a government-licensed private tour guide. 516+ tours completed with 4.86★ rating. Custom walking tours of Asakusa, Shibuya, Ginza & more. Book your personal Tokyo experience."
+        canonicalPath="/"
+      />
+
       {/* Hero Section */}
       <section className="relative min-h-[90vh] flex items-center">
         <div className="absolute inset-0">
           <img
             src={heroImage}
-            alt="Tokyo Tour Guide with guests at temple"
+            alt="Scenic view of Tokyo's Sumida River with traditional and modern skyline"
             className="w-full h-full object-cover"
           />
           <div className="absolute inset-0 bg-gradient-to-r from-black/70 via-black/40 to-transparent" />
@@ -114,14 +139,14 @@ const Index = () => {
 
         <div className="relative container-section py-20">
           <div className="max-w-2xl">
-            <p className="text-label text-white/80 mb-4 animate-fade-in-up" style={{ animationDelay: "0.1s" }}>
-              Private Tokyo Tour Guide
-            </p>
             <h1 className="heading-display text-white animate-fade-in-up" style={{ animationDelay: "0.2s" }}>
-              Explore Tokyo with a{" "}
-              <span className="text-accent">Local Professional</span>
+              Private Walking Tours of Tokyo with a{" "}
+              <span className="text-accent">Licensed Local Guide</span>
             </h1>
-            <p className="mt-6 text-lg text-white/80 leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.3s" }}>
+            <p className="mt-6 text-lg text-white/90 leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.3s" }}>
+              516+ tours completed. 4.86★ average rating. Government-licensed guide.
+            </p>
+            <p className="mt-3 text-base text-white/70 leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.35s" }}>
               Discover the authentic side of Tokyo through immersive walking tours.
               From ancient temples to hidden alleyways, experience the stories that
               make this city unforgettable.
@@ -129,13 +154,34 @@ const Index = () => {
 
             <div className="mt-8 flex flex-col sm:flex-row gap-4 animate-fade-in-up" style={{ animationDelay: "0.4s" }}>
               <Link to="/tours" className="btn-accent">
-                View Tours
+                Browse Tours
                 <ArrowRight className="ml-2 w-4 h-4" />
               </Link>
-              <Link to="/contact" className="btn-outline">
-                Book Now
+              <Link to="/tours/custom" className="btn-outline">
+                Book a Custom Tour
               </Link>
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Trust Signals */}
+      <section className="py-16 md:py-20 bg-card border-b border-border">
+        <div className="container-section">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+            {trustSignals.map((signal) => (
+              <div key={signal.title} className="text-center group">
+                <div className="w-14 h-14 rounded-full bg-accent/10 flex items-center justify-center mx-auto mb-4 group-hover:bg-accent/20 transition-colors">
+                  <signal.icon className="w-7 h-7 text-accent" />
+                </div>
+                <h3 className="font-serif text-lg font-medium text-foreground">
+                  {signal.title}
+                </h3>
+                <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+                  {signal.description}
+                </p>
+              </div>
+            ))}
           </div>
         </div>
       </section>
@@ -180,48 +226,136 @@ const Index = () => {
         </div>
       </section>
 
-      {/* Why Choose Me */}
+      {/* About Section (short) */}
       <section className="py-20 md:py-28">
         <div className="container-section">
           <div className="grid lg:grid-cols-2 gap-16 items-center">
             <div>
-              <p className="text-label text-accent mb-3">Why Choose Me</p>
+              <p className="text-label text-accent mb-3">Your Guide</p>
               <h2 className="heading-section text-foreground">
-                Your Trusted Guide to Authentic Tokyo
+                Meet Manabu — Your Licensed Tokyo Guide
               </h2>
               <p className="mt-4 text-body">
-                With years of experience guiding visitors from around the world,
-                I bring together local knowledge, cultural insights, and genuine
-                passion for sharing Tokyo's stories.
+                I'm Manabu, a National Government Licensed Guide Interpreter
+                (全国通訳案内士) with over 516 tours completed and a 4.86-star
+                average rating. Born in Kanazawa, raised in Kyoto, and now based
+                in Tokyo — I bring insights from across Japan's rich cultural
+                regions.
               </p>
-
-              <div className="mt-10 grid grid-cols-1 sm:grid-cols-2 gap-8">
-                {features.map((feature) => (
-                  <div key={feature.title} className="group">
-                    <div className="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center mb-4 group-hover:bg-accent/20 transition-colors">
-                      <feature.icon className="w-6 h-6 text-accent" />
-                    </div>
-                    <h3 className="font-serif text-lg font-medium text-foreground">
-                      {feature.title}
-                    </h3>
-                    <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
-                      {feature.description}
-                    </p>
-                  </div>
-                ))}
-              </div>
+              <p className="mt-4 text-body">
+                My approach is simple: in the first 30 minutes, I learn what
+                excites you, then I adapt the tour in real time. It's not a
+                lecture — it's a conversation.
+              </p>
+              <Link to="/about" className="btn-outline mt-8 inline-flex">
+                Learn more about your guide
+                <ArrowRight className="ml-2 w-4 h-4" />
+              </Link>
             </div>
 
             <div className="relative">
               <div className="aspect-[3/4] rounded-lg overflow-hidden shadow-[var(--shadow-medium)]">
                 <img
                   src={guidePortrait}
-                  alt="Manabu - Tokyo Tour Guide"
+                  alt="Manabu, government-licensed Tokyo tour guide, ready to lead a private walking tour"
                   className="w-full h-full object-cover"
                 />
               </div>
             </div>
           </div>
+        </div>
+      </section>
+
+      {/* How It Works */}
+      <section className="py-20 md:py-28 bg-secondary/30">
+        <div className="container-section">
+          <div className="text-center max-w-2xl mx-auto mb-12">
+            <p className="text-label text-accent mb-3">Simple Booking</p>
+            <h2 className="heading-section text-foreground">How It Works</h2>
+          </div>
+
+          <div className="grid md:grid-cols-3 gap-12">
+            <div className="text-center">
+              <div className="w-16 h-16 rounded-full bg-accent text-white flex items-center justify-center mx-auto mb-6 text-2xl font-serif font-semibold">
+                1
+              </div>
+              <h3 className="font-serif text-xl font-medium text-foreground mb-3">
+                Choose a Tour
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                Browse our curated tours or request a custom itinerary tailored to your interests.
+              </p>
+            </div>
+            <div className="text-center">
+              <div className="w-16 h-16 rounded-full bg-accent text-white flex items-center justify-center mx-auto mb-6 text-2xl font-serif font-semibold">
+                2
+              </div>
+              <h3 className="font-serif text-xl font-medium text-foreground mb-3">
+                Share Your Interests
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                Tell us what excites you — food, history, photography, pop culture — and we'll personalize your experience.
+              </p>
+            </div>
+            <div className="text-center">
+              <div className="w-16 h-16 rounded-full bg-accent text-white flex items-center justify-center mx-auto mb-6 text-2xl font-serif font-semibold">
+                3
+              </div>
+              <h3 className="font-serif text-xl font-medium text-foreground mb-3">
+                Explore Tokyo
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                Meet your guide and discover Tokyo at your own pace. No crowds, no rush — just an authentic experience.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Testimonials */}
+      <section className="py-20 md:py-28">
+        <div className="container-section">
+          <div className="text-center max-w-2xl mx-auto mb-12">
+            <p className="text-label text-accent mb-3">Guest Reviews</p>
+            <h2 className="heading-section text-foreground">What Travelers Say</h2>
+          </div>
+
+          <div className="grid md:grid-cols-3 gap-8">
+            {testimonials.map((testimonial) => (
+              <blockquote
+                key={testimonial.author}
+                className="bg-card border border-border rounded-lg p-6 shadow-[var(--shadow-card)]"
+              >
+                <div className="flex gap-1 mb-4">
+                  {Array.from({ length: testimonial.rating }).map((_, i) => (
+                    <Star
+                      key={i}
+                      className="w-5 h-5 fill-gold text-gold"
+                    />
+                  ))}
+                </div>
+                <p className="text-muted-foreground leading-relaxed mb-4">
+                  "{testimonial.text}"
+                </p>
+                <footer className="pt-4 border-t border-border">
+                  <cite className="not-italic font-medium text-foreground text-sm">
+                    — {testimonial.author}
+                  </cite>
+                </footer>
+              </blockquote>
+            ))}
+          </div>
+
+          <p className="mt-8 text-center text-sm text-muted-foreground">
+            <a
+              href="https://www.guruwalk.com/guruwalkers/manabu"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent hover:underline"
+            >
+              500+ five-star reviews on GuruWalk →
+            </a>
+          </p>
         </div>
       </section>
 
@@ -243,6 +377,47 @@ const Index = () => {
           </div>
         </div>
       </section>
+
+      {/* JSON-LD Structured Data */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "LocalBusiness",
+            "name": "Tanuki Tabi Travel",
+            "description": "Private walking tours of Tokyo with a government-licensed guide",
+            "url": "https://tanuki-tabi-travel.com",
+            "email": "info@tanuki-tabi-travel.com",
+            "areaServed": {
+              "@type": "City",
+              "name": "Tokyo",
+              "addressCountry": "JP",
+            },
+            "founder": {
+              "@type": "Person",
+              "name": "Manabu",
+              "jobTitle": "Government-Licensed Tour Guide",
+            },
+            "aggregateRating": {
+              "@type": "AggregateRating",
+              "ratingValue": "4.86",
+              "reviewCount": "516",
+              "bestRating": "5",
+            },
+            "review": testimonials.map((t) => ({
+              "@type": "Review",
+              "reviewBody": t.text,
+              "author": { "@type": "Person", "name": t.author },
+              "reviewRating": {
+                "@type": "Rating",
+                "ratingValue": "5",
+                "bestRating": "5",
+              },
+            })),
+          }),
+        }}
+      />
     </Layout>
   );
 };

--- a/src/pages/TourDetail.tsx
+++ b/src/pages/TourDetail.tsx
@@ -1,7 +1,8 @@
 import { useParams, Link } from "react-router-dom";
 import { useState, useCallback, useEffect } from "react";
-import { Clock, Users, MapPin, Check, ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react";
+import { Clock, Users, MapPin, Check, ArrowLeft, ChevronLeft, ChevronRight, ArrowRight } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
 import useEmblaCarousel from "embla-carousel-react";
 import tourAsakusa from "@/assets/tour-asakusa.jpg";
 import tourYanaka from "@/assets/tour-yanaka.jpg";
@@ -21,6 +22,48 @@ import imperialBridge from "@/assets/imperial-bridge.jpg";
 import tokyoStation from "@/assets/tokyo-station.jpg";
 import hamarikyu from "@/assets/hamarikyu.jpg";
 
+const tourSEO: Record<string, { title: string; description: string; h1: string }> = {
+  asakusa: {
+    title: "Asakusa Walking Tour | Private Tokyo Tour Guide | Tanuki Tabi Travel",
+    description: "Discover Asakusa's historic temples, Senso-ji shrine, and traditional streets with a licensed private guide. Personalized walking tour tailored to your interests.",
+    h1: "Asakusa Private Walking Tour",
+  },
+  yanaka: {
+    title: "Yanaka Walking Tour | Tokyo's Hidden Old Town | Tanuki Tabi Travel",
+    description: "Explore Yanaka, Tokyo's best-kept secret neighborhood. Walk through Edo-era streets, local temples, and Yanaka Ginza with a licensed private guide.",
+    h1: "Yanaka Private Walking Tour",
+  },
+  "shibuya-harajuku": {
+    title: "Shibuya & Harajuku Tour | Pop Culture & Fashion | Tanuki Tabi Travel",
+    description: "Experience Shibuya Crossing, Takeshita Street, and Harajuku's unique culture with a private licensed guide. See Tokyo's modern side up close.",
+    h1: "Shibuya & Harajuku Private Walking Tour",
+  },
+  "tsukiji-ginza": {
+    title: "Tsukiji & Ginza Tour | Food & Luxury Shopping | Tanuki Tabi Travel",
+    description: "Tour Tsukiji's famous food market and Ginza's luxury shopping district with a licensed private guide. Sample street food and explore historic shops.",
+    h1: "Tsukiji & Ginza Private Walking Tour",
+  },
+  "imperial-palace": {
+    title: "Imperial Palace Tour | Tokyo History Walk | Tanuki Tabi Travel",
+    description: "Explore the Imperial Palace gardens, Edo Castle ruins, and surrounding historic districts with a government-licensed private tour guide.",
+    h1: "Imperial Palace Private Walking Tour",
+  },
+  custom: {
+    title: "Custom Tokyo Tour | Design Your Own Itinerary | Tanuki Tabi Travel",
+    description: "Create your perfect Tokyo day with a licensed private guide. Tell us your interests and we'll design a custom walking tour just for you. Groups of 1-8 welcome.",
+    h1: "Custom Private Tour — Your Tokyo, Your Way",
+  },
+};
+
+const tourSchemaData: Record<string, { name: string; area: string; price: string }> = {
+  asakusa: { name: "Asakusa Private Walking Tour", area: "Asakusa", price: "30000" },
+  yanaka: { name: "Yanaka Private Walking Tour", area: "Yanaka", price: "40000" },
+  "shibuya-harajuku": { name: "Shibuya & Harajuku Private Walking Tour", area: "Shibuya & Harajuku", price: "35000" },
+  "tsukiji-ginza": { name: "Tsukiji & Ginza Private Walking Tour", area: "Tsukiji & Ginza", price: "30000" },
+  "imperial-palace": { name: "Imperial Palace Private Walking Tour", area: "Imperial Palace & Marunouchi", price: "25000" },
+  custom: { name: "Custom Private Tokyo Tour", area: "Tokyo", price: "10000" },
+};
+
 const tourData = {
   asakusa: {
     title: "Asakusa Walking Tour",
@@ -33,10 +76,10 @@ const tourData = {
     startTime: "10:00 AM or 2:00 PM",
     meetingPoint: "Asakusa Station, Exit 1",
     images: [
-      { src: tourAsakusa, position: "center 80%" },
-      { src: asakusaStreet, position: "center" },
-      { src: asakusaMask, position: "center" },
-      { src: asakusaTemple, position: "center" },
+      { src: tourAsakusa, alt: "Senso-ji Temple and Kaminarimon Gate in Asakusa, Tokyo", position: "center 80%" },
+      { src: asakusaStreet, alt: "Traditional shopping street in Asakusa with lanterns", position: "center" },
+      { src: asakusaMask, alt: "Traditional Japanese mask at an Asakusa souvenir shop", position: "center" },
+      { src: asakusaTemple, alt: "Senso-ji Temple five-story pagoda in Asakusa", position: "center" },
     ],
     highlights: [
       "Senso-ji Temple - Tokyo's oldest and most famous temple",
@@ -79,9 +122,9 @@ const tourData = {
     startTime: "9:30 AM or 1:30 PM",
     meetingPoint: "Nippori Station, North Exit",
     images: [
-      { src: tourUeno, position: "center" },
-      { src: tourYanaka, position: "center" },
-      { src: uenoNight, position: "center" },
+      { src: tourUeno, alt: "Traditional Yanaka neighborhood street in Tokyo", position: "center" },
+      { src: tourYanaka, alt: "Yanaka Ginza retro shopping street with local shops", position: "center" },
+      { src: uenoNight, alt: "Ueno Park temple illuminated at evening", position: "center" },
     ],
     highlights: [
       "Yanaka Ginza - Charming retro shopping street",
@@ -125,10 +168,10 @@ const tourData = {
     startTime: "10:30 AM or 2:30 PM",
     meetingPoint: "Shibuya Station, Hachiko Exit",
     images: [
-      { src: shibuyaCrossing, position: "center" },
-      { src: shibuyaStreet, position: "center" },
-      { src: meijiShrine, position: "center" },
-      { src: harajukuStreet, position: "center" },
+      { src: shibuyaCrossing, alt: "Shibuya Crossing at dusk with hundreds of pedestrians", position: "center" },
+      { src: shibuyaStreet, alt: "Vibrant Shibuya shopping street with neon signs", position: "center" },
+      { src: meijiShrine, alt: "Meiji Shrine torii gate surrounded by ancient forest", position: "center" },
+      { src: harajukuStreet, alt: "Colorful Harajuku Takeshita Street with youth fashion", position: "center" },
     ],
     highlights: [
       "Shibuya Crossing - The world's busiest pedestrian crossing",
@@ -172,8 +215,8 @@ const tourData = {
     startTime: "9:00 AM or 1:00 PM",
     meetingPoint: "Tsukiji Market Station, Exit A1",
     images: [
-      { src: tsukijiMarket, position: "center" },
-      { src: tsukijiFood, position: "center" },
+      { src: tsukijiMarket, alt: "Tsukiji Outer Market fresh seafood and food stalls", position: "center" },
+      { src: tsukijiFood, alt: "Fresh Japanese street food at Tsukiji Market", position: "center" },
     ],
     highlights: [
       "Tsukiji Outer Market - Fresh seafood and street food",
@@ -185,7 +228,7 @@ const tourData = {
     itinerary: [
       { time: "9:00", activity: "Meet at Tsukiji Market Station" },
       { time: "9:15", activity: "Tsukiji Outer Market exploration & tastings" },
-      { time: "10:15", activity: "Walk through築地 Honganji Temple" },
+      { time: "10:15", activity: "Walk through Tsukiji Honganji Temple" },
       { time: "10:45", activity: "Ginza main street architecture tour" },
       { time: "11:15", activity: "Traditional shops & department stores" },
       { time: "11:45", activity: "Hidden backstreets & local gems" },
@@ -217,9 +260,9 @@ const tourData = {
     startTime: "10:00 AM or 2:00 PM",
     meetingPoint: "Tokyo Station, Marunouchi North Exit",
     images: [
-      { src: imperialPalace, position: "center" },
-      { src: imperialBridge, position: "center" },
-      { src: tokyoStation, position: "center" },
+      { src: imperialPalace, alt: "Imperial Palace East Gardens with traditional Japanese landscaping", position: "center" },
+      { src: imperialBridge, alt: "Nijubashi Bridge at the Imperial Palace, iconic Tokyo landmark", position: "center" },
+      { src: tokyoStation, alt: "Historic red brick Tokyo Station building in Marunouchi", position: "center" },
     ],
     highlights: [
       "Imperial Palace East Gardens - Beautiful Japanese gardens",
@@ -263,7 +306,7 @@ const tourData = {
     startTime: "Flexible",
     meetingPoint: "Your choice",
     images: [
-      { src: hamarikyu, position: "center" },
+      { src: hamarikyu, alt: "Hamarikyu Gardens tea house overlooking Tokyo skyline", position: "center" },
     ],
     highlights: [
       "Personalized itinerary based on your interests",
@@ -296,9 +339,29 @@ const tourData = {
   },
 };
 
+const relatedTours: Record<string, string[]> = {
+  asakusa: ["yanaka", "tsukiji-ginza", "imperial-palace"],
+  yanaka: ["asakusa", "imperial-palace", "shibuya-harajuku"],
+  "shibuya-harajuku": ["tsukiji-ginza", "asakusa", "custom"],
+  "tsukiji-ginza": ["asakusa", "imperial-palace", "shibuya-harajuku"],
+  "imperial-palace": ["asakusa", "tsukiji-ginza", "yanaka"],
+  custom: ["asakusa", "shibuya-harajuku", "tsukiji-ginza"],
+};
+
+const tourNames: Record<string, string> = {
+  asakusa: "Asakusa Walking Tour",
+  yanaka: "Yanaka Walking Tour",
+  "shibuya-harajuku": "Shibuya & Harajuku Tour",
+  "tsukiji-ginza": "Tsukiji & Ginza Tour",
+  "imperial-palace": "Imperial Palace Tour",
+  custom: "Custom Private Tour",
+};
+
 const TourDetail = () => {
   const { id } = useParams<{ id: string }>();
   const tour = tourData[id as keyof typeof tourData];
+  const seo = tourSEO[id as keyof typeof tourSEO];
+  const schema = tourSchemaData[id as keyof typeof tourSchemaData];
 
   if (!tour) {
     return (
@@ -343,8 +406,16 @@ const TourDetail = () => {
     };
   }, [emblaApi, onSelect]);
 
+  const related = relatedTours[id as string] || [];
+
   return (
     <Layout>
+      <SEO
+        title={seo.title}
+        description={seo.description}
+        canonicalPath={`/tours/${id}`}
+      />
+
       {/* Hero Carousel with Thumbnails */}
       <section className="relative h-[50vh] md:h-[60vh] min-h-[400px] md:min-h-[500px]">
         {/* Main Image */}
@@ -354,7 +425,7 @@ const TourDetail = () => {
               <div key={index} className="flex-[0_0_100%] min-w-0 h-full">
                 <img
                   src={image.src}
-                  alt={`${tour.title} - Image ${index + 1}`}
+                  alt={image.alt}
                   className="w-full h-full object-cover"
                   style={{ objectPosition: image.position }}
                 />
@@ -416,7 +487,7 @@ const TourDetail = () => {
       <section className="py-8 md:py-12 bg-secondary/30">
         <div className="container-section">
           <p className="text-label text-accent mb-1 md:mb-2">{tour.difficulty} · {tour.duration}</p>
-          <h1 className="text-2xl md:text-4xl lg:text-5xl font-serif font-semibold text-foreground">{tour.title}</h1>
+          <h1 className="text-2xl md:text-4xl lg:text-5xl font-serif font-semibold text-foreground">{seo.h1}</h1>
           <p className="text-sm md:text-lg text-muted-foreground mt-1 md:mt-2">{tour.subtitle}</p>
         </div>
       </section>
@@ -535,6 +606,75 @@ const TourDetail = () => {
           </div>
         </div>
       </section>
+
+      {/* You Might Also Like */}
+      {related.length > 0 && (
+        <section className="py-16 bg-secondary/30 border-t border-border">
+          <div className="container-section">
+            <h2 className="heading-section text-foreground mb-8 text-center">You Might Also Like</h2>
+            <div className="grid md:grid-cols-3 gap-6">
+              {related.map((tourId) => {
+                const relatedTour = tourData[tourId as keyof typeof tourData];
+                if (!relatedTour) return null;
+                return (
+                  <Link
+                    key={tourId}
+                    to={`/tours/${tourId}`}
+                    className="group bg-card border border-border rounded-lg p-6 hover:border-accent/50 hover:shadow-[var(--shadow-card)] transition-all"
+                  >
+                    <h3 className="font-serif text-lg font-medium text-foreground group-hover:text-accent transition-colors">
+                      {tourNames[tourId]}
+                    </h3>
+                    <p className="mt-2 text-sm text-muted-foreground line-clamp-2">
+                      {relatedTour.description}
+                    </p>
+                    <div className="mt-4 flex items-center gap-2 text-accent font-medium text-sm">
+                      <span>View Tour</span>
+                      <ArrowRight className="w-4 h-4" />
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* JSON-LD Structured Data */}
+      {schema && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "TouristTrip",
+              "name": schema.name,
+              "description": seo.description,
+              "touristType": "Cultural",
+              "provider": {
+                "@type": "LocalBusiness",
+                "name": "Tanuki Tabi Travel",
+                "url": "https://tanuki-tabi-travel.com",
+              },
+              "offers": {
+                "@type": "Offer",
+                "price": schema.price,
+                "priceCurrency": "JPY",
+                "availability": "https://schema.org/InStock",
+              },
+              "itinerary": {
+                "@type": "Place",
+                "name": `${schema.area}, Tokyo`,
+                "address": {
+                  "@type": "PostalAddress",
+                  "addressLocality": "Tokyo",
+                  "addressCountry": "JP",
+                },
+              },
+            }),
+          }}
+        />
+      )}
     </Layout>
   );
 };

--- a/src/pages/Tours.tsx
+++ b/src/pages/Tours.tsx
@@ -1,4 +1,5 @@
 import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
 import { TourCard } from "@/components/tours/TourCard";
 import tourAsakusa from "@/assets/tour-asakusa.jpg";
 import tourUeno from "@/assets/tour-ueno.jpg";
@@ -67,12 +68,18 @@ const tours = [
 const Tours = () => {
   return (
     <Layout>
+      <SEO
+        title="Tokyo Walking Tours | Private Guided Tours | Tanuki Tabi Travel"
+        description="Browse private walking tours of Tokyo led by a government-licensed guide. Asakusa, Yanaka, Shibuya, Ginza, Imperial Palace and custom tours available."
+        canonicalPath="/tours"
+      />
+
       {/* Header */}
       <section className="pt-16 pb-12 bg-secondary/30">
         <div className="container-section">
           <div className="max-w-2xl">
             <p className="text-label text-accent mb-3">Explore Tokyo</p>
-            <h1 className="heading-display text-foreground">Walking Tours</h1>
+            <h1 className="heading-display text-foreground">Private Walking Tours of Tokyo</h1>
             <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
               Discover Tokyo's rich culture and hidden gems through immersive 
               walking tours led by a local professional guide.


### PR DESCRIPTION
## Summary
This PR significantly improves the website's SEO, rebrands to "Tanuki Tabi Travel," and enhances credibility by prominently featuring the guide's government licensing and verified metrics (516+ tours, 4.86★ rating).

## Key Changes

**SEO Improvements:**
- Added `react-helmet-async` for dynamic meta tag management
- Created new `SEO` component for consistent title, description, and canonical URL handling across pages
- Implemented SEO component on all major pages (Index, About, Tours, TourDetail, Contact, FAQ)
- Added tour-specific SEO metadata with unique titles and descriptions for each tour detail page
- Updated `index.html` with improved meta descriptions emphasizing government licensing and metrics
- Updated `sitemap.xml` to reflect current page structure and priorities
- Enhanced `robots.txt` to remove Next.js-specific disallows

**Branding & Rebranding:**
- Changed site name from "TokyoGuide" to "Tanuki Tabi Travel" throughout (Header, Footer, etc.)
- Updated all page titles and descriptions to reference "Tanuki Tabi Travel"
- Updated email domain references to `tanuki-tabi-travel.com`

**Credibility & Content Updates:**
- Replaced "Years Guiding" stat (3+) with "Tours Completed" (516+)
- Replaced "Happy Guests" stat (100+) with "Average Rating" (4.86★)
- Prominently featured government licensing credential (全国通訳案内士) as primary credential
- Added new "Why Choose a Licensed Private Guide?" section with 4 key advantages
- Added "Where You Can Find Me" section listing booking platforms (GuruWalk, GetYourGuide, GoWithGuide)
- Added 8 detailed guest testimonials with author context
- Added "How It Works" section explaining the booking process
- Expanded About page with comprehensive guide philosophy and approach
- Added trust signals section on homepage highlighting licensing, tour count, and rating

**Content Enhancements:**
- Improved image alt text for better accessibility and SEO
- Added structured data references for tour schema information
- Enhanced hero section copy to emphasize "licensed" and "private" tour experience
- Added related tours section to TourDetail pages for better navigation
- Updated tour area names (e.g., "Nihonbashi & Ginza" → "Tsukiji & Ginza")
- Improved footer with tour links and better information architecture

**Technical Details:**
- SEO component accepts title, description, canonicalPath, and optional ogImage
- Tour detail pages use dynamic SEO data from `tourSEO` object
- All canonical URLs properly formatted with base domain
- Open Graph and Twitter Card meta tags included for social sharing

https://claude.ai/code/session_01MyJcAg4uy2NJz4YpFSc3UB