### PR TITLE
Add day trip tours and blog content with navigation updates

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -69,4 +69,58 @@
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
+
+  <!-- Day Trip Pages -->
+  <url>
+    <loc>https://tanuki-tabi-travel.com/tours/kamakura-day-trip</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/tours/hakone-day-trip</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/tours/nikko-day-trip</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <!-- FAQ -->
+  <url>
+    <loc>https://tanuki-tabi-travel.com/faq</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Blog -->
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/tokyo-3-day-itinerary</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,10 @@ import TourDetail from "./pages/TourDetail";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
 import FAQ from "./pages/FAQ";
+import BlogIndex from "./pages/blog/BlogIndex";
+import Tokyo3DayItinerary from "./pages/blog/Tokyo3DayItinerary";
+import IsItWorthHiringGuide from "./pages/blog/IsItWorthHiringGuide";
+import DayTripComparison from "./pages/blog/DayTripComparison";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -26,6 +30,10 @@ const App = () => (
           <Route path="/about" element={<About />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="/faq" element={<FAQ />} />
+          <Route path="/blog" element={<BlogIndex />} />
+          <Route path="/blog/tokyo-3-day-itinerary" element={<Tokyo3DayItinerary />} />
+          <Route path="/blog/is-it-worth-hiring-a-tour-guide-in-tokyo" element={<IsItWorthHiringGuide />} />
+          <Route path="/blog/kamakura-vs-hakone-vs-nikko-day-trip" element={<DayTripComparison />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -5,16 +5,16 @@ export const Footer = () => {
   return (
     <footer className="bg-primary text-primary-foreground">
       <div className="container-section py-16">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-12">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-12">
           {/* Brand */}
-          <div>
+          <div className="lg:col-span-2">
             <Link to="/" className="inline-block">
               <span className="font-serif text-2xl font-semibold">
                 Tanuki<span className="text-accent">Tabi</span>
               </span>
             </Link>
             <p className="mt-4 text-primary-foreground/70 max-w-sm leading-relaxed">
-              Private walking tours of Tokyo with a government-licensed guide.
+              Private walking tours of Tokyo and day trips with a government-licensed guide.
               516+ tours completed. 4.86★ average rating.
             </p>
             <div className="flex items-center gap-4 mt-6">
@@ -35,9 +35,9 @@ export const Footer = () => {
             </div>
           </div>
 
-          {/* Tours */}
+          {/* Tokyo Tours */}
           <div>
-            <h4 className="font-serif text-lg font-medium mb-4">Tours</h4>
+            <h4 className="font-serif text-lg font-medium mb-4">Tokyo Tours</h4>
             <ul className="space-y-3">
               <li>
                 <Link to="/tours/asakusa" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
@@ -72,13 +72,59 @@ export const Footer = () => {
             </ul>
           </div>
 
-          {/* Quick Links */}
+          {/* Day Trips & Blog */}
+          <div>
+            <h4 className="font-serif text-lg font-medium mb-4">Day Trips</h4>
+            <ul className="space-y-3">
+              <li>
+                <Link to="/tours/kamakura-day-trip" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Kamakura Day Trip
+                </Link>
+              </li>
+              <li>
+                <Link to="/tours/hakone-day-trip" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Hakone Day Trip
+                </Link>
+              </li>
+              <li>
+                <Link to="/tours/nikko-day-trip" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Nikko Day Trip
+                </Link>
+              </li>
+            </ul>
+
+            <h4 className="font-serif text-lg font-medium mb-4 mt-8">Blog</h4>
+            <ul className="space-y-3">
+              <li>
+                <Link to="/blog/tokyo-3-day-itinerary" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Tokyo 3-Day Itinerary
+                </Link>
+              </li>
+              <li>
+                <Link to="/blog/is-it-worth-hiring-a-tour-guide-in-tokyo" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Is a Guide Worth It?
+                </Link>
+              </li>
+              <li>
+                <Link to="/blog/kamakura-vs-hakone-vs-nikko-day-trip" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Day Trip Comparison
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          {/* Explore & Contact */}
           <div>
             <h4 className="font-serif text-lg font-medium mb-4">Explore</h4>
             <ul className="space-y-3">
               <li>
                 <Link to="/tours" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
                   All Tours
+                </Link>
+              </li>
+              <li>
+                <Link to="/blog" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Blog
                 </Link>
               </li>
               <li>
@@ -97,11 +143,8 @@ export const Footer = () => {
                 </Link>
               </li>
             </ul>
-          </div>
 
-          {/* Contact Info */}
-          <div>
-            <h4 className="font-serif text-lg font-medium mb-4">Contact</h4>
+            <h4 className="font-serif text-lg font-medium mb-4 mt-8">Contact</h4>
             <ul className="space-y-3">
               <li className="flex items-start gap-3 text-primary-foreground/70">
                 <MapPin className="w-5 h-5 shrink-0 mt-0.5" />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,18 +1,43 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Menu, X } from "lucide-react";
+import { Menu, X, ChevronDown } from "lucide-react";
 
-const navigation = [
-  { name: "Home", href: "/" },
-  { name: "Tours", href: "/tours" },
-  { name: "About", href: "/about" },
-  { name: "FAQ", href: "/faq" },
-  { name: "Contact", href: "/contact" },
+const tokyoTours = [
+  { name: "Asakusa", href: "/tours/asakusa" },
+  { name: "Yanaka", href: "/tours/yanaka" },
+  { name: "Shibuya & Harajuku", href: "/tours/shibuya-harajuku" },
+  { name: "Tsukiji & Ginza", href: "/tours/tsukiji-ginza" },
+  { name: "Imperial Palace", href: "/tours/imperial-palace" },
+];
+
+const dayTrips = [
+  { name: "Kamakura Day Trip", href: "/tours/kamakura-day-trip" },
+  { name: "Hakone Day Trip", href: "/tours/hakone-day-trip" },
+  { name: "Nikko Day Trip", href: "/tours/nikko-day-trip" },
 ];
 
 export const Header = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [toursDropdownOpen, setToursDropdownOpen] = useState(false);
+  const [mobilToursOpen, setMobileToursOpen] = useState(false);
   const location = useLocation();
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setToursDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    setMobileMenuOpen(false);
+    setToursDropdownOpen(false);
+    setMobileToursOpen(false);
+  }, [location.pathname]);
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-md border-b border-border/50">
@@ -27,19 +52,119 @@ export const Header = () => {
 
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center gap-8">
-            {navigation.map((item) => (
-              <Link
-                key={item.name}
-                to={item.href}
-                className={`text-sm font-medium transition-colors link-underline ${
-                  location.pathname === item.href
+            <Link
+              to="/"
+              className={`text-sm font-medium transition-colors link-underline ${
+                location.pathname === "/"
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Home
+            </Link>
+
+            {/* Tours Dropdown */}
+            <div className="relative" ref={dropdownRef}>
+              <button
+                onClick={() => setToursDropdownOpen(!toursDropdownOpen)}
+                className={`flex items-center gap-1 text-sm font-medium transition-colors link-underline ${
+                  location.pathname.startsWith("/tours")
                     ? "text-foreground"
                     : "text-muted-foreground hover:text-foreground"
                 }`}
               >
-                {item.name}
-              </Link>
-            ))}
+                Tours
+                <ChevronDown className={`w-4 h-4 transition-transform ${toursDropdownOpen ? "rotate-180" : ""}`} />
+              </button>
+
+              {toursDropdownOpen && (
+                <div className="absolute top-full left-0 mt-2 w-64 bg-background border border-border rounded-lg shadow-[var(--shadow-medium)] py-2 animate-fade-in z-50">
+                  <Link
+                    to="/tours"
+                    className="block px-4 py-2 text-sm text-foreground font-medium hover:bg-secondary/50 transition-colors"
+                  >
+                    All Tours
+                  </Link>
+                  <div className="border-t border-border my-1" />
+                  <p className="px-4 py-1 text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                    Tokyo Walking Tours
+                  </p>
+                  {tokyoTours.map((tour) => (
+                    <Link
+                      key={tour.href}
+                      to={tour.href}
+                      className="block px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
+                    >
+                      {tour.name}
+                    </Link>
+                  ))}
+                  <div className="border-t border-border my-1" />
+                  <p className="px-4 py-1 text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                    Day Trips from Tokyo
+                  </p>
+                  {dayTrips.map((tour) => (
+                    <Link
+                      key={tour.href}
+                      to={tour.href}
+                      className="block px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
+                    >
+                      {tour.name}
+                    </Link>
+                  ))}
+                  <div className="border-t border-border my-1" />
+                  <Link
+                    to="/tours/custom"
+                    className="block px-4 py-2 text-sm text-accent font-medium hover:bg-secondary/50 transition-colors"
+                  >
+                    Custom Tour
+                  </Link>
+                </div>
+              )}
+            </div>
+
+            <Link
+              to="/blog"
+              className={`text-sm font-medium transition-colors link-underline ${
+                location.pathname.startsWith("/blog")
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Blog
+            </Link>
+
+            <Link
+              to="/faq"
+              className={`text-sm font-medium transition-colors link-underline ${
+                location.pathname === "/faq"
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              FAQ
+            </Link>
+
+            <Link
+              to="/about"
+              className={`text-sm font-medium transition-colors link-underline ${
+                location.pathname === "/about"
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              About
+            </Link>
+
+            <Link
+              to="/contact"
+              className={`text-sm font-medium transition-colors link-underline ${
+                location.pathname === "/contact"
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Contact
+            </Link>
           </div>
 
           {/* CTA Button */}
@@ -62,21 +187,112 @@ export const Header = () => {
         {/* Mobile Navigation */}
         {mobileMenuOpen && (
           <div className="md:hidden py-4 border-t border-border/50 animate-fade-in">
-            <div className="flex flex-col gap-4">
-              {navigation.map((item) => (
-                <Link
-                  key={item.name}
-                  to={item.href}
-                  className={`text-base font-medium py-2 ${
-                    location.pathname === item.href
-                      ? "text-foreground"
-                      : "text-muted-foreground"
-                  }`}
-                  onClick={() => setMobileMenuOpen(false)}
-                >
-                  {item.name}
-                </Link>
-              ))}
+            <div className="flex flex-col gap-2">
+              <Link
+                to="/"
+                className={`text-base font-medium py-2 ${
+                  location.pathname === "/" ? "text-foreground" : "text-muted-foreground"
+                }`}
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                Home
+              </Link>
+
+              {/* Mobile Tours Accordion */}
+              <button
+                onClick={() => setMobileToursOpen(!mobilToursOpen)}
+                className={`flex items-center justify-between text-base font-medium py-2 ${
+                  location.pathname.startsWith("/tours") ? "text-foreground" : "text-muted-foreground"
+                }`}
+              >
+                Tours
+                <ChevronDown className={`w-4 h-4 transition-transform ${mobilToursOpen ? "rotate-180" : ""}`} />
+              </button>
+              {mobilToursOpen && (
+                <div className="pl-4 space-y-1 animate-fade-in">
+                  <Link
+                    to="/tours"
+                    className="block py-1.5 text-sm text-foreground font-medium"
+                    onClick={() => setMobileMenuOpen(false)}
+                  >
+                    All Tours
+                  </Link>
+                  <p className="py-1 text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                    Tokyo
+                  </p>
+                  {tokyoTours.map((tour) => (
+                    <Link
+                      key={tour.href}
+                      to={tour.href}
+                      className="block py-1.5 text-sm text-muted-foreground"
+                      onClick={() => setMobileMenuOpen(false)}
+                    >
+                      {tour.name}
+                    </Link>
+                  ))}
+                  <p className="py-1 text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                    Day Trips
+                  </p>
+                  {dayTrips.map((tour) => (
+                    <Link
+                      key={tour.href}
+                      to={tour.href}
+                      className="block py-1.5 text-sm text-muted-foreground"
+                      onClick={() => setMobileMenuOpen(false)}
+                    >
+                      {tour.name}
+                    </Link>
+                  ))}
+                  <Link
+                    to="/tours/custom"
+                    className="block py-1.5 text-sm text-accent font-medium"
+                    onClick={() => setMobileMenuOpen(false)}
+                  >
+                    Custom Tour
+                  </Link>
+                </div>
+              )}
+
+              <Link
+                to="/blog"
+                className={`text-base font-medium py-2 ${
+                  location.pathname.startsWith("/blog") ? "text-foreground" : "text-muted-foreground"
+                }`}
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                Blog
+              </Link>
+
+              <Link
+                to="/faq"
+                className={`text-base font-medium py-2 ${
+                  location.pathname === "/faq" ? "text-foreground" : "text-muted-foreground"
+                }`}
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                FAQ
+              </Link>
+
+              <Link
+                to="/about"
+                className={`text-base font-medium py-2 ${
+                  location.pathname === "/about" ? "text-foreground" : "text-muted-foreground"
+                }`}
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                About
+              </Link>
+
+              <Link
+                to="/contact"
+                className={`text-base font-medium py-2 ${
+                  location.pathname === "/contact" ? "text-foreground" : "text-muted-foreground"
+                }`}
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                Contact
+              </Link>
+
               <Link
                 to="/contact"
                 className="btn-accent text-center mt-2"

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -58,24 +58,6 @@ const whyChooseGuide = [
   },
 ];
 
-const platforms = [
-  {
-    name: "GuruWalk",
-    url: "https://www.guruwalk.com/",
-    description: "Free walking tour platform",
-  },
-  {
-    name: "GetYourGuide",
-    url: "https://www.getyourguide.com/",
-    description: "Global tours and activities",
-  },
-  {
-    name: "GoWithGuide",
-    url: "https://www.gowithguide.com/",
-    description: "Licensed private guide booking",
-  },
-];
-
 const allReviews = [
   {
     text: "We did 3 tours in Tokyo and Manabu's was by far the most informative and engaging. He was very clear in his delivery and offered interesting cultural insights as sidebars to each venue we visited. Highly recommended!",
@@ -266,41 +248,6 @@ const About = () => {
         </div>
       </section>
 
-      {/* Where I've Been Featured / My Platforms */}
-      <section className="py-20">
-        <div className="container-section">
-          <div className="text-center max-w-2xl mx-auto mb-12">
-            <p className="text-label text-accent mb-3">Featured On</p>
-            <h2 className="heading-section text-foreground">
-              Where You Can Find Me
-            </h2>
-            <p className="mt-4 text-body">
-              I'm active on multiple booking platforms. You can read reviews and
-              book tours on any of these:
-            </p>
-          </div>
-
-          <div className="grid md:grid-cols-3 gap-8">
-            {platforms.map((platform) => (
-              <a
-                key={platform.name}
-                href={platform.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block p-6 bg-card border border-border rounded-lg text-center hover:border-accent/50 hover:shadow-[var(--shadow-card)] transition-all"
-              >
-                <h3 className="font-serif text-xl font-medium text-foreground mb-2">
-                  {platform.name}
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  {platform.description}
-                </p>
-              </a>
-            ))}
-          </div>
-        </div>
-      </section>
-
       {/* Tour Areas */}
       <section className="py-20 bg-secondary/30">
         <div className="container-section">
@@ -333,6 +280,9 @@ const About = () => {
                   { area: "Tsukiji & Ginza", link: "/tours/tsukiji-ginza" },
                   { area: "Shibuya & Harajuku", link: "/tours/shibuya-harajuku" },
                   { area: "Imperial Palace & Marunouchi", link: "/tours/imperial-palace" },
+                  { area: "Kamakura (Day Trip)", link: "/tours/kamakura-day-trip" },
+                  { area: "Hakone (Day Trip)", link: "/tours/hakone-day-trip" },
+                  { area: "Nikko (Day Trip)", link: "/tours/nikko-day-trip" },
                 ].map((item) => (
                   <Link
                     key={item.area}
@@ -390,14 +340,7 @@ const About = () => {
           </div>
 
           <p className="mt-8 text-center text-sm text-muted-foreground">
-            <a
-              href="https://www.guruwalk.com/guruwalkers/manabu"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent hover:underline"
-            >
-              500+ five-star reviews on GuruWalk →
-            </a>
+            500+ five-star reviews from travelers worldwide
           </p>
         </div>
       </section>

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -4,61 +4,121 @@ import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { Link } from "react-router-dom";
 
-const faqs = [
+interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+interface FAQCategory {
+  title: string;
+  items: FAQItem[];
+}
+
+const faqCategories: FAQCategory[] = [
   {
-    question: "What happens if it rains?",
-    answer: "Tours run rain or shine! I provide umbrellas if needed, and we can adjust the itinerary to include more covered areas like temples, shopping arcades, and indoor spots. Some guests even find the rainy atmosphere adds to the authentic Tokyo experience.",
+    title: "Booking & Pricing",
+    items: [
+      {
+        question: "How much does a private tour cost?",
+        answer: "Our Tokyo walking tours range from ¥25,000 to ¥40,000 per group depending on the tour and duration. Day trips to Kamakura (¥50,000), Hakone (¥55,000), and Nikko (¥60,000) have different pricing. Check each tour page for specific rates, or contact us for a custom quote.",
+      },
+      {
+        question: "How do I book a tour?",
+        answer: "Simply visit our Contact page and tell us your preferred date, group size, and interests. We'll respond within 24 hours with availability and a suggested itinerary.",
+      },
+      {
+        question: "How far in advance should I book?",
+        answer: "We recommend booking at least 1-2 weeks in advance, especially during peak seasons (March-May for cherry blossoms, October-November for autumn). Last-minute bookings are sometimes possible — just ask!",
+      },
+      {
+        question: "What is your cancellation policy?",
+        answer: "Free cancellation up to 48 hours before the tour. Cancellations within 48 hours are charged in full. In case of severe weather warnings (typhoons etc.), you'll receive a full refund or reschedule option.",
+      },
+      {
+        question: "Can I book for just 1 person?",
+        answer: "Yes! Solo travelers are very welcome. Pricing may differ from group rates — contact us for a quote.",
+      },
+    ],
   },
   {
-    question: "Is this tour suitable for children?",
-    answer: "Absolutely! My tours are family-friendly and I can adjust the pace and content for children. We can include more interactive elements, snack breaks, and kid-friendly spots. Please let me know the ages of your children when booking.",
+    title: "About the Tours",
+    items: [
+      {
+        question: 'What is a "Government-Licensed Guide"?',
+        answer: "The National Government Licensed Guide Interpreter (全国通訳案内士) is a national certification issued by the Japanese government. It requires passing rigorous exams covering Japanese history, geography, culture, and English proficiency. It is the only nationally recognized professional tour guide certification in Japan.",
+      },
+      {
+        question: "Are your tours private?",
+        answer: "Yes, all our tours are 100% private. It's just you and your group with your guide — no strangers, no fixed schedule. You set the pace.",
+      },
+      {
+        question: "What happens if it rains?",
+        answer: "Tours run rain or shine — Tokyo has many covered areas, indoor stops, and underground passages. Your guide will adapt the route for weather. We only cancel for severe weather warnings (typhoons etc.), in which case you'll receive a full refund or reschedule.",
+      },
+      {
+        question: "Can you accommodate dietary restrictions?",
+        answer: "Absolutely. Let us know in advance and your guide will recommend restaurants that cater to vegetarian, vegan, halal, gluten-free, or allergy-specific needs.",
+      },
+      {
+        question: "Are your tours suitable for children?",
+        answer: "Yes! We regularly welcome families with children of all ages. Our routes are mostly flat and pram-friendly. Your guide will adjust the pace and content to keep younger travelers engaged.",
+      },
+      {
+        question: "Can you accommodate wheelchair users?",
+        answer: "We do our best to make tours accessible. Please let us know in advance and we'll plan a route that avoids stairs and uses accessible entrances. Some historic sites have limited accessibility — your guide will plan accordingly.",
+      },
+    ],
   },
   {
-    question: "How far do we walk?",
-    answer: "Walking distances vary by tour: Asakusa is about 3-4 km, Yanaka is about 4-5 km. We walk at a comfortable pace with plenty of stops. If you have mobility concerns, please let me know and I can customize the route.",
+    title: "Day Trips",
+    items: [
+      {
+        question: "How do we get to Kamakura / Hakone / Nikko?",
+        answer: "By train from central Tokyo. Your guide meets you at your hotel or a convenient station and handles all navigation. Train fares are not included in the tour price but your guide will help you purchase tickets.",
+      },
+      {
+        question: "Is it worth doing a day trip with a guide vs. on my own?",
+        answer: 'While you can certainly visit these destinations independently, a guide provides three key benefits: (1) efficient navigation of complex transport systems, (2) deep cultural and historical context at each site, and (3) flexibility to adjust the itinerary based on weather, crowds, and your energy level. Most travelers tell us the guide transformed their experience from "visiting places" to "understanding Japan."',
+      },
+      {
+        question: "Can I combine a day trip with a Tokyo tour?",
+        answer: "Yes! Many guests book a Tokyo walking tour for one day and a day trip for another. We offer multi-day packages — contact us for details.",
+      },
+    ],
   },
   {
-    question: "What is your cancellation policy?",
-    answer: "Free cancellation up to 24 hours before the tour start time. Cancellations within 24 hours are charged 100% of the tour fee. In case of severe weather warnings, I may offer to reschedule at no extra cost.",
-  },
-  {
-    question: "How do I pay?",
-    answer: "Payment is made on the day of the tour. I accept cash (Japanese Yen) or major credit cards. For custom tours or special arrangements, advance payment may be requested.",
-  },
-  {
-    question: "Can you accommodate dietary restrictions?",
-    answer: "Yes! If we're doing food tasting or stopping for lunch, please inform me of any allergies or dietary restrictions (vegetarian, halal, kosher, etc.) when booking, and I'll make appropriate arrangements.",
-  },
-  {
-    question: "What should I wear/bring?",
-    answer: "Wear comfortable walking shoes and dress for the weather. Bring a camera, water, and perhaps a small backpack. Temples require removing shoes, so easy-to-remove footwear is helpful. I'll send detailed preparation tips before your tour.",
-  },
-  {
-    question: "Can you pick us up from our hotel?",
-    answer: "Tours typically start at convenient train station meeting points. However, for custom tours, I can arrange to meet you at your hotel lobby in central Tokyo for an additional fee. Please inquire when booking.",
-  },
-  {
-    question: "Do you offer tours in languages other than English?",
-    answer: "Currently, I conduct tours in English and Japanese. If you need another language, please contact me and I may be able to recommend a colleague or arrange interpretation.",
-  },
-  {
-    question: "How do I book a custom tour?",
-    answer: "Contact me through the booking form with your interests, dates, and group size. We'll have a conversation to understand what you'd like to experience, and I'll create a personalized itinerary for you.",
+    title: "Practical",
+    items: [
+      {
+        question: "Where do we meet?",
+        answer: "Your guide can meet you at your hotel lobby, a nearby train station, or any convenient location in central Tokyo. We'll confirm the meeting point when you book.",
+      },
+      {
+        question: "What should I wear / bring?",
+        answer: "Comfortable walking shoes are essential. We recommend layers (Tokyo weather changes quickly), a water bottle, and sun protection in summer. Your guide will advise on any specific needs for your chosen tour.",
+      },
+      {
+        question: "Do I need to tip?",
+        answer: "Tipping is not customary in Japan and not expected. If you enjoyed the tour, a kind review is always appreciated!",
+      },
+    ],
   },
 ];
 
-const FAQ = () => {
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
+const allFaqs = faqCategories.flatMap((cat) => cat.items);
 
-  const toggleFAQ = (index: number) => {
-    setOpenIndex(openIndex === index ? null : index);
+const FAQ = () => {
+  const [openIndex, setOpenIndex] = useState<string | null>(null);
+
+  const toggleFAQ = (key: string) => {
+    setOpenIndex(openIndex === key ? null : key);
   };
 
   return (
     <Layout>
       <SEO
-        title="FAQ | Tokyo Private Tour Questions | Tanuki Tabi Travel"
-        description="Answers to common questions about private Tokyo walking tours: cancellation policy, payment, weather, accessibility, and custom tour options."
+        title="FAQ | Tokyo Private Tour Guide Questions | Tanuki Tabi Travel"
+        description="Common questions about booking a private tour in Tokyo. Learn about pricing, what's included, meeting points, group sizes, and how to customize your experience."
         canonicalPath="/faq"
       />
 
@@ -71,46 +131,58 @@ const FAQ = () => {
               Frequently Asked Questions
             </h1>
             <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
-              Find answers to common questions about my tours. Can't find what 
-              you're looking for? Feel free to contact me directly.
+              Find answers to common questions about our tours. Can't find what
+              you're looking for?{" "}
+              <Link to="/contact" className="text-accent hover:underline">
+                Contact us directly
+              </Link>
+              .
             </p>
           </div>
         </div>
       </section>
 
-      {/* FAQ List */}
+      {/* FAQ Categories */}
       <section className="py-16">
         <div className="container-section">
-          <div className="max-w-3xl mx-auto">
-            <div className="space-y-4">
-              {faqs.map((faq, index) => (
-                <div
-                  key={index}
-                  className="bg-card border border-border rounded-lg overflow-hidden"
-                >
-                  <button
-                    onClick={() => toggleFAQ(index)}
-                    className="w-full flex items-center justify-between p-6 text-left hover:bg-secondary/50 transition-colors"
-                  >
-                    <span className="font-serif text-lg font-medium text-foreground pr-4">
-                      {faq.question}
-                    </span>
-                    <ChevronDown
-                      className={`w-5 h-5 text-muted-foreground shrink-0 transition-transform duration-200 ${
-                        openIndex === index ? "rotate-180" : ""
-                      }`}
-                    />
-                  </button>
-                  {openIndex === index && (
-                    <div className="px-6 pb-6 animate-fade-in">
-                      <p className="text-muted-foreground leading-relaxed">
-                        {faq.answer}
-                      </p>
-                    </div>
-                  )}
+          <div className="max-w-3xl mx-auto space-y-12">
+            {faqCategories.map((category) => (
+              <div key={category.title}>
+                <h2 className="heading-card text-foreground mb-6">{category.title}</h2>
+                <div className="space-y-4">
+                  {category.items.map((faq, index) => {
+                    const key = `${category.title}-${index}`;
+                    return (
+                      <div
+                        key={key}
+                        className="bg-card border border-border rounded-lg overflow-hidden"
+                      >
+                        <button
+                          onClick={() => toggleFAQ(key)}
+                          className="w-full flex items-center justify-between p-6 text-left hover:bg-secondary/50 transition-colors"
+                        >
+                          <span className="font-serif text-lg font-medium text-foreground pr-4">
+                            {faq.question}
+                          </span>
+                          <ChevronDown
+                            className={`w-5 h-5 text-muted-foreground shrink-0 transition-transform duration-200 ${
+                              openIndex === key ? "rotate-180" : ""
+                            }`}
+                          />
+                        </button>
+                        {openIndex === key && (
+                          <div className="px-6 pb-6 animate-fade-in">
+                            <p className="text-muted-foreground leading-relaxed">
+                              {faq.answer}
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
-              ))}
-            </div>
+              </div>
+            ))}
           </div>
         </div>
       </section>
@@ -120,7 +192,7 @@ const FAQ = () => {
         <div className="container-section text-center">
           <h2 className="heading-card text-foreground">Still Have Questions?</h2>
           <p className="mt-4 text-muted-foreground max-w-xl mx-auto">
-            I'm happy to answer any other questions you may have about the tours 
+            I'm happy to answer any other questions you may have about the tours
             or your visit to Tokyo.
           </p>
           <Link to="/contact" className="btn-accent mt-8 inline-flex">
@@ -128,6 +200,25 @@ const FAQ = () => {
           </Link>
         </div>
       </section>
+
+      {/* FAQPage Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            "mainEntity": allFaqs.map((faq) => ({
+              "@type": "Question",
+              "name": faq.question,
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": faq.answer,
+              },
+            })),
+          }),
+        }}
+      />
     </Layout>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -66,6 +66,33 @@ const tours = [
     image: imperialPalace,
   },
   {
+    id: "kamakura-day-trip",
+    title: "Kamakura Day Trip",
+    description: "Explore Kamakura's Great Buddha, ancient temples, and coastal charm on a private day trip from Tokyo.",
+    duration: "7-8 hours",
+    price: "¥50,000",
+    difficulty: "Easy-Moderate",
+    image: hamarikyu,
+  },
+  {
+    id: "hakone-day-trip",
+    title: "Hakone Day Trip",
+    description: "See Mt. Fuji, cruise Lake Ashi, and experience hot spring culture on a private guided day trip from Tokyo.",
+    duration: "8-10 hours",
+    price: "¥55,000",
+    difficulty: "Easy",
+    image: hamarikyu,
+  },
+  {
+    id: "nikko-day-trip",
+    title: "Nikko Day Trip",
+    description: "Visit UNESCO World Heritage Toshogu Shrine, stunning waterfalls, and mountain scenery on a day trip from Tokyo.",
+    duration: "9-10 hours",
+    price: "¥60,000",
+    difficulty: "Moderate",
+    image: hamarikyu,
+  },
+  {
     id: "custom",
     title: "Custom Private Tour",
     description: "Create your perfect Tokyo experience. Tell me your interests and I'll design a personalized itinerary just for you.",
@@ -85,12 +112,12 @@ const trustSignals = [
   {
     icon: Star,
     title: "516+ Tours Completed",
-    description: "Trusted by hundreds of travelers from around the world on GuruWalk, GetYourGuide, and GoWithGuide.",
+    description: "Trusted by hundreds of travelers from around the world for quality, authenticity, and personalized experiences.",
   },
   {
     icon: Award,
     title: "4.86★ Average Rating",
-    description: "Consistently top-rated across multiple booking platforms for quality and guest satisfaction.",
+    description: "Consistently top-rated for quality, cultural depth, and guest satisfaction.",
   },
   {
     icon: Users,
@@ -347,14 +374,7 @@ const Index = () => {
           </div>
 
           <p className="mt-8 text-center text-sm text-muted-foreground">
-            <a
-              href="https://www.guruwalk.com/guruwalkers/manabu"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent hover:underline"
-            >
-              500+ five-star reviews on GuruWalk →
-            </a>
+            500+ five-star reviews from travelers worldwide
           </p>
         </div>
       </section>

--- a/src/pages/TourDetail.tsx
+++ b/src/pages/TourDetail.tsx
@@ -1,6 +1,6 @@
 import { useParams, Link } from "react-router-dom";
 import { useState, useCallback, useEffect } from "react";
-import { Clock, Users, MapPin, Check, ArrowLeft, ChevronLeft, ChevronRight, ArrowRight } from "lucide-react";
+import { Clock, Users, MapPin, Check, X, ArrowLeft, ChevronLeft, ChevronRight, ArrowRight, Calendar, Mountain, Footprints, Info } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import useEmblaCarousel from "embla-carousel-react";
@@ -53,6 +53,21 @@ const tourSEO: Record<string, { title: string; description: string; h1: string }
     description: "Create your perfect Tokyo day with a licensed private guide. Tell us your interests and we'll design a custom walking tour just for you. Groups of 1-8 welcome.",
     h1: "Custom Private Tour — Your Tokyo, Your Way",
   },
+  "kamakura-day-trip": {
+    title: "Kamakura Day Trip from Tokyo | Private Guided Tour | Tanuki Tabi Travel",
+    description: "Explore Kamakura's Great Buddha, ancient temples, and coastal charm on a private day trip from Tokyo. Licensed guide, custom itinerary, train travel included in planning.",
+    h1: "Kamakura Day Trip from Tokyo — Private Guided Tour",
+  },
+  "hakone-day-trip": {
+    title: "Hakone Day Trip from Tokyo | Hot Springs & Mt. Fuji Views | Tanuki Tabi Travel",
+    description: "Private guided day trip to Hakone from Tokyo. See Mt. Fuji, cruise Lake Ashi, ride the ropeway, and experience hot spring culture with a licensed guide.",
+    h1: "Hakone Day Trip from Tokyo — Mt. Fuji Views & Hot Springs",
+  },
+  "nikko-day-trip": {
+    title: "Nikko Day Trip from Tokyo | Toshogu Shrine & Nature | Tanuki Tabi Travel",
+    description: "Visit Nikko's UNESCO World Heritage Toshogu Shrine, stunning waterfalls, and mountain scenery on a private guided day trip from Tokyo.",
+    h1: "Nikko Day Trip from Tokyo — UNESCO Shrines & Mountain Scenery",
+  },
 };
 
 const tourSchemaData: Record<string, { name: string; area: string; price: string }> = {
@@ -62,6 +77,9 @@ const tourSchemaData: Record<string, { name: string; area: string; price: string
   "tsukiji-ginza": { name: "Tsukiji & Ginza Private Walking Tour", area: "Tsukiji & Ginza", price: "30000" },
   "imperial-palace": { name: "Imperial Palace Private Walking Tour", area: "Imperial Palace & Marunouchi", price: "25000" },
   custom: { name: "Custom Private Tokyo Tour", area: "Tokyo", price: "10000" },
+  "kamakura-day-trip": { name: "Kamakura Day Trip from Tokyo", area: "Kamakura", price: "50000" },
+  "hakone-day-trip": { name: "Hakone Day Trip from Tokyo", area: "Hakone", price: "55000" },
+  "nikko-day-trip": { name: "Nikko Day Trip from Tokyo", area: "Nikko", price: "60000" },
 };
 
 const tourData = {
@@ -337,15 +355,200 @@ const tourData = {
       "Families with unique needs",
     ],
   },
+  "kamakura-day-trip": {
+    title: "Kamakura Day Trip",
+    subtitle: "Ancient temples, Great Buddha & coastal charm",
+    description: "Escape Tokyo for a day and explore Kamakura, Japan's first military capital. This private day trip takes you to the iconic Great Buddha, serene temples with ocean views, and the charming Komachi-dori shopping street — all with a licensed guide who brings 800 years of samurai history to life.",
+    duration: "7-8 hours",
+    price: "¥50,000",
+    difficulty: "Easy to moderate",
+    groupSize: "1-6 people",
+    startTime: "8:30 AM",
+    meetingPoint: "Your hotel in Tokyo",
+    images: [
+      { src: hamarikyu, alt: "Kamakura Great Buddha and surrounding temple grounds", position: "center" },
+    ],
+    highlights: [
+      "Great Buddha at Kotoku-in — 13th century bronze statue, one of Japan's most iconic landmarks",
+      "Hasedera Temple — ocean views, Kannon statue, hydrangeas in June",
+      "Tsurugaoka Hachimangu Shrine — Kamakura's most important shrine",
+      "Komachi-dori shopping street — local snacks, souvenirs, artisan crafts",
+      "Optional: Hokokuji Temple bamboo grove + matcha experience",
+    ],
+    itinerary: [
+      { time: "8:30 AM", activity: "Meet at your hotel in Tokyo" },
+      { time: "9:30 AM", activity: "Arrive Kamakura by train (~1 hour from Tokyo)" },
+      { time: "10:00 AM", activity: "Tsurugaoka Hachimangu Shrine" },
+      { time: "11:00 AM", activity: "Hokokuji Temple bamboo grove (optional matcha)" },
+      { time: "12:00 PM", activity: "Lunch at a local restaurant (guide recommends based on your preferences)" },
+      { time: "1:30 PM", activity: "Great Buddha at Kotoku-in" },
+      { time: "2:30 PM", activity: "Hasedera Temple (ocean views from observation deck)" },
+      { time: "3:30 PM", activity: "Komachi-dori street — street food, shopping" },
+      { time: "4:30 PM", activity: "Return to Tokyo by train" },
+      { time: "5:30 PM", activity: "Arrive back in Tokyo" },
+    ],
+    includes: [
+      "Licensed English-speaking guide for the full day",
+      "Custom itinerary planning based on your interests",
+      "Navigation of trains and local transport",
+      "Restaurant recommendations and booking assistance",
+      "Cultural context and historical explanations at each site",
+    ],
+    notIncluded: [
+      "Train fares (approx. ¥1,500-2,000 round trip per person)",
+      "Lunch and snacks",
+      "Temple admission fees (approx. ¥200-400 per site)",
+    ],
+    practicalInfo: {
+      duration: "7-8 hours (flexible)",
+      bestSeason: "Year-round. June for hydrangeas, November-December for autumn leaves",
+      difficulty: "Easy to moderate walking on mostly flat terrain",
+      goodFor: "Families, couples, history enthusiasts, first-time Japan visitors",
+    },
+    whyGuide: "Kamakura has over 65 temples and shrines — a guide helps you prioritize and understand the rich history of Japan's first military capital. Skip the confusion of train connections and navigate crowds efficiently, especially at popular sites. Your guide provides cultural context that transforms temple visits from sightseeing into meaningful experiences.",
+    suitableFor: [
+      "Families with children",
+      "Couples seeking a romantic day out",
+      "History and culture enthusiasts",
+      "First-time visitors to Japan",
+      "Anyone wanting to escape the city for a day",
+    ],
+  },
+  "hakone-day-trip": {
+    title: "Hakone Day Trip",
+    subtitle: "Mt. Fuji views, hot springs & volcanic valleys",
+    description: "Experience the best of Hakone in a single day — cruise across Lake Ashi with Mt. Fuji as your backdrop, ride the aerial ropeway over steaming volcanic valleys, and discover the iconic lakeside torii gate of Hakone Shrine. Your guide navigates the complex transport system so you can focus on the views.",
+    duration: "8-10 hours",
+    price: "¥55,000",
+    difficulty: "Easy",
+    groupSize: "1-6 people",
+    startTime: "8:00 AM",
+    meetingPoint: "Your hotel in Tokyo",
+    images: [
+      { src: hamarikyu, alt: "Lake Ashi cruise with Mt. Fuji views in Hakone", position: "center" },
+    ],
+    highlights: [
+      "Lake Ashi pirate ship cruise with Mt. Fuji views (weather permitting)",
+      "Hakone Ropeway — aerial views over Owakudani volcanic valley",
+      "Owakudani — volcanic hot springs, famous black eggs",
+      "Hakone Shrine — iconic torii gate on the lake",
+      "Optional: Hakone Open-Air Museum or onsen (hot spring) experience",
+    ],
+    itinerary: [
+      { time: "8:00 AM", activity: "Meet at your hotel in Tokyo" },
+      { time: "9:30 AM", activity: "Arrive Hakone-Yumoto by Romancecar (scenic express train)" },
+      { time: "10:00 AM", activity: "Hakone Ropeway to Owakudani" },
+      { time: "11:00 AM", activity: "Owakudani volcanic valley (try the famous black eggs!)" },
+      { time: "12:00 PM", activity: "Continue ropeway to Togendai" },
+      { time: "12:30 PM", activity: "Lake Ashi cruise (Mt. Fuji views on clear days)" },
+      { time: "1:30 PM", activity: "Hakone Shrine (walk the lakeside torii gate path)" },
+      { time: "2:30 PM", activity: "Lunch at a local restaurant" },
+      { time: "3:30 PM", activity: "Option: Open-Air Museum OR onsen foot bath" },
+      { time: "5:00 PM", activity: "Return to Tokyo by Romancecar" },
+      { time: "6:30 PM", activity: "Arrive back in Tokyo" },
+    ],
+    includes: [
+      "Licensed English-speaking guide for the full day",
+      "Custom itinerary planning",
+      "Hakone transport navigation (ropeway, cruise, buses — it's complex!)",
+      "Restaurant and onsen recommendations",
+      "Cultural and geological explanations",
+    ],
+    notIncluded: [
+      "Hakone Free Pass (approx. ¥6,100 — covers all Hakone transport + round trip from Shinjuku)",
+      "Lunch",
+      "Museum admission / onsen fees",
+      "Romancecar supplement (approx. ¥1,110 each way, optional)",
+    ],
+    practicalInfo: {
+      duration: "8-10 hours",
+      bestSeason: "October-February for Mt. Fuji visibility. Year-round for hot springs",
+      difficulty: "Easy. Mostly transport-based with short walks",
+      goodFor: "Nature lovers, photographers, couples, anyone wanting to escape the city",
+    },
+    whyGuide: "Hakone's transport system (trains, cable cars, ropeways, buses, boats) can be overwhelming for first-time visitors. A guide navigates the famous \"Hakone Loop\" efficiently, saving you time and confusion. More importantly, Mt. Fuji visibility changes by the hour — your guide adjusts the itinerary in real-time to maximize your chances of that iconic view.",
+    suitableFor: [
+      "Nature lovers and photographers",
+      "Couples seeking a scenic getaway",
+      "Hot spring enthusiasts",
+      "First-time visitors wanting to see Mt. Fuji",
+      "Anyone wanting variety (mountains, lakes, volcanoes)",
+    ],
+  },
+  "nikko-day-trip": {
+    title: "Nikko Day Trip",
+    subtitle: "UNESCO shrines, waterfalls & mountain scenery",
+    description: "Journey to Nikko, home to Japan's most ornate shrine complex and breathtaking mountain scenery. Discover the UNESCO World Heritage Toshogu Shrine with its 5,000+ intricate carvings, witness the powerful Kegon Falls, and enjoy the serene beauty of Lake Chuzenji — all with expert historical commentary from your guide.",
+    duration: "9-10 hours",
+    price: "¥60,000",
+    difficulty: "Moderate",
+    groupSize: "1-6 people",
+    startTime: "7:30 AM",
+    meetingPoint: "Tokyo Station",
+    images: [
+      { src: hamarikyu, alt: "Toshogu Shrine ornate carvings in Nikko", position: "center" },
+    ],
+    highlights: [
+      "Toshogu Shrine — UNESCO World Heritage, Japan's most ornate shrine complex",
+      "\"See no evil, speak no evil, hear no evil\" original carvings",
+      "Shinkyo Bridge — sacred vermillion bridge over the Daiya River",
+      "Kegon Falls — one of Japan's most famous waterfalls (97m drop)",
+      "Lake Chuzenji — mountain lake at 1,269m elevation",
+    ],
+    itinerary: [
+      { time: "7:30 AM", activity: "Meet at Tokyo Station" },
+      { time: "9:30 AM", activity: "Arrive Nikko by Shinkansen + local train (~2 hours)" },
+      { time: "10:00 AM", activity: "Shinkyo Bridge (photo stop)" },
+      { time: "10:30 AM", activity: "Toshogu Shrine complex (allow 1.5-2 hours)" },
+      { time: "12:30 PM", activity: "Lunch (try local specialty: yuba — tofu skin dishes)" },
+      { time: "1:30 PM", activity: "Drive/bus to Chuzenji area" },
+      { time: "2:00 PM", activity: "Kegon Falls observation platform" },
+      { time: "2:30 PM", activity: "Lake Chuzenji lakeside walk" },
+      { time: "3:30 PM", activity: "Return to Nikko Station" },
+      { time: "4:00 PM", activity: "Train back to Tokyo" },
+      { time: "6:00 PM", activity: "Arrive Tokyo" },
+    ],
+    includes: [
+      "Licensed English-speaking guide for the full day",
+      "Custom itinerary planning",
+      "Train and bus navigation",
+      "Detailed explanations of Toshogu's intricate carvings and Shinto/Buddhist history",
+      "Local food recommendations",
+    ],
+    notIncluded: [
+      "Train fares (approx. ¥5,000-8,000 round trip depending on train type)",
+      "Toshogu Shrine admission (¥1,600)",
+      "Lunch",
+      "Kegon Falls elevator (¥570, optional)",
+      "Bus fares within Nikko area",
+    ],
+    practicalInfo: {
+      duration: "9-10 hours (Nikko is further from Tokyo)",
+      bestSeason: "October-November for spectacular autumn foliage. May for spring greenery",
+      difficulty: "Moderate. Some uphill walking and stairs at Toshogu",
+      goodFor: "History buffs, nature lovers, UNESCO heritage enthusiasts, photographers",
+    },
+    whyGuide: "Toshogu Shrine has over 5,000 intricate carvings — without a guide, you'll walk past 90% of them without understanding their meaning. The shrine complex is a masterpiece of Tokugawa-era craftsmanship, and a knowledgeable guide transforms the visit from \"pretty buildings\" into a deep dive into Japanese political and spiritual history. The guide also handles the complex transport logistics between Nikko town and the mountain lake area.",
+    suitableFor: [
+      "History buffs and culture enthusiasts",
+      "Nature lovers and photographers",
+      "UNESCO heritage enthusiasts",
+      "Those seeking less-crowded destinations",
+      "Travelers who enjoy deeper cultural experiences",
+    ],
+  },
 };
 
 const relatedTours: Record<string, string[]> = {
-  asakusa: ["yanaka", "tsukiji-ginza", "imperial-palace"],
-  yanaka: ["asakusa", "imperial-palace", "shibuya-harajuku"],
-  "shibuya-harajuku": ["tsukiji-ginza", "asakusa", "custom"],
-  "tsukiji-ginza": ["asakusa", "imperial-palace", "shibuya-harajuku"],
-  "imperial-palace": ["asakusa", "tsukiji-ginza", "yanaka"],
-  custom: ["asakusa", "shibuya-harajuku", "tsukiji-ginza"],
+  asakusa: ["yanaka", "tsukiji-ginza", "kamakura-day-trip"],
+  yanaka: ["asakusa", "imperial-palace", "nikko-day-trip"],
+  "shibuya-harajuku": ["tsukiji-ginza", "asakusa", "hakone-day-trip"],
+  "tsukiji-ginza": ["asakusa", "imperial-palace", "kamakura-day-trip"],
+  "imperial-palace": ["asakusa", "tsukiji-ginza", "nikko-day-trip"],
+  custom: ["asakusa", "shibuya-harajuku", "hakone-day-trip"],
+  "kamakura-day-trip": ["hakone-day-trip", "nikko-day-trip", "custom"],
+  "hakone-day-trip": ["kamakura-day-trip", "nikko-day-trip", "custom"],
+  "nikko-day-trip": ["kamakura-day-trip", "hakone-day-trip", "custom"],
 };
 
 const tourNames: Record<string, string> = {
@@ -355,6 +558,9 @@ const tourNames: Record<string, string> = {
   "tsukiji-ginza": "Tsukiji & Ginza Tour",
   "imperial-palace": "Imperial Palace Tour",
   custom: "Custom Private Tour",
+  "kamakura-day-trip": "Kamakura Day Trip",
+  "hakone-day-trip": "Hakone Day Trip",
+  "nikko-day-trip": "Nikko Day Trip",
 };
 
 const TourDetail = () => {
@@ -547,6 +753,66 @@ const TourDetail = () => {
                 </ul>
               </div>
 
+              {/* Not Included (day trips only) */}
+              {"notIncluded" in tour && (tour as any).notIncluded && (
+                <div>
+                  <h2 className="heading-card text-foreground mb-4">Not Included</h2>
+                  <ul className="space-y-3">
+                    {((tour as any).notIncluded as string[]).map((item: string, index: number) => (
+                      <li key={index} className="flex items-start gap-3">
+                        <X className="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
+                        <span className="text-muted-foreground">{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Why Go With a Private Guide (day trips only) */}
+              {"whyGuide" in tour && (tour as any).whyGuide && (
+                <div className="bg-secondary/50 rounded-lg p-6">
+                  <h2 className="heading-card text-foreground mb-4">Why Go With a Private Guide?</h2>
+                  <p className="text-muted-foreground leading-relaxed">{(tour as any).whyGuide}</p>
+                </div>
+              )}
+
+              {/* Practical Information (day trips only) */}
+              {"practicalInfo" in tour && (tour as any).practicalInfo && (
+                <div>
+                  <h2 className="heading-card text-foreground mb-4">Practical Information</h2>
+                  <div className="grid sm:grid-cols-2 gap-4">
+                    <div className="flex items-start gap-3 p-4 bg-card border border-border rounded-lg">
+                      <Clock className="w-5 h-5 text-accent shrink-0 mt-0.5" />
+                      <div>
+                        <p className="font-medium text-foreground text-sm">Duration</p>
+                        <p className="text-muted-foreground text-sm">{(tour as any).practicalInfo.duration}</p>
+                      </div>
+                    </div>
+                    <div className="flex items-start gap-3 p-4 bg-card border border-border rounded-lg">
+                      <Calendar className="w-5 h-5 text-accent shrink-0 mt-0.5" />
+                      <div>
+                        <p className="font-medium text-foreground text-sm">Best Season</p>
+                        <p className="text-muted-foreground text-sm">{(tour as any).practicalInfo.bestSeason}</p>
+                      </div>
+                    </div>
+                    <div className="flex items-start gap-3 p-4 bg-card border border-border rounded-lg">
+                      <Footprints className="w-5 h-5 text-accent shrink-0 mt-0.5" />
+                      <div>
+                        <p className="font-medium text-foreground text-sm">Difficulty</p>
+                        <p className="text-muted-foreground text-sm">{(tour as any).practicalInfo.difficulty}</p>
+                      </div>
+                    </div>
+                    <div className="flex items-start gap-3 p-4 bg-card border border-border rounded-lg">
+                      <Users className="w-5 h-5 text-accent shrink-0 mt-0.5" />
+                      <div>
+                        <p className="font-medium text-foreground text-sm">Good For</p>
+                        <p className="text-muted-foreground text-sm">{(tour as any).practicalInfo.goodFor}</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
               {/* Suitable For */}
               <div>
                 <h2 className="heading-card text-foreground mb-4">This Tour is Perfect For</h2>
@@ -606,6 +872,26 @@ const TourDetail = () => {
           </div>
         </div>
       </section>
+
+      {/* Day Trip CTA */}
+      {"whyGuide" in tour && (
+        <section className="py-16 bg-primary text-primary-foreground">
+          <div className="container-section text-center">
+            <h2 className="heading-section">Ready to explore {tour.title.replace(" Day Trip", "")}?</h2>
+            <p className="mt-4 text-primary-foreground/70 max-w-xl mx-auto">
+              Let's create an unforgettable day trip experience. Contact us to book your private guided tour or customize the itinerary.
+            </p>
+            <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+              <Link to="/contact" className="btn-accent">
+                Book This Tour
+              </Link>
+              <Link to="/tours/custom" className="inline-flex items-center justify-center px-6 py-3 border-2 border-primary-foreground/30 text-primary-foreground font-medium rounded-md transition-all duration-200 hover:bg-primary-foreground/10">
+                Customize This Trip
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* You Might Also Like */}
       {related.length > 0 && (

--- a/src/pages/Tours.tsx
+++ b/src/pages/Tours.tsx
@@ -8,7 +8,7 @@ import tsukijiMarket from "@/assets/tsukiji-market.jpg";
 import imperialPalace from "@/assets/imperial-palace.jpg";
 import hamarikyu from "@/assets/hamarikyu.jpg";
 
-const tours = [
+const tokyoTours = [
   {
     id: "asakusa",
     title: "Asakusa Walking Tour",
@@ -65,12 +65,42 @@ const tours = [
   },
 ];
 
+const dayTrips = [
+  {
+    id: "kamakura-day-trip",
+    title: "Kamakura Day Trip",
+    description: "Explore Kamakura's Great Buddha, ancient temples, and coastal charm on a private day trip from Tokyo with a licensed guide.",
+    duration: "7-8 hours",
+    price: "¥50,000",
+    difficulty: "Easy-Moderate",
+    image: hamarikyu,
+  },
+  {
+    id: "hakone-day-trip",
+    title: "Hakone Day Trip",
+    description: "See Mt. Fuji, cruise Lake Ashi, ride the ropeway over volcanic valleys, and experience hot spring culture on a private guided day trip.",
+    duration: "8-10 hours",
+    price: "¥55,000",
+    difficulty: "Easy",
+    image: hamarikyu,
+  },
+  {
+    id: "nikko-day-trip",
+    title: "Nikko Day Trip",
+    description: "Visit Nikko's UNESCO World Heritage Toshogu Shrine, stunning waterfalls, and mountain scenery on a private guided day trip from Tokyo.",
+    duration: "9-10 hours",
+    price: "¥60,000",
+    difficulty: "Moderate",
+    image: hamarikyu,
+  },
+];
+
 const Tours = () => {
   return (
     <Layout>
       <SEO
-        title="Tokyo Walking Tours | Private Guided Tours | Tanuki Tabi Travel"
-        description="Browse private walking tours of Tokyo led by a government-licensed guide. Asakusa, Yanaka, Shibuya, Ginza, Imperial Palace and custom tours available."
+        title="Tokyo Tours & Day Trips | Private Guided Tours | Tanuki Tabi Travel"
+        description="Browse private walking tours of Tokyo and day trips to Kamakura, Hakone, and Nikko. Led by a government-licensed guide. Custom tours available."
         canonicalPath="/tours"
       />
 
@@ -79,20 +109,38 @@ const Tours = () => {
         <div className="container-section">
           <div className="max-w-2xl">
             <p className="text-label text-accent mb-3">Explore Tokyo</p>
-            <h1 className="heading-display text-foreground">Private Walking Tours of Tokyo</h1>
+            <h1 className="heading-display text-foreground">Private Tours & Day Trips</h1>
             <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
-              Discover Tokyo's rich culture and hidden gems through immersive 
-              walking tours led by a local professional guide.
+              Discover Tokyo's rich culture through immersive walking tours, or explore beyond the city with private day trips to Kamakura, Hakone, and Nikko.
             </p>
           </div>
         </div>
       </section>
 
-      {/* Tour Grid */}
+      {/* Tokyo Walking Tours */}
       <section className="py-16">
         <div className="container-section">
+          <h2 className="heading-section text-foreground mb-8">Tokyo Walking Tours</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {tours.map((tour) => (
+            {tokyoTours.map((tour) => (
+              <TourCard key={tour.id} {...tour} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Day Trips from Tokyo */}
+      <section className="py-16 bg-secondary/30">
+        <div className="container-section">
+          <div className="mb-8">
+            <p className="text-label text-accent mb-3">Day Trips</p>
+            <h2 className="heading-section text-foreground">Day Trips from Tokyo</h2>
+            <p className="mt-4 text-body max-w-2xl">
+              Explore beyond Tokyo with a private guide. Each day trip includes full-day guide service, transport navigation, and cultural commentary.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {dayTrips.map((tour) => (
               <TourCard key={tour.id} {...tour} />
             ))}
           </div>

--- a/src/pages/blog/BlogIndex.tsx
+++ b/src/pages/blog/BlogIndex.tsx
@@ -1,0 +1,122 @@
+import { Link } from "react-router-dom";
+import { ArrowRight, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const blogPosts = [
+  {
+    slug: "tokyo-3-day-itinerary",
+    title: "The Perfect 3-Day Tokyo Itinerary — From a Local Guide",
+    description:
+      "Plan the perfect 3 days in Tokyo with insider tips from a licensed local guide. Covers Asakusa, Shibuya, Tsukiji, day trips, and hidden gems most tourists miss.",
+    date: "February 25, 2026",
+    author: "Manabu, Licensed Tour Guide",
+    category: "Itineraries",
+  },
+  {
+    slug: "is-it-worth-hiring-a-tour-guide-in-tokyo",
+    title: "Is It Worth Hiring a Private Tour Guide in Tokyo?",
+    description:
+      "Wondering if a private tour guide in Tokyo is worth the cost? A licensed guide explains when it makes sense, what you get, and who benefits most.",
+    date: "February 25, 2026",
+    author: "Manabu, Licensed Tour Guide",
+    category: "Travel Tips",
+  },
+  {
+    slug: "kamakura-vs-hakone-vs-nikko-day-trip",
+    title: "Kamakura vs Hakone vs Nikko — Which Day Trip Should You Choose?",
+    description:
+      "Can't decide between Kamakura, Hakone, or Nikko? A local guide compares travel time, highlights, and who each trip is best for to help you choose.",
+    date: "February 25, 2026",
+    author: "Manabu, Licensed Tour Guide",
+    category: "Day Trips",
+  },
+];
+
+const BlogIndex = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Blog | Tokyo Travel Tips & Guide Stories | Tanuki Tabi Travel"
+        description="Travel tips, itineraries, and insider recommendations from a licensed Tokyo tour guide. Plan your perfect Tokyo trip with local knowledge."
+        canonicalPath="/blog"
+      />
+
+      {/* Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-2xl">
+            <p className="text-label text-accent mb-3">From Your Guide</p>
+            <h1 className="heading-display text-foreground">Blog</h1>
+            <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
+              Travel tips, itineraries, and insider recommendations to help you
+              plan the perfect Tokyo experience.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Blog Grid */}
+      <section className="py-16">
+        <div className="container-section">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {blogPosts.map((post) => (
+              <Link
+                key={post.slug}
+                to={`/blog/${post.slug}`}
+                className="group bg-card border border-border rounded-lg overflow-hidden hover:shadow-[var(--shadow-medium)] hover:-translate-y-1 transition-all duration-300"
+              >
+                <div className="p-6">
+                  <p className="text-label text-accent mb-2">{post.category}</p>
+                  <h2 className="font-serif text-xl font-medium text-foreground group-hover:text-accent transition-colors mb-3">
+                    {post.title}
+                  </h2>
+                  <p className="text-muted-foreground text-sm leading-relaxed mb-4">
+                    {post.description}
+                  </p>
+                  <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <User className="w-3 h-3" />
+                      {post.author}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <Calendar className="w-3 h-3" />
+                      {post.date}
+                    </span>
+                  </div>
+                  <div className="mt-4 flex items-center gap-2 text-accent font-medium text-sm">
+                    <span>Read Article</span>
+                    <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 bg-primary text-primary-foreground">
+        <div className="container-section text-center">
+          <h2 className="heading-section">Ready to Explore Tokyo?</h2>
+          <p className="mt-4 text-primary-foreground/70 max-w-xl mx-auto">
+            Turn these travel tips into real experiences with a private guided tour.
+          </p>
+          <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+            <Link to="/tours" className="btn-accent">
+              Browse Tours
+            </Link>
+            <Link
+              to="/contact"
+              className="inline-flex items-center justify-center px-6 py-3 border-2 border-primary-foreground/30 text-primary-foreground font-medium rounded-md transition-all duration-200 hover:bg-primary-foreground/10"
+            >
+              Contact Us
+            </Link>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default BlogIndex;

--- a/src/pages/blog/DayTripComparison.tsx
+++ b/src/pages/blog/DayTripComparison.tsx
@@ -1,0 +1,321 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const DayTripComparison = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Kamakura vs Hakone vs Nikko: Which Day Trip from Tokyo Is Best? | Tanuki Tabi Travel"
+        description="Can't decide between Kamakura, Hakone, or Nikko? A local guide compares travel time, highlights, and who each trip is best for to help you choose."
+        canonicalPath="/blog/kamakura-vs-hakone-vs-nikko-day-trip"
+      />
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Day Trips</p>
+            <h1 className="heading-display text-foreground">
+              Kamakura vs Hakone vs Nikko — Which Day Trip Should You Choose?
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                February 25, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-4">
+              "Which day trip should I do?" — I get this question on almost every tour. It's one of the most common dilemmas facing Tokyo visitors, and the answer is genuinely different for every traveler.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Kamakura, Hakone, and Nikko are the three most popular day trip destinations from Tokyo, and each offers a completely different experience. Having guided hundreds of travelers to all three, I can tell you that there's no single "best" choice — it depends on what you're looking for, how much time you have, and what kind of experience excites you.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              Here's an honest, detailed comparison to help you decide. And if you still can't choose after reading this — that's what custom itineraries are for.
+            </p>
+
+            {/* Quick Comparison Table */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Quick Comparison
+            </h2>
+            <div className="overflow-x-auto mb-8">
+              <table className="w-full text-sm border border-border rounded-lg overflow-hidden">
+                <thead>
+                  <tr className="bg-secondary/50">
+                    <th className="text-left p-4 font-serif font-medium text-foreground"></th>
+                    <th className="text-left p-4 font-serif font-medium text-foreground">Kamakura</th>
+                    <th className="text-left p-4 font-serif font-medium text-foreground">Hakone</th>
+                    <th className="text-left p-4 font-serif font-medium text-foreground">Nikko</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  <tr>
+                    <td className="p-4 font-medium text-foreground">Travel time</td>
+                    <td className="p-4 text-muted-foreground">~1 hour</td>
+                    <td className="p-4 text-muted-foreground">~1.5 hours</td>
+                    <td className="p-4 text-muted-foreground">~2 hours</td>
+                  </tr>
+                  <tr className="bg-secondary/20">
+                    <td className="p-4 font-medium text-foreground">Main draw</td>
+                    <td className="p-4 text-muted-foreground">Ancient temples, coastal town</td>
+                    <td className="p-4 text-muted-foreground">Mt. Fuji views, hot springs</td>
+                    <td className="p-4 text-muted-foreground">UNESCO shrine, nature</td>
+                  </tr>
+                  <tr>
+                    <td className="p-4 font-medium text-foreground">Best for</td>
+                    <td className="p-4 text-muted-foreground">History lovers, foodies</td>
+                    <td className="p-4 text-muted-foreground">Nature & relaxation</td>
+                    <td className="p-4 text-muted-foreground">History + nature combo</td>
+                  </tr>
+                  <tr className="bg-secondary/20">
+                    <td className="p-4 font-medium text-foreground">Difficulty</td>
+                    <td className="p-4 text-muted-foreground">Easy</td>
+                    <td className="p-4 text-muted-foreground">Easy</td>
+                    <td className="p-4 text-muted-foreground">Moderate</td>
+                  </tr>
+                  <tr>
+                    <td className="p-4 font-medium text-foreground">Best season</td>
+                    <td className="p-4 text-muted-foreground">June (hydrangeas), year-round</td>
+                    <td className="p-4 text-muted-foreground">Oct-Feb (Fuji views)</td>
+                    <td className="p-4 text-muted-foreground">Oct-Nov (autumn leaves)</td>
+                  </tr>
+                  <tr className="bg-secondary/20">
+                    <td className="p-4 font-medium text-foreground">Transport cost</td>
+                    <td className="p-4 text-muted-foreground">~¥1,500 RT</td>
+                    <td className="p-4 text-muted-foreground">~¥6,100 (Hakone Pass)</td>
+                    <td className="p-4 text-muted-foreground">~¥5,000-8,000 RT</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            {/* Kamakura */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              Kamakura: Japan's Ancient Capital by the Sea
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Kamakura was Japan's political capital from 1185 to 1333, when the Kamakura shogunate ruled the country. Today, it's a small, walkable coastal city with over 65 temples and shrines packed into a remarkably compact area. The combination of ancient history, natural beauty, and excellent food makes it the most well-rounded day trip option.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The star attraction is the Great Buddha (Daibutsu) at Kotoku-in — a 13-meter bronze statue from the 13th century that originally sat inside a massive wooden hall. Typhoons and tsunamis destroyed the hall centuries ago, and the Buddha has sat serenely in the open air ever since. There's something deeply moving about seeing this ancient figure sitting peacefully against the sky, weathering the same storms for 800 years.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Beyond the Great Buddha, Kamakura offers Hasedera Temple (spectacular ocean views and a famous golden Kannon statue), Tsurugaoka Hachimangu Shrine (the city's most important shrine, with a dramatic approach road), and Hokokuji Temple (a serene bamboo grove where you can enjoy matcha tea). The Komachi-dori shopping street near the station is perfect for lunch and snacking — try the local shirasu (baby sardines) that Kamakura is famous for.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Best For
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              History lovers, first-time Japan visitors who want a well-rounded experience, families (easy terrain, lots of variety), and food enthusiasts. Kamakura is also the easiest day trip logistically — simple train connections, compact walking area, and well-signed paths.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              What Most People Don't Know
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Most tourists follow the same route (Station → Hachimangu → Great Buddha → Station), but Kamakura's real magic is in the smaller temples tucked into the surrounding hills. Zuisen-ji Temple has a stunning rock garden that receives a fraction of the visitors. The hiking trails between temples offer ocean views and forest walks. And in June, Kamakura transforms into a hydrangea paradise — Meigetsu-in Temple's blue hydrangea garden is one of the most photographed spots in Japan.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <Link to="/tours/kamakura-day-trip" className="text-accent hover:underline font-medium">
+                View our Kamakura Day Trip tour details →
+              </Link>
+            </p>
+
+            {/* Hakone */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              Hakone: Hot Springs & the Iconic Fuji View
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Hakone is where Tokyo residents go to escape the city, and it's been a popular retreat for centuries. Located in the mountains southwest of Tokyo, it offers a unique combination of natural beauty, volcanic geology, and traditional hot spring culture. The famous "Hakone Loop" — a circuit of trains, cable cars, ropeways, cruise ships, and buses — is both a transportation system and an attraction in itself.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The highlight for most visitors is the view of Mt. Fuji across Lake Ashi. When conditions are right (clear winter mornings are best), the snow-capped peak reflected in the lake is one of Japan's most iconic images. The Hakone Ropeway carries you high over Owakudani, an active volcanic valley where you can see sulfurous steam rising from the ground and try the famous black eggs — regular eggs boiled in the volcanic hot springs that turn the shell black. Legend says each one adds seven years to your life.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Hakone Shrine, with its red torii gate standing in the lake, is one of Japan's most photographed spiritual sites. The approach through the ancient cedar forest is atmospheric, and the lakeside torii creates a stunning composition. Beyond the main attractions, Hakone offers the Open-Air Museum (impressive sculpture garden with Picasso pavilion), traditional ryokan inns, and of course, onsen — the natural hot spring baths that are central to Japanese relaxation culture.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Best For
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Nature lovers, photographers (especially those chasing the Fuji shot), couples seeking a romantic experience, and anyone who wants a complete change of scenery from Tokyo's urban energy. If seeing Mt. Fuji is on your bucket list, Hakone is your best bet for a day trip (though weather cooperation is required — Fuji is visible roughly 60-70% of clear days in winter, less in summer).
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Insider Tip: The Fuji Factor
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Here's what most travel guides won't tell you: Mt. Fuji visibility is highly unpredictable and changes throughout the day. Morning is generally better than afternoon, and winter months (October to February) offer significantly better odds than summer. Cloud cover can roll in within minutes. This is exactly why a guide is valuable in Hakone — I check weather conditions in real-time and rearrange the itinerary to maximize your chances. If Fuji is visible in the morning, we do the lake cruise first instead of saving it for later.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The transport system is also genuinely complex. The Hakone Free Pass is the most economical option, but figuring out the right combination of transportation, timing, and routing on your own takes significant planning. A guide eliminates this cognitive load entirely.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <Link to="/tours/hakone-day-trip" className="text-accent hover:underline font-medium">
+                View our Hakone Day Trip tour details →
+              </Link>
+            </p>
+
+            {/* Nikko */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              Nikko: The Hidden UNESCO Masterpiece
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If Kamakura is Japan's accessible ancient capital and Hakone is its scenic playground, Nikko is the hidden masterpiece that rewards those willing to make the longer journey. Located about two hours north of Tokyo in the mountains of Tochigi Prefecture, Nikko is home to the most ornate shrine complex in Japan — and some of the country's most spectacular natural scenery.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Toshogu Shrine is the mausoleum of Tokugawa Ieyasu, the founder of the Tokugawa shogunate that ruled Japan for over 250 years. Unlike the austere simplicity of most Japanese shrines, Toshogu is deliberately, almost overwhelmingly ornate. Over 5,000 intricate carvings cover every surface — mythological creatures, natural scenes, philosophical allegories, and historical narratives. The "see no evil, speak no evil, hear no evil" monkeys that you see on souvenirs worldwide? The original carving is here, and it's part of a larger series depicting the stages of human life.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Beyond the shrine complex, Nikko offers the dramatic Kegon Falls — a 97-meter waterfall that you can view from an observation platform reached by elevator inside the cliff. Lake Chuzenji, at 1,269 meters elevation, offers a completely different climate and atmosphere from Tokyo. In autumn (October to November), the mountainside transforms into a tapestry of red, orange, and gold that rivals any foliage display in the world.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Best For
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              History buffs who want to understand the Tokugawa era, nature lovers (especially in autumn), UNESCO heritage enthusiasts, and photographers. Nikko is also significantly less crowded than Kamakura or Hakone, which is a major advantage for those who prefer a more peaceful experience.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Why It's Less Crowded Than the Others
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The longer travel time (about 2 hours each way) means fewer tourists make the trip, especially on day visits. This works in your favor — you'll have more space at the shrine, shorter queues for the falls elevator, and a more contemplative experience overall. The trade-off is a longer day — you'll need to leave Tokyo earlier and return later. But for travelers who value depth over convenience, Nikko delivers an experience that the closer destinations simply can't match.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              A guide is particularly valuable at Nikko because Toshogu's carvings are a visual encyclopedia that requires explanation to appreciate. Without context, you'll see "pretty decorations." With a guide, you'll understand the political messages, Buddhist symbolism, and Confucian philosophy embedded in every panel. It's the difference between looking at the Sistine Chapel and understanding what Michelangelo was trying to say.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <Link to="/tours/nikko-day-trip" className="text-accent hover:underline font-medium">
+                View our Nikko Day Trip tour details →
+              </Link>
+            </p>
+
+            {/* Can I Do Two? */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              Can I Do Two in One Trip?
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you have multiple days available, you can absolutely combine day trips. The most popular combinations are:
+            </p>
+            <ul className="space-y-3 mb-4">
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Kamakura + Hakone</strong> — The most popular combo. Both are south/southwest of Tokyo, and you could even stay overnight in Hakone at a ryokan for the ultimate hot spring experience.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Kamakura + Nikko</strong> — Great for history enthusiasts. Kamakura (Kamakura shogunate) and Nikko (Tokugawa shogunate) together tell the story of 700 years of Japanese military government.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Hakone + Nikko</strong> — For nature lovers who want maximum scenery variety. Mountains, lakes, volcanoes, waterfalls — everything Japan's geography has to offer.
+              </li>
+            </ul>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              We offer multi-day packages that combine Tokyo walking tours with day trips. This is the best value option and allows us to build a comprehensive itinerary that covers different aspects of Japan's culture and nature.{" "}
+              <Link to="/contact" className="text-accent hover:underline">
+                Contact us
+              </Link>{" "}
+              to discuss multi-day options.
+            </p>
+
+            {/* My Recommendation */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              My Recommendation
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              After hundreds of day trips with travelers, here's my honest recommendation:
+            </p>
+            <ul className="space-y-3 mb-4">
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">If you only have 1 day:</strong> Go to Kamakura. It's the easiest, most well-rounded experience with the shortest travel time. You'll see ancient temples, a world-famous Buddha statue, ocean views, and excellent food — all in a comfortable 7-8 hour day.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">If you want nature + relaxation:</strong> Choose Hakone. The combination of Mt. Fuji views, volcanic valley, lake cruise, and potential onsen experience creates a day that feels like a complete escape from Tokyo.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">If you love history and don't mind a longer ride:</strong> Nikko is the answer. Toshogu Shrine alone justifies the trip, and the natural scenery is a bonus that makes the longer travel time worthwhile.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">If you have 2+ days for day trips:</strong> Do Kamakura + Hakone (most popular combination) or Kamakura + Nikko (for history lovers). Each destination offers something the others don't, so you won't feel like you're repeating the experience.
+              </li>
+            </ul>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              The most important thing is to choose based on what excites you, not what's "most popular." If you're genuinely passionate about history, Nikko will blow your mind even though it's the least-visited of the three. If you dream of seeing Mt. Fuji, Hakone is your best shot. And if you want the most balanced, easy-going experience, Kamakura delivers every time.
+            </p>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="font-serif text-2xl font-medium text-foreground mb-4">
+                Ready to explore beyond Tokyo?
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                Check out our day trip tours, or contact us to build a custom multi-day itinerary that combines the best of Tokyo and surrounding destinations.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/tours" className="btn-accent">
+                  Browse Day Trips
+                </Link>
+                <Link to="/contact" className="btn-outline">
+                  Plan a Multi-Day Trip
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Kamakura vs Hakone vs Nikko — Which Day Trip Should You Choose?",
+            "description": "Can't decide between Kamakura, Hakone, or Nikko? A local guide compares travel time, highlights, and who each trip is best for.",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+            },
+            "datePublished": "2026-02-25",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default DayTripComparison;

--- a/src/pages/blog/IsItWorthHiringGuide.tsx
+++ b/src/pages/blog/IsItWorthHiringGuide.tsx
@@ -1,0 +1,301 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const IsItWorthHiringGuide = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Is It Worth Hiring a Private Tour Guide in Tokyo? | Tanuki Tabi Travel"
+        description="Wondering if a private tour guide in Tokyo is worth the cost? A licensed guide explains when it makes sense, what you get, and who benefits most."
+        canonicalPath="/blog/is-it-worth-hiring-a-tour-guide-in-tokyo"
+      />
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Travel Tips</p>
+            <h1 className="heading-display text-foreground">
+              Is It Worth Hiring a Private Tour Guide in Tokyo?
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                February 25, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-4">
+              Let me be honest upfront: Tokyo is one of the safest, most well-organized cities in the world. Signs are increasingly in English, Google Maps works perfectly, and you can absolutely explore on your own and have an amazing time.
+            </p>
+            <p className="text-lg text-muted-foreground leading-relaxed mb-4">
+              So why would you hire a private tour guide?
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Having guided over 500 tours in Tokyo, I've seen the moments where a guide makes a real difference — and the moments where travelers are perfectly fine on their own. This isn't a sales pitch. It's an honest breakdown from someone who has seen both sides, so you can make the right decision for your trip.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              I believe that the best travel decisions come from honest information, not pressure. If you read this article and decide you don't need a guide, that's a perfectly valid choice. Tokyo will still be amazing.
+            </p>
+
+            {/* When a Guide Is Worth It */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              When a Guide Is Worth It
+            </h2>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              First-Time Visitors Who Want Depth, Not Just Selfies
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tokyo can be overwhelming on your first visit. Not because it's difficult to navigate — it isn't — but because there's so much happening beneath the surface that you can't see. A temple isn't just a building; it's a living piece of history with rituals, symbolism, and community roles that aren't written on the information boards.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              On my{" "}
+              <Link to="/tours/asakusa" className="text-accent hover:underline">
+                Asakusa tour
+              </Link>
+              , for example, I don't just point out Senso-ji Temple — I explain why the gate guardians look fierce, what the incense ritual means, and why the fortune papers tied to the racks might actually be "bad luck" fortunes that visitors are leaving behind. These layers of meaning transform sightseeing into understanding.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              First-time visitors consistently tell me that the cultural context changes everything. It's the difference between "I saw a temple" and "I understood why this temple has been the spiritual heart of this neighborhood for 1,400 years."
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Travelers with Limited Time
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you have 2-3 days in Tokyo (which is common for business travelers or those on a multi-city Japan trip), every hour matters. A guide eliminates the time you'd spend figuring out train routes, walking in the wrong direction, and standing in front of a menu you can't read.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              More importantly, a guide knows the rhythm of the city. I know which attractions to hit first to avoid crowds, when certain shops and markets are at their best, and which "must-sees" can be experienced quickly versus which ones deserve an hour of your time. This kind of real-time optimization can easily save you 2-3 hours over the course of a day.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Families with Children
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Traveling with kids in Tokyo is wonderful but requires pace management. Children get tired, hungry, and bored at different times than adults. A guide adjusts the route in real-time — we know where the nearest restrooms are, which temples have spaces for kids to run, and how to keep younger travelers engaged with stories and interactive elements.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Our routes are mostly flat and pram-friendly. We regularly welcome families with children of all ages, and I've developed storytelling techniques that keep kids fascinated while still giving adults the cultural depth they're looking for.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Special Interest Travelers
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you're passionate about Japanese history, architecture, food, photography, or pop culture, a guide can take you far deeper than any guidebook. I adjust every tour based on what excites each guest. A photographer gets taken to the best light and composition spots. A history buff gets the full backstory of every landmark. A food lover gets taken to the places locals actually eat.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              This level of personalization is impossible with a group tour or an audioguide. It comes from reading the guest's reactions and having deep enough knowledge to pivot the conversation in real-time.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Day Trip Explorers
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Day trips to{" "}
+              <Link to="/tours/kamakura-day-trip" className="text-accent hover:underline">
+                Kamakura
+              </Link>
+              ,{" "}
+              <Link to="/tours/hakone-day-trip" className="text-accent hover:underline">
+                Hakone
+              </Link>
+              , and{" "}
+              <Link to="/tours/nikko-day-trip" className="text-accent hover:underline">
+                Nikko
+              </Link>{" "}
+              involve complex transport systems, multiple connections, and destinations that are much less English-friendly than central Tokyo. Hakone alone involves trains, cable cars, ropeways, boats, and buses — all operated by different companies with different passes and schedules.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              A guide handles all the logistics so you can focus on the experience. They also adjust the itinerary based on weather (crucial for Mt. Fuji views in Hakone) and crowds. For day trips, the value of a guide is often highest because the time savings and logistical relief are most significant.
+            </p>
+
+            {/* When You Might Not Need a Guide */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              When You Might Not Need a Guide
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              I believe in being transparent — a guide isn't right for everyone, and overselling would do a disservice to both you and me.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Repeat Visitors Who Know the Basics
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you've been to Tokyo before and already have a feel for the train system, cultural norms, and general geography, you may not need a guide for the main attractions. That said, even repeat visitors often book a guide for specific interests — a deep-dive into a neighborhood they haven't explored, or a day trip they're unfamiliar with. But for revisiting your favorite spots? You've got this.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Independent Explorers Who Love Getting Lost
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Some of the best travel experiences come from wandering without a plan — discovering a tiny ramen shop in a back alley, stumbling into a local festival, or getting lost in a neighborhood you've never heard of. If this is your travel style, a structured guided tour might feel constraining. Tokyo is incredibly safe for wandering, even at night, and the serendipity of unplanned discovery is genuinely one of the joys of visiting Japan.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Budget-Conscious Backpackers
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you're on a tight budget, a private guide is a significant expense. Tokyo has excellent free resources: the Tourist Information Centers provide detailed English maps and advice, temple and shrine visits are often free, and the city's public spaces are endlessly interesting. YouTube, blogs, and apps like Japan Travel can fill in cultural context. It won't be the same as a live guide, but it's a solid alternative if budget is the primary concern.
+            </p>
+
+            {/* What a Licensed Guide Provides */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              What a Licensed Guide Provides That Google Can't
+            </h2>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Reading the Room
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              A good guide pays attention to your energy, your reactions, and your questions. If I notice you're fascinated by the architecture, I'll spend more time pointing out details and taking you to lesser-known buildings. If I see you're getting tired, I'll suggest a cafe break at a place I know you'll love. If it starts raining, I have three backup plans that are equally good.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              This real-time adaptation is something no app, audioguide, or pre-planned itinerary can offer. It's the human element that transforms a tour from "information delivery" to "shared experience."
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              The "Why" Behind What You See
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Japan's culture has layers that aren't immediately visible. Why are there two different types of rope at shrines? Why do some restaurants not accept reservations? Why is that seemingly ordinary building actually a national treasure? A guide provides the cultural operating system that makes everything click.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              You can Google individual facts, but a guide weaves them into a narrative that builds throughout the day. By the end of a tour, you don't just know more facts about Japan — you understand the underlying logic of how Japanese culture works, which enriches the rest of your trip even after the tour ends.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Hidden Spots and Local Connections
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Every guide has places that don't appear on tourist maps — the tiny temple garden that's always empty, the side street with the best taiyaki in the city, the viewpoint that gives you a perfect photo composition. These aren't secrets exactly, but they're the kind of local knowledge that takes years of walking the same streets to develop.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              I also have relationships with local shopkeepers, restaurant owners, and temple priests. These connections sometimes open doors that would otherwise be closed — a quick chat in Japanese can get you into a workshop demonstration, a tasting, or a story you'd never hear otherwise.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              What the National License Means
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The National Government Licensed Guide Interpreter (全国通訳案内士) is Japan's only nationally recognized professional guide certification. It requires passing extensive exams covering Japanese history, geography, culture, politics, and English proficiency. Only about 20% of test-takers pass.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              This means your guide has verified deep knowledge — not just memorized scripts, but genuine understanding of Japanese culture and history that allows them to answer unexpected questions and provide context that goes beyond the standard tourist narrative. You can ask about anything, and you'll get a thoughtful, informed answer.
+            </p>
+
+            {/* How Much Does It Cost */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              How Much Does a Private Guide Cost in Tokyo?
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Private walking tours in Tokyo typically range from ¥25,000 to ¥40,000 per group for a half-day experience (2.5 to 4 hours). This is a per-group price, not per-person, so the value increases significantly with larger groups. For a family of four, it works out to about ¥7,500-10,000 per person.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Day trips to{" "}
+              <Link to="/tours/kamakura-day-trip" className="text-accent hover:underline">
+                Kamakura
+              </Link>
+              ,{" "}
+              <Link to="/tours/hakone-day-trip" className="text-accent hover:underline">
+                Hakone
+              </Link>
+              , and{" "}
+              <Link to="/tours/nikko-day-trip" className="text-accent hover:underline">
+                Nikko
+              </Link>{" "}
+              range from ¥50,000 to ¥60,000 for a full day (7-10 hours). These include guide service, itinerary planning, and full transport navigation — essentially, you get a personal concierge for the entire day.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              For the most flexible option, our{" "}
+              <Link to="/tours/custom" className="text-accent hover:underline">
+                Custom Tour
+              </Link>{" "}
+              starts from ¥10,000 per hour, letting you design exactly the experience you want. Check our{" "}
+              <Link to="/tours" className="text-accent hover:underline">
+                tour pages
+              </Link>{" "}
+              for specific pricing on each experience.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              When considering the cost, think about what you're getting: a full day of personalized attention from a certified professional who speaks your language, knows the culture deeply, handles all logistics, and adapts the experience to your exact interests. Compare that to the hours you'd spend planning, navigating, and potentially missing hidden gems.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              The travelers who get the most value are those who treat the guide fee not as an expense, but as an investment in the quality of their experience. Time is the most valuable thing you have on vacation — a guide helps you make the most of every hour.
+            </p>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="font-serif text-2xl font-medium text-foreground mb-4">
+                Still not sure? Let's talk.
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                I'm happy to help you decide if a guided tour is right for your trip. Tell me about your travel plans and I'll give you an honest recommendation — even if that recommendation is "you'll be fine on your own."
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/contact" className="btn-accent">
+                  Contact Us
+                </Link>
+                <Link to="/tours" className="btn-outline">
+                  Browse Tour Options
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Is It Worth Hiring a Private Tour Guide in Tokyo?",
+            "description": "Wondering if a private tour guide in Tokyo is worth the cost? A licensed guide explains when it makes sense, what you get, and who benefits most.",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+            },
+            "datePublished": "2026-02-25",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default IsItWorthHiringGuide;

--- a/src/pages/blog/Tokyo3DayItinerary.tsx
+++ b/src/pages/blog/Tokyo3DayItinerary.tsx
@@ -1,0 +1,339 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const Tokyo3DayItinerary = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Tokyo 3-Day Itinerary | A Local Guide's Recommendations | Tanuki Tabi Travel"
+        description="Plan the perfect 3 days in Tokyo with insider tips from a licensed local guide. Covers Asakusa, Shibuya, Tsukiji, day trips, and hidden gems most tourists miss."
+        canonicalPath="/blog/tokyo-3-day-itinerary"
+      />
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Itineraries</p>
+            <h1 className="heading-display text-foreground">
+              The Perfect 3-Day Tokyo Itinerary — From a Local Guide
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                February 25, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-8">
+              After guiding over 500 tours in Tokyo, I've seen what works and what doesn't for first-time visitors. Some travelers try to cram everything into a single day and end up exhausted. Others miss hidden gems because they stick to the most obvious attractions. This 3-day itinerary balances must-see highlights with local experiences most tourists miss. Feel free to mix and match — every traveler is different, and the best itinerary is the one that excites you.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              I've organized the three days geographically to minimize transit time and maximize exploration. Each day covers a different side of Tokyo — traditional east, modern west, and then your choice of central Tokyo or a day trip. Here's what I recommend based on years of walking these streets with travelers from around the world.
+            </p>
+
+            {/* Day 1 */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Day 1: East Tokyo — History & Tradition
+            </h2>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Morning: Asakusa — Where Old Tokyo Lives
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Start your Tokyo journey where the city itself began — Asakusa. This neighborhood is home to Senso-ji, Tokyo's oldest temple, founded in the 7th century. Walk through the iconic Kaminarimon (Thunder Gate) and down Nakamise-dori, a shopping street that has been serving visitors for centuries.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Local tip:</strong> Arrive before 9 AM to experience Senso-ji without the crowds. The morning light through the incense smoke creates a magical atmosphere that you simply cannot get later in the day. The temple grounds are open 24 hours, but the Nakamise shops open around 10 AM — so you get the best of both worlds if you time it right.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Don't just walk the main street — venture into the side alleys where you'll find traditional craft shops, small temples, and local eateries that have been in the same family for generations. The area around Dempoin Temple Garden is particularly beautiful and often overlooked by tourists rushing to Senso-ji.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you want a deeper exploration of Asakusa with cultural context and hidden spots, our{" "}
+              <Link to="/tours/asakusa" className="text-accent hover:underline">
+                Asakusa Walking Tour
+              </Link>{" "}
+              covers everything from temple rituals to the best street food stalls.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Late Morning: Walk to Tokyo Skytree via Sumida Park
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              From Asakusa, take a scenic walk along the Sumida River toward Tokyo Skytree. The riverside promenade is one of Tokyo's most photogenic walks, with the traditional temple pagoda on one side and the futuristic Skytree tower on the other. In spring (late March to early April), this area is lined with cherry blossoms — it's one of the best viewing spots in the city.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              You don't need to go up the Skytree (long queues and expensive), but the views from the base and the surrounding Solamachi shopping complex are worth the 15-minute walk. The complex also has some excellent food options if you're getting hungry.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Lunch: Local Flavors Near Asakusa
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              For lunch, I recommend trying one of Asakusa's traditional soba (buckwheat noodle) restaurants or a tempura spot. Asakusa has been famous for tempura since the Edo period, and there are still family-run restaurants here that have been perfecting their craft for over a century. If you're adventurous, try monjayaki — Tokyo's version of the Osaka okonomiyaki pancake, messier but delicious.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Afternoon: Yanaka — Tokyo's Nostalgic Old Town
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Take the train to Nippori Station (about 15 minutes) and step into Yanaka — one of the few Tokyo neighborhoods that survived both the 1923 earthquake and the WWII bombings. This is Tokyo as it used to be: narrow lanes, wooden houses, independent shops, and cats lounging on temple walls.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Walk down the Yanaka Ginza shopping street, where local vendors sell handmade goods, traditional snacks, and craft beer. Visit Tennoji Temple, wander through the atmospheric Yanaka Cemetery, and if the timing is right, watch the sunset from the famous Yuyake Dandan steps — it's truly a special moment.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Yanaka is a neighborhood that rewards slow exploration, and it's a place where most tourists never go. For the full experience, our{" "}
+              <Link to="/tours/yanaka" className="text-accent hover:underline">
+                Yanaka Walking Tour
+              </Link>{" "}
+              uncovers stories and spots you won't find in any guidebook.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Evening: Ueno Area — Ameyoko Market
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              End your first day at Ameyoko, the lively market street near Ueno Station. Originally a post-war black market, it's now a bustling strip of food stalls, seafood vendors, and discount shops. Great for street food — try the fresh seafood bowls, grilled meats on sticks, or chocolate-covered strawberries. The energy here is infectious and it's a perfect way to end your first day.
+            </p>
+
+            {/* Day 2 */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              Day 2: West Tokyo — Modern Culture & Energy
+            </h2>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Morning: Meiji Shrine — Peace in the City
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Start your second day at Meiji Shrine (Meiji Jingu), dedicated to Emperor Meiji and Empress Shoken. Arrive early (the shrine opens at sunrise) for the most peaceful experience. Walk through the towering torii gate and the 170-acre forest — it's hard to believe you're in the middle of Tokyo's busiest area. The forest was entirely planted by volunteers in the 1920s, with trees donated from every prefecture in Japan.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Watch for wedding ceremonies if you visit on weekends — you might catch a traditional Shinto wedding procession. The shrine also has a beautiful iris garden (best in June) and a sake barrel display that tells the story of Japan's relationship with wine and spirits.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Late Morning: Harajuku — Youth Culture Explosion
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              From Meiji Shrine's southern exit, you'll emerge directly onto Harajuku's famous Takeshita Street — one of the most dramatic transitions in Tokyo. In seconds, you go from a 100-year-old shrine forest to a neon-lit street packed with crepe shops, vintage clothing stores, and Japanese pop culture.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Walk Takeshita Street for the sensory overload, then head to Omotesando — often called "Tokyo's Champs-Élysées" — for world-class architecture by Tadao Ando, Kengo Kuma, and Toyo Ito. The contrast between Harajuku's kawaii culture and Omotesando's sleek sophistication tells you everything about Tokyo's ability to contain multitudes.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Our{" "}
+              <Link to="/tours/shibuya-harajuku" className="text-accent hover:underline">
+                Shibuya & Harajuku Tour
+              </Link>{" "}
+              covers this area in depth — from hidden vintage shops to the stories behind Omotesando's architectural masterpieces.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Lunch: Shibuya Area
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Head to Shibuya for lunch. Skip the chain restaurants and look for local spots in the back streets. I recommend trying a proper ramen shop (the wait is worth it) or a Japanese curry restaurant — Shibuya has some of the best in the city. If you want something quick and quintessentially Japanese, try a gyudon (beef bowl) at a counter restaurant — fast, filling, and delicious.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Afternoon: Shibuya Crossing & Beyond
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              No Tokyo visit is complete without experiencing Shibuya Crossing — the world's busiest pedestrian intersection, where up to 3,000 people cross at once. Cross it yourself, then head to the Shibuya Sky observation deck or the Starbucks above the crossing for the best overhead views. Visit the Hachiko statue (the famous loyal dog) and explore Center-gai for a taste of Tokyo's vibrant street culture.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you have energy left, walk through the quieter neighborhoods behind the main streets. Tomigaya and Kamiyamacho are local favorites with excellent cafes, independent bookshops, and small restaurants that most tourists never discover.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Evening: Shinjuku Nightlife
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              End day two in Shinjuku, Tokyo's entertainment capital. For drinks, head to Golden Gai — a tiny network of over 200 small bars, each seating about 6-8 people. It's intimate, quirky, and a completely unique experience. Look for bars with English menus or "Foreigner Welcome" signs if you're nervous about the language barrier.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              For dinner, try Omoide Yokocho ("Memory Lane") — a narrow alley of yakitori (grilled chicken) stalls that has been serving workers since the 1940s. It's smoky, crowded, and absolutely authentic. Vegetarians should note that options are limited here, but nearby Shinjuku has restaurants for every dietary need.
+            </p>
+
+            {/* Day 3 */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              Day 3: Choose Your Adventure
+            </h2>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Option A: Central Tokyo — Food, Gardens & History
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Morning — Tsukiji Outer Market:</strong> Even though the inner wholesale market moved to Toyosu, Tsukiji Outer Market is still the best food destination in Tokyo. Arrive by 8-9 AM for the freshest offerings: sushi for breakfast (yes, it's a thing), tamagoyaki (Japanese omelet), fresh oysters, and wagyu beef skewers. Take your time and graze — it's the best way to experience the market.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              For a guided food exploration, our{" "}
+              <Link to="/tours/tsukiji-ginza" className="text-accent hover:underline">
+                Tsukiji & Ginza Tour
+              </Link>{" "}
+              will help you navigate the best stalls and explain what you're eating.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Afternoon — Imperial Palace East Gardens:</strong> A peaceful contrast to the morning's market energy. These free-entry gardens were once the innermost circle of Edo Castle, the seat of Tokugawa shogunate power for over 250 years. The stone walls, moats, and garden design tell the story of samurai-era Japan. Walk through to the Marunouchi business district to see Tokyo's modern skyline framed by ancient castle walls.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Explore the area in depth with our{" "}
+              <Link to="/tours/imperial-palace" className="text-accent hover:underline">
+                Imperial Palace Tour
+              </Link>
+              .
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Evening — Ginza:</strong> End your Tokyo stay in Ginza, the upscale shopping district. Even if you're not shopping, the department store food halls (depachika) in the basement floors are worth visiting — they're culinary wonderlands of beautifully packaged Japanese sweets, bento boxes, and gourmet treats. Perfect for picking up edible souvenirs.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Option B: Day Trip from Tokyo
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you've covered central Tokyo and want to see more of Japan, a day trip is an excellent use of your third day. Each destination offers something completely different from Tokyo:
+            </p>
+            <ul className="space-y-4 mb-8">
+              <li className="text-muted-foreground leading-relaxed">
+                <Link to="/tours/kamakura-day-trip" className="text-accent hover:underline font-medium">
+                  Kamakura
+                </Link>{" "}
+                — Ancient temples, the Great Buddha, and coastal charm. Just 1 hour from Tokyo by train. The most well-rounded day trip for first-timers. Best in June for hydrangeas or November for autumn leaves.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <Link to="/tours/hakone-day-trip" className="text-accent hover:underline font-medium">
+                  Hakone
+                </Link>{" "}
+                — Mt. Fuji views, hot springs, and a volcanic valley. Perfect for nature lovers and photographers. The transport system is complex, so a guide really helps here. Best October-February for Fuji visibility.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <Link to="/tours/nikko-day-trip" className="text-accent hover:underline font-medium">
+                  Nikko
+                </Link>{" "}
+                — UNESCO World Heritage Toshogu Shrine, dramatic waterfalls, and mountain lake scenery. Further from Tokyo (2 hours) but less crowded and deeply rewarding for history enthusiasts. October-November is spectacular for autumn foliage.
+              </li>
+            </ul>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Can't decide? Read our detailed comparison:{" "}
+              <Link to="/blog/kamakura-vs-hakone-vs-nikko-day-trip" className="text-accent hover:underline">
+                Kamakura vs Hakone vs Nikko — Which Day Trip Should You Choose?
+              </Link>
+            </p>
+
+            {/* Practical Tips */}
+            <h2 className="heading-section text-foreground mt-16 mb-6">
+              Practical Tips for Your Tokyo Visit
+            </h2>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Getting Around
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Get a Suica or Pasmo IC card at any station — it works on all trains, subways, and buses in Tokyo. Just tap and go. You can also use it at convenience stores and vending machines. The Tokyo Metro and JR lines cover virtually everywhere you'll want to go, and Google Maps works perfectly for navigation in Japan.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Don't be intimidated by the train system — it's actually very intuitive once you understand that different companies operate different lines. Signs are in English, stations are announced in English, and trains are almost always on time. During rush hour (7:30-9 AM), avoid the busiest lines if possible, or travel in the opposite direction of commuter flow.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              When to Visit
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tokyo is a year-round destination. Spring (March-May) brings cherry blossoms and pleasant weather. Summer (June-August) is hot and humid but offers festivals and fireworks. Autumn (October-November) has stunning foliage and comfortable temperatures. Winter (December-February) is cold but clear, with fewer tourists and beautiful illuminations.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Peak tourist seasons are cherry blossom season (late March to mid-April) and autumn foliage (mid-November to early December). Book accommodations and tours early during these periods. Golden Week (late April to early May) is a Japanese national holiday — domestic travel peaks and some businesses close.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Money Matters
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Japan is still more cash-dependent than many countries, especially at small restaurants, temples, and markets. Carry at least ¥10,000-20,000 in cash. 7-Eleven and Post Office ATMs accept international cards reliably. Credit cards are increasingly accepted at larger establishments, but don't rely on them exclusively. Your IC card (Suica/Pasmo) is the most convenient payment method for small purchases.
+            </p>
+
+            <h3 className="font-serif text-xl font-medium text-foreground mt-8 mb-4">
+              Temple & Shrine Etiquette
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              At shrines: bow slightly before passing through the torii gate, walk on the sides (the center path is for the deity), purify your hands at the water basin, and bow-clap-bow when praying. At temples: remove shoes when entering buildings, don't point at statues, and speak quietly. Your guide will explain all customs in detail, but these basics will help you feel confident.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              The most important thing is simply to be respectful and observant. Japanese people are incredibly welcoming to tourists who show an interest in their culture, even if you don't get every custom perfectly right.
+            </p>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="font-serif text-2xl font-medium text-foreground mb-4">
+                Want a local guide to bring this itinerary to life?
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                I'd love to help you experience the best of Tokyo. Whether you want to follow this itinerary or create something completely custom, let's make your trip unforgettable.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/tours" className="btn-accent">
+                  Browse Our Tokyo Tours
+                </Link>
+                <Link to="/tours/custom" className="btn-outline">
+                  Design a Custom Tour
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "The Perfect 3-Day Tokyo Itinerary — From a Local Guide",
+            "description": "Plan the perfect 3 days in Tokyo with insider tips from a licensed local guide.",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+            },
+            "datePublished": "2026-02-25",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/tokyo-3-day-itinerary",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default Tokyo3DayItinerary;


### PR DESCRIPTION
## Summary
This PR expands the tour offerings to include day trips (Kamakura, Hakone, Nikko) and adds a blog section with three initial articles. It also updates navigation and FAQ to reflect the new content structure.

## Key Changes

### New Tour Pages
- Added three new day trip tour detail pages in `TourDetail.tsx`:
  - Kamakura Day Trip (¥50,000, 7-8 hours)
  - Hakone Day Trip (¥55,000, 8-10 hours)
  - Nikko Day Trip (¥60,000, 9-10 hours)
- Each includes full itineraries, highlights, practical info, and SEO metadata

### New Blog Section
- Created `BlogIndex.tsx` as the main blog landing page
- Added three blog articles:
  - `Tokyo3DayItinerary.tsx` - 3-day itinerary guide with neighborhood breakdowns
  - `DayTripComparison.tsx` - Comparison table and detailed analysis of Kamakura vs Hakone vs Nikko
  - `IsItWorthHiringGuide.tsx` - Guide value proposition and use cases
- All blog posts include proper SEO metadata and author/date information

### Navigation Updates
- Enhanced `Header.tsx` with dropdown menu for Tours section
  - Separated Tokyo walking tours from day trips
  - Added quick access to custom tour option
  - Implemented click-outside detection for dropdown closure
  - Added Blog link to main navigation
- Updated `Footer.tsx` to reflect new tour categories and include blog links

### Content Updates
- Reorganized `Tours.tsx` to separate `tokyoTours` and `dayTrips` arrays
- Updated `Index.tsx` homepage to showcase day trip options
- Expanded `FAQ.tsx` with categorized questions covering booking, tour details, practical info, and day trips
- Updated `About.tsx` by removing "Featured On" platforms section

### SEO & Metadata
- Added tour SEO data for all three day trips in `TourDetail.tsx`
- Updated `sitemap.xml` with new tour pages and blog routes
- All new pages include proper canonical paths and meta descriptions

## Implementation Details
- Maintained consistent styling with existing prose-custom and heading classes
- Day trip tours follow same data structure as existing Tokyo tours for consistency
- Blog articles use serif typography and custom prose styling for readability
- Navigation dropdown includes keyboard/click handling for accessibility
- All new routes properly integrated into App.tsx routing

https://claude.ai/code/session_018PXhjyqska4gLTK2ugisMq