### PR TITLE
Add URL redirects for routes→tours migration and booking page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,45 @@
   command = "npm run build"
   publish = "dist"
 
+# 301 redirects: old /routes/ URLs → new /tours/ URLs
+[[redirects]]
+  from = "/routes/ginza-the-luxury-shopping-district"
+  to = "/tours/tsukiji-ginza"
+  status = 301
+
+[[redirects]]
+  from = "/routes/asakusa-senso-ji-temple"
+  to = "/tours/asakusa"
+  status = 301
+
+[[redirects]]
+  from = "/routes/yanaka-old-town"
+  to = "/tours/yanaka"
+  status = 301
+
+[[redirects]]
+  from = "/routes/shibuya-harajuku"
+  to = "/tours/shibuya-harajuku"
+  status = 301
+
+[[redirects]]
+  from = "/routes/imperial-palace"
+  to = "/tours/imperial-palace"
+  status = 301
+
+# Catch-all: any other old /routes/ URL → /tours listing page
+[[redirects]]
+  from = "/routes/*"
+  to = "/tours"
+  status = 301
+
+# /booking → /contact redirect (no booking page exists)
+[[redirects]]
+  from = "/booking"
+  to = "/contact"
+  status = 301
+
+# SPA catch-all (must be last)
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
## Summary
Added comprehensive URL redirect rules to Netlify configuration to handle the migration from `/routes/` URLs to `/tours/` URLs and redirect the deprecated `/booking` page to `/contact`.

## Key Changes
- **Routes migration redirects**: Added 301 redirects for 5 specific tour routes from old `/routes/` paths to new `/tours/` paths:
  - `/routes/ginza-the-luxury-shopping-district` → `/tours/tsukiji-ginza`
  - `/routes/asakusa-senso-ji-temple` → `/tours/asakusa`
  - `/routes/yanaka-old-town` → `/tours/yanaka`
  - `/routes/shibuya-harajuku` → `/tours/shibuya-harajuku`
  - `/routes/imperial-palace` → `/tours/imperial-palace`

- **Catch-all routes redirect**: Added a wildcard redirect to send any other `/routes/*` URLs to the `/tours` listing page

- **Booking page redirect**: Added redirect from `/booking` to `/contact` since no booking page exists

- **Redirect ordering**: Ensured the SPA catch-all redirect remains last to avoid interfering with specific redirects

## Implementation Details
All redirects use HTTP 301 (permanent) status codes to properly signal to search engines and browsers that these are permanent URL changes, which helps preserve SEO value during the migration.

https://claude.ai/code/session_01RgAqepm2p38K62KbATDfcL