### PR TITLE
Phase 4: Add 8 new pages, SEO enhancements, and navigation updates

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -98,6 +98,28 @@
     <priority>0.7</priority>
   </url>
 
+  <!-- Experience Tours -->
+  <url>
+    <loc>https://tanuki-tabi-travel.com/tours/tokyo-food-tour</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/tours/tokyo-night-tour</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <!-- Booking (redirects to /contact) -->
+  <url>
+    <loc>https://tanuki-tabi-travel.com/booking</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
   <!-- Blog -->
   <url>
     <loc>https://tanuki-tabi-travel.com/blog</loc>
@@ -119,6 +141,42 @@
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/asakusa-guide-what-to-see</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/shinjuku-guide</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/tsukiji-guide-food-lover</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/best-time-to-visit-tokyo</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette</loc>
     <lastmod>2026-02-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Tours from "./pages/Tours";
 import TourDetail from "./pages/TourDetail";
+import TokyoFoodTour from "./pages/tours/TokyoFoodTour";
+import TokyoNightTour from "./pages/tours/TokyoNightTour";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
 import FAQ from "./pages/FAQ";
@@ -13,6 +15,12 @@ import BlogIndex from "./pages/blog/BlogIndex";
 import Tokyo3DayItinerary from "./pages/blog/Tokyo3DayItinerary";
 import IsItWorthHiringGuide from "./pages/blog/IsItWorthHiringGuide";
 import DayTripComparison from "./pages/blog/DayTripComparison";
+import AsakusaGuide from "./pages/blog/AsakusaGuide";
+import ShibuyaHarajukuGuide from "./pages/blog/ShibuyaHarajukuGuide";
+import ShinjukuGuide from "./pages/blog/ShinjukuGuide";
+import TsukijiGuide from "./pages/blog/TsukijiGuide";
+import BestTimeToVisit from "./pages/blog/BestTimeToVisit";
+import TempleEtiquette from "./pages/blog/TempleEtiquette";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -26,6 +34,8 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/tours" element={<Tours />} />
+          <Route path="/tours/tokyo-food-tour" element={<TokyoFoodTour />} />
+          <Route path="/tours/tokyo-night-tour" element={<TokyoNightTour />} />
           <Route path="/tours/:id" element={<TourDetail />} />
           <Route path="/about" element={<About />} />
           <Route path="/contact" element={<Contact />} />
@@ -34,6 +44,12 @@ const App = () => (
           <Route path="/blog/tokyo-3-day-itinerary" element={<Tokyo3DayItinerary />} />
           <Route path="/blog/is-it-worth-hiring-a-tour-guide-in-tokyo" element={<IsItWorthHiringGuide />} />
           <Route path="/blog/kamakura-vs-hakone-vs-nikko-day-trip" element={<DayTripComparison />} />
+          <Route path="/blog/asakusa-guide-what-to-see" element={<AsakusaGuide />} />
+          <Route path="/blog/shibuya-harajuku-guide" element={<ShibuyaHarajukuGuide />} />
+          <Route path="/blog/shinjuku-guide" element={<ShinjukuGuide />} />
+          <Route path="/blog/tsukiji-guide-food-lover" element={<TsukijiGuide />} />
+          <Route path="/blog/best-time-to-visit-tokyo" element={<BestTimeToVisit />} />
+          <Route path="/blog/japan-temple-shrine-etiquette" element={<TempleEtiquette />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -65,6 +65,16 @@ export const Footer = () => {
                 </Link>
               </li>
               <li>
+                <Link to="/tours/tokyo-food-tour" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Tokyo Food Tour
+                </Link>
+              </li>
+              <li>
+                <Link to="/tours/tokyo-night-tour" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Tokyo Night Tour
+                </Link>
+              </li>
+              <li>
                 <Link to="/tours/custom" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
                   Custom Tour
                 </Link>
@@ -98,6 +108,36 @@ export const Footer = () => {
               <li>
                 <Link to="/blog/tokyo-3-day-itinerary" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
                   Tokyo 3-Day Itinerary
+                </Link>
+              </li>
+              <li>
+                <Link to="/blog/asakusa-guide-what-to-see" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Asakusa Guide
+                </Link>
+              </li>
+              <li>
+                <Link to="/blog/shibuya-harajuku-guide" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Shibuya & Harajuku Guide
+                </Link>
+              </li>
+              <li>
+                <Link to="/blog/shinjuku-guide" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Shinjuku Guide
+                </Link>
+              </li>
+              <li>
+                <Link to="/blog/tsukiji-guide-food-lover" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Tsukiji Guide
+                </Link>
+              </li>
+              <li>
+                <Link to="/blog/best-time-to-visit-tokyo" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Best Time to Visit
+                </Link>
+              </li>
+              <li>
+                <Link to="/blog/japan-temple-shrine-etiquette" className="text-primary-foreground/70 hover:text-primary-foreground transition-colors">
+                  Temple & Shrine Etiquette
                 </Link>
               </li>
               <li>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,6 +10,11 @@ const tokyoTours = [
   { name: "Imperial Palace", href: "/tours/imperial-palace" },
 ];
 
+const experienceTours = [
+  { name: "Tokyo Food Tour", href: "/tours/tokyo-food-tour" },
+  { name: "Tokyo Night Tour", href: "/tours/tokyo-night-tour" },
+];
+
 const dayTrips = [
   { name: "Kamakura Day Trip", href: "/tours/kamakura-day-trip" },
   { name: "Hakone Day Trip", href: "/tours/hakone-day-trip" },
@@ -90,6 +95,19 @@ export const Header = () => {
                     Tokyo Walking Tours
                   </p>
                   {tokyoTours.map((tour) => (
+                    <Link
+                      key={tour.href}
+                      to={tour.href}
+                      className="block px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
+                    >
+                      {tour.name}
+                    </Link>
+                  ))}
+                  <div className="border-t border-border my-1" />
+                  <p className="px-4 py-1 text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                    Experience Tours
+                  </p>
+                  {experienceTours.map((tour) => (
                     <Link
                       key={tour.href}
                       to={tour.href}
@@ -221,6 +239,19 @@ export const Header = () => {
                     Tokyo
                   </p>
                   {tokyoTours.map((tour) => (
+                    <Link
+                      key={tour.href}
+                      to={tour.href}
+                      className="block py-1.5 text-sm text-muted-foreground"
+                      onClick={() => setMobileMenuOpen(false)}
+                    >
+                      {tour.name}
+                    </Link>
+                  ))}
+                  <p className="py-1 text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                    Experience Tours
+                  </p>
+                  {experienceTours.map((tour) => (
                     <Link
                       key={tour.href}
                       to={tour.href}

--- a/src/pages/Tours.tsx
+++ b/src/pages/Tours.tsx
@@ -65,6 +65,27 @@ const tokyoTours = [
   },
 ];
 
+const experienceTours = [
+  {
+    id: "tokyo-food-tour",
+    title: "Tokyo Food Tour",
+    description: "Taste Tokyo's best food with a local licensed guide. From Tsukiji street food to hidden ramen shops, customize your private food tour experience.",
+    duration: "3-7 hours",
+    price: "Contact for quote",
+    difficulty: "Easy",
+    image: tsukijiMarket,
+  },
+  {
+    id: "tokyo-night-tour",
+    title: "Tokyo Night Tour",
+    description: "Experience Tokyo after dark with a local guide. Explore neon-lit streets, hidden bars, izakayas, and nightlife spots safely with a licensed private guide.",
+    duration: "3-4 hours",
+    price: "Contact for quote",
+    difficulty: "Easy",
+    image: shibuyaCrossing,
+  },
+];
+
 const dayTrips = [
   {
     id: "kamakura-day-trip",
@@ -129,8 +150,26 @@ const Tours = () => {
         </div>
       </section>
 
-      {/* Day Trips from Tokyo */}
+      {/* Experience Tours */}
       <section className="py-16 bg-secondary/30">
+        <div className="container-section">
+          <div className="mb-8">
+            <p className="text-label text-accent mb-3">Experience Tours</p>
+            <h2 className="heading-section text-foreground">Experience Tours</h2>
+            <p className="mt-4 text-body max-w-2xl">
+              Dive deep into Tokyo's food scene or explore the city after dark with a private guide who knows the best local spots.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {experienceTours.map((tour) => (
+              <TourCard key={tour.id} {...tour} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Day Trips from Tokyo */}
+      <section className="py-16">
         <div className="container-section">
           <div className="mb-8">
             <p className="text-label text-accent mb-3">Day Trips</p>

--- a/src/pages/blog/AsakusaGuide.tsx
+++ b/src/pages/blog/AsakusaGuide.tsx
@@ -1,0 +1,261 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const AsakusaGuide = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Asakusa Guide: What to See Beyond Senso-ji | Local Tips | Tanuki Tabi Travel"
+        description="A local guide's insider tips for exploring Asakusa. Go beyond Senso-ji Temple to discover hidden shrines, street food spots, and the best times to visit."
+        canonicalPath="/blog/asakusa-guide-what-to-see"
+      />
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Tokyo Area Guides</p>
+            <h1 className="heading-display text-foreground">
+              Asakusa Guide — What to See Beyond Senso-ji Temple
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                February 25, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-8">
+              Asakusa is Tokyo's most traditional neighborhood — and one of its most crowded. Every year, roughly 30 million visitors pass through Senso-ji Temple, making it one of the most visited religious sites in the entire world. Most of those visitors follow the exact same route: Kaminarimon Gate, Nakamise-dori shopping street, a quick photo at the main hall, and then they leave. They miss about 90% of what makes Asakusa truly special.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              After leading over 500 tours through this neighborhood, I know the spots that tourists walk right past, the timing tricks that make the difference between a stressful crowd-fight and a peaceful cultural experience, and the street food stalls where locals actually eat. This guide goes well beyond the basics you will find in any travel blog. Whether you are visiting Asakusa for the first time or coming back for a deeper look, these tips will help you experience the neighborhood the way it deserves to be experienced — slowly, curiously, and with a sense of discovery.
+            </p>
+
+            {/* Senso-ji Temple */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Senso-ji Temple: Tips Most Guides Won't Tell You
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Let's start with the main attraction, because you are going to visit Senso-ji no matter what — and you should. It is Tokyo's oldest temple, founded in 645 AD according to legend, and the history here is genuinely remarkable. The key is knowing how to visit it properly so you actually enjoy the experience rather than just surviving the crowds.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Timing Is Everything
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">The best time to visit Senso-ji is before 8 AM or after 5 PM.</strong> The temple grounds are open 24 hours a day, 365 days a year. The main hall has limited hours (generally 6 AM to 5 PM, with seasonal variations), but the grounds, the five-story pagoda, and the atmospheric incense cauldron are accessible at any time. Early morning is my personal favorite — the light is soft, the incense smoke drifts through quiet air, and you can actually hear the monks chanting. It feels like stepping back in time. Evening visits are equally magical, with the Kaminarimon gate and pagoda illuminated against the dark sky. The lanterns glow red, and the whole complex takes on a completely different character.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you must visit during peak hours (10 AM to 4 PM), weekdays are significantly less crowded than weekends. Avoid national holidays and the first three days of January (Hatsumode, the New Year temple visit) unless you specifically want to experience the festival atmosphere — in which case, embrace the crowds and enjoy the energy.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              The Hidden Side Entrance
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Here is something most visitors never discover: you do not have to enter through Kaminarimon and fight your way down Nakamise-dori. There are side entrances to the temple grounds from both the east and the west. My favorite approach is from the west side, walking through the quieter residential streets. You enter through Nitenmon Gate, a beautiful but largely ignored entrance that puts you right next to the five-story pagoda and the main hall without ever touching the crowded shopping street. You can always walk Nakamise-dori afterward — just approach it from the temple end, walking south, which goes against the main tourist flow and gives you a completely different perspective.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Understanding the Fortune Slips
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The omikuji (fortune slips) at Senso-ji are famous for giving out a disproportionately high number of "bad luck" fortunes — roughly 30% of the fortunes here are kyo (bad luck), compared to about 7% at most other temples. This is actually historically authentic and has not been adjusted for tourists. If you draw a bad fortune, don't worry — the tradition is to tie it to the metal rack near the fortune box, which symbolically leaves the bad luck behind at the temple. If you draw a good fortune, keep it in your wallet. The fortunes are written in classical Japanese with English translations, and they cover everything from health and business to travel and relationships.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Temple vs. Shrine — They're Both Here
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              One detail that confuses many visitors: Senso-ji is a Buddhist temple, but right next to it — literally sharing the same grounds — is Asakusa Shrine, which is a Shinto shrine. This coexistence of Buddhism and Shinto in the same complex is very common in Japan and reflects centuries of religious syncretism. The rituals are different at each: at the shrine, you bow twice, clap twice, then bow once. At the temple, you simply bow with your hands pressed together in prayer. Knowing the difference adds a layer of understanding that transforms a quick photo stop into a genuine cultural experience.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              For a guided experience that covers all of these details and more, our{" "}
+              <Link to="/tours/asakusa" className="text-accent hover:underline">
+                Asakusa Walking Tour
+              </Link>{" "}
+              takes you through the temple complex with full historical context and into the hidden corners most visitors never find.
+            </p>
+
+            {/* Hidden Gems */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Hidden Gems Around Asakusa
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Senso-ji is the anchor of Asakusa, but the neighborhood surrounding it is rich with spots that most tourists walk right past. These are the places that make Asakusa feel like a living, breathing neighborhood rather than just a tourist attraction.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Asakusa Shrine
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              I mentioned Asakusa Shrine above, but it deserves its own spotlight because roughly 90% of tourists walk right past it without realizing it is there. The shrine sits immediately to the east of Senso-ji's main hall, through a small gate that many people assume leads to a restricted area. It doesn't — walk through and you will find a beautiful Shinto shrine that dates to 1649, built by the third Tokugawa shogun. The architecture is original and designated an Important Cultural Property. It is also the center of the Sanja Matsuri festival in May, one of the largest and most exciting festivals in all of Tokyo. On a typical day, you might be the only visitor here while hundreds of people crowd Senso-ji just meters away.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Denboin Garden
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Denboin Garden is a hidden paradise that most Asakusa visitors never see. This Edo-period garden belongs to the abbot's residence at Senso-ji and features a tranquil pond, carefully shaped trees, a tea house, and views of the five-story pagoda reflected in the water. The catch is that it is only open seasonally — typically in spring (March to May) — and requires a small admission fee. Check current opening dates before you visit, as the schedule changes yearly. When it is open, the contrast between the crowded Nakamise-dori just outside the walls and this serene, almost secret garden is one of the most striking experiences in Tokyo.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Hoppy Street (Hoppy-dori)
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Walk a few minutes west of Senso-ji and you will find Hoppy Street, a lively drinking alley that comes alive in the late afternoon and evening. Named after Hoppy — a low-alcohol, beer-like drink that became popular in post-war Japan when real beer was too expensive — this narrow street is lined with small izakaya (Japanese pubs) that spill their tables and chairs out onto the sidewalk. The atmosphere is relaxed and cheerful, with smoke rising from grills, lanterns swaying in the breeze, and the sound of clinking glasses and laughter. Order a Hoppy set (the drink plus a glass of shochu) and some yakitori or stewed beef tendon. This is where local Asakusa workers come after a long day, and it is a world away from the tourist crowds at the temple. Best visited from around 4 PM onward.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Sumida Park and the River Walk
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The Sumida River runs along the eastern edge of Asakusa, and the park that lines its banks is one of the most pleasant walks in the area. From the park, you get a stunning view that combines traditional and modern Tokyo in a single frame — the ancient Senso-ji pagoda behind you and the futuristic Tokyo Skytree directly ahead. In late March to early April, the cherry trees along the river explode into bloom, and the area becomes one of the best hanami (cherry blossom viewing) spots in the city. Even outside cherry blossom season, the river walk is a peaceful escape from the busy streets, and the newer pedestrian bridge offers elevated views of the water and the skyline. Walk north along the river to discover small neighborhood parks and local fishing spots that feel miles from any tourist trail.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Kappabashi Street — Kitchen Tool Paradise
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              About a 10-minute walk west from Senso-ji lies Kappabashi-dori, also known as Kitchen Town. This 800-meter-long street is lined with over 170 specialty shops selling everything a professional kitchen could need: hand-forged Japanese knives, ceramic tableware, bamboo utensils, lacquerware, restaurant-quality cookware, and the incredibly realistic plastic food samples (shokuhin sampuru) that you see in restaurant display windows across Japan. Even if you're not in the market for kitchen supplies, Kappabashi is fascinating to walk through. The knife shops alone are worth the detour — Japanese kitchen knives are world-famous, and the craftsmen here can help you choose the right blade for your cooking style. Several shops offer knife engraving, making this a truly unique souvenir. Look for the giant chef's head statue on the south end of the street — you can't miss it.
+            </p>
+
+            {/* Best Street Food */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Best Street Food in Asakusa
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Asakusa is one of the best neighborhoods in Tokyo for street food, but you need to know where to look. Nakamise-dori, the main shopping street leading to Senso-ji, has over 90 stalls — but not all of them are worth your money. Here is how to navigate the food scene like a local.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Nakamise-dori: What's Worth It
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The tourist traps on Nakamise tend to be the stalls selling overpriced, mass-produced snacks with flashy signs in multiple languages. Skip those. Instead, look for the stalls with long lines of Japanese customers — that is always the most reliable indicator of quality. The items genuinely worth trying on Nakamise and the surrounding streets include <strong className="text-foreground">ningyo-yaki</strong> — small cakes shaped like Kaminarimon, the seven lucky gods, or other traditional figures, filled with sweet red bean paste and baked fresh right in front of you. They've been made here for over a century and they're best eaten warm.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Kibi-dango</strong> are another Asakusa classic — small, chewy millet dumplings coated in sweet soybean flour (kinako). They're served on a stick with a cup of iced or hot tea, and they cost almost nothing. The tradition of selling kibi-dango here dates back to the Edo period, and one stall on the main approach has been making them the same way for generations. <strong className="text-foreground">Melon-pan</strong> (melon bread) is a Japanese bakery staple, and the versions sold near Senso-ji are particularly good — crispy cookie crust on the outside, soft fluffy bread inside. Some stalls offer them fresh from the oven with a scoop of ice cream stuffed in the middle, which is an indulgent and delicious combination.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Beyond the Main Street
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The best food in Asakusa is not actually on Nakamise-dori — it's on the side streets. For a proper meal, look for the small soba (buckwheat noodle) shops tucked into the alleys behind Senso-ji on the west side. You will recognize them by their simple curtains (noren) hanging in the doorway and the handwritten menus. The soba here is typically handmade daily and served either hot in a dashi broth or cold on a bamboo mat with dipping sauce. Either way, it is a quintessential Asakusa experience.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              For something heartier, seek out the tempura restaurants in the streets south of Kaminarimon. Asakusa has been famous for tempura since the Edo period, and there are still family-run restaurants here where the frying technique has been passed down through multiple generations. Look for the small places with just a counter and a few tables — if the owner is frying behind the counter, you're in the right place. Finally, for an afternoon snack, find the tiny taiyaki (fish-shaped cake) stalls scattered around the neighborhood. The ones with thin, crispy shells and generous fillings of red bean paste or custard cream are the best — you will know them by the line of locals waiting patiently.
+            </p>
+
+            {/* When to Visit */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              When to Visit Asakusa
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Weekday vs. weekend:</strong> If you have flexibility in your schedule, visit Asakusa on a weekday. The difference in crowd levels between a Tuesday morning and a Saturday afternoon is dramatic — we are talking about a fivefold difference in the number of people on Nakamise-dori. Wednesday and Thursday tend to be the quietest days. If you can only visit on a weekend, arrive as early as possible and start with the temple before the shops open at 10 AM.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Seasonal events:</strong> Asakusa hosts some of Tokyo's most spectacular festivals. The <strong className="text-foreground">Sanja Matsuri</strong> in mid-May is the biggest — three days of portable shrine processions, traditional music, and a wildly energetic atmosphere that draws nearly two million people. It is chaotic, loud, and absolutely unforgettable. The <strong className="text-foreground">Sumida River Fireworks Festival</strong> in late July is another highlight, with over 20,000 fireworks lighting up the sky above the river. Locals stake out viewing spots hours in advance, so plan accordingly. In December, the Hagoita-ichi (battledore fair) at Senso-ji is a charming traditional market selling ornate wooden paddles — a great way to experience a quieter, more local festival.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              <strong className="text-foreground">Rainy day strategy:</strong> Don't skip Asakusa just because it's raining. Rainy days mean significantly fewer tourists, and Senso-ji has a beautiful, moody atmosphere in the rain — the wet stone pathways reflect the lanterns, and the incense smoke hangs low in the humid air. Bring an umbrella and enjoy having the place almost to yourself. The covered sections of Nakamise-dori and the surrounding shopping arcades (shotengai) keep you dry while you explore. And if the rain gets heavy, duck into one of the traditional kissaten (old-style coffee shops) in the neighborhood for a slow cup of hand-dripped coffee. There are several around the west side of the temple that have barely changed since the 1960s.
+            </p>
+
+            {/* Combine With */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Combine With
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Asakusa's location in eastern Tokyo makes it a natural starting point or pairing for several other great destinations:
+            </p>
+            <ul className="space-y-4 mb-8">
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Tokyo Skytree</strong> — Just a 10-minute walk across the Sumida River. The observation decks offer panoramic views of the entire city, and the Solamachi shopping complex at its base has excellent restaurants, a planetarium, and an aquarium. Walk there via the river promenade for the best approach.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Yanaka</strong> — About 30 minutes away by train (take the Tsukuba Express to Ueno, then JR to Nippori). Yanaka is one of Tokyo's best-preserved old neighborhoods, with narrow lanes, independent shops, temples, and a famous sunset stairway. It pairs beautifully with Asakusa for a full day of traditional Tokyo. Our{" "}
+                <Link to="/tours/yanaka" className="text-accent hover:underline">
+                  Yanaka Walking Tour
+                </Link>{" "}
+                covers the best of this hidden neighborhood.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Ueno</strong> — Only 10 minutes by train from Asakusa. Ueno Park is home to several world-class museums (Tokyo National Museum, National Museum of Western Art), a zoo, temples, and the lively Ameyoko market street. A morning in Asakusa followed by an afternoon in Ueno makes for an excellent full-day itinerary through Tokyo's historic eastern side.
+              </li>
+            </ul>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="text-2xl font-medium text-foreground mb-4">
+                Want a local to show you the Asakusa most tourists never see?
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                Check out our Asakusa Walking Tour. I'll take you through the hidden shrines, the best street food stalls, and the quiet corners of this incredible neighborhood — with all the history and cultural context that brings it to life. Or get in touch to design a custom itinerary that fits your interests.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/tours/asakusa" className="btn-accent">
+                  Browse Tours
+                </Link>
+                <Link to="/contact" className="btn-outline">
+                  Contact Us
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Asakusa Guide — What to See Beyond Senso-ji Temple",
+            "description": "A local guide's insider tips for exploring Asakusa beyond Senso-ji Temple.",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+            },
+            "datePublished": "2026-02-25",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/asakusa-guide-what-to-see",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default AsakusaGuide;

--- a/src/pages/blog/BestTimeToVisit.tsx
+++ b/src/pages/blog/BestTimeToVisit.tsx
@@ -1,0 +1,326 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const BestTimeToVisit = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Best Time to Visit Tokyo: Month-by-Month Guide | Tanuki Tabi Travel"
+        description="When should you visit Tokyo? A local guide breaks down weather, events, crowds, and costs for every month to help you plan the perfect trip."
+        canonicalPath="/blog/best-time-to-visit-tokyo"
+      />
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Planning Your Trip</p>
+            <h1 className="heading-display text-foreground">
+              Best Time to Visit Tokyo — A Month-by-Month Guide
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                February 25, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-8">
+              There's no bad time to visit Tokyo — but each season offers a very different experience. Cherry blossoms in spring, fireworks in summer, golden foliage in autumn, and glittering illuminations in winter all paint the city in completely different colors. After guiding tours year-round for over a decade, I've seen Tokyo in every mood: sweltering August heat, crisp November mornings, sudden spring downpours, and quiet January snowfalls. Every month has something special to offer, and every month has trade-offs you should know about. Here's what I tell every traveler who asks me "when should I come?" — a detailed breakdown of weather, events, crowd levels, and costs so you can choose the timing that's perfect for your trip.
+            </p>
+
+            {/* Quick Overview Table */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Quick Overview
+            </h2>
+            <div className="overflow-x-auto mb-8">
+              <table className="w-full text-sm text-muted-foreground border border-border rounded-lg overflow-hidden">
+                <thead className="bg-secondary/50">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium text-foreground">Month</th>
+                    <th className="px-4 py-3 text-left font-medium text-foreground">Weather</th>
+                    <th className="px-4 py-3 text-left font-medium text-foreground">Crowds</th>
+                    <th className="px-4 py-3 text-left font-medium text-foreground">Highlights</th>
+                    <th className="px-4 py-3 text-left font-medium text-foreground">Rating</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-t border-border">
+                    <td className="px-4 py-3 font-medium text-foreground">Jan</td>
+                    <td className="px-4 py-3">Cold, dry</td>
+                    <td className="px-4 py-3">Low</td>
+                    <td className="px-4 py-3">New Year shrine visits, winter illuminations</td>
+                    <td className="px-4 py-3">★★★☆☆</td>
+                  </tr>
+                  <tr className="border-t border-border bg-secondary/20">
+                    <td className="px-4 py-3 font-medium text-foreground">Feb</td>
+                    <td className="px-4 py-3">Cold</td>
+                    <td className="px-4 py-3">Low</td>
+                    <td className="px-4 py-3">Plum blossoms, fewer tourists</td>
+                    <td className="px-4 py-3">★★★☆☆</td>
+                  </tr>
+                  <tr className="border-t border-border">
+                    <td className="px-4 py-3 font-medium text-foreground">Mar</td>
+                    <td className="px-4 py-3">Mild</td>
+                    <td className="px-4 py-3">HIGH</td>
+                    <td className="px-4 py-3">Cherry blossoms begin (late March)</td>
+                    <td className="px-4 py-3">★★★★★</td>
+                  </tr>
+                  <tr className="border-t border-border bg-secondary/20">
+                    <td className="px-4 py-3 font-medium text-foreground">Apr</td>
+                    <td className="px-4 py-3">Warm</td>
+                    <td className="px-4 py-3">HIGH</td>
+                    <td className="px-4 py-3">Peak cherry blossoms, Golden Week starts</td>
+                    <td className="px-4 py-3">★★★★★</td>
+                  </tr>
+                  <tr className="border-t border-border">
+                    <td className="px-4 py-3 font-medium text-foreground">May</td>
+                    <td className="px-4 py-3">Warm</td>
+                    <td className="px-4 py-3">Medium-High</td>
+                    <td className="px-4 py-3">Golden Week, pleasant weather</td>
+                    <td className="px-4 py-3">★★★★☆</td>
+                  </tr>
+                  <tr className="border-t border-border bg-secondary/20">
+                    <td className="px-4 py-3 font-medium text-foreground">Jun</td>
+                    <td className="px-4 py-3">Rainy</td>
+                    <td className="px-4 py-3">Medium</td>
+                    <td className="px-4 py-3">Hydrangeas, rainy season begins</td>
+                    <td className="px-4 py-3">★★★☆☆</td>
+                  </tr>
+                  <tr className="border-t border-border">
+                    <td className="px-4 py-3 font-medium text-foreground">Jul</td>
+                    <td className="px-4 py-3">Hot, humid</td>
+                    <td className="px-4 py-3">Medium</td>
+                    <td className="px-4 py-3">Sumida fireworks, summer festivals</td>
+                    <td className="px-4 py-3">★★★☆☆</td>
+                  </tr>
+                  <tr className="border-t border-border bg-secondary/20">
+                    <td className="px-4 py-3 font-medium text-foreground">Aug</td>
+                    <td className="px-4 py-3">Very hot</td>
+                    <td className="px-4 py-3">Medium</td>
+                    <td className="px-4 py-3">Obon, summer festivals continue</td>
+                    <td className="px-4 py-3">★★☆☆☆</td>
+                  </tr>
+                  <tr className="border-t border-border">
+                    <td className="px-4 py-3 font-medium text-foreground">Sep</td>
+                    <td className="px-4 py-3">Warm, typhoons</td>
+                    <td className="px-4 py-3">Low</td>
+                    <td className="px-4 py-3">Bargain season, fewer tourists</td>
+                    <td className="px-4 py-3">★★★☆☆</td>
+                  </tr>
+                  <tr className="border-t border-border bg-secondary/20">
+                    <td className="px-4 py-3 font-medium text-foreground">Oct</td>
+                    <td className="px-4 py-3">Comfortable</td>
+                    <td className="px-4 py-3">Medium</td>
+                    <td className="px-4 py-3">Autumn begins, perfect weather</td>
+                    <td className="px-4 py-3">★★★★★</td>
+                  </tr>
+                  <tr className="border-t border-border">
+                    <td className="px-4 py-3 font-medium text-foreground">Nov</td>
+                    <td className="px-4 py-3">Cool</td>
+                    <td className="px-4 py-3">Medium-High</td>
+                    <td className="px-4 py-3">Peak autumn foliage</td>
+                    <td className="px-4 py-3">★★★★★</td>
+                  </tr>
+                  <tr className="border-t border-border bg-secondary/20">
+                    <td className="px-4 py-3 font-medium text-foreground">Dec</td>
+                    <td className="px-4 py-3">Cold</td>
+                    <td className="px-4 py-3">Medium</td>
+                    <td className="px-4 py-3">Winter illuminations, year-end markets</td>
+                    <td className="px-4 py-3">★★★★☆</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Now let's dive deeper into each season so you can understand exactly what to expect — and what to prepare for.
+            </p>
+
+            {/* Spring */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Spring (March - May)
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Spring is the most iconic time to visit Tokyo, and for good reason. The cherry blossoms (<strong className="text-foreground">sakura</strong>) transform the entire city into a pink-and-white wonderland from late March through mid-April. Parks, temples, rivers, and even office buildings are framed by cascading blossoms, and the tradition of <strong className="text-foreground">hanami</strong> (flower viewing) fills every green space with picnicking groups, lantern-lit evening gatherings, and a festive atmosphere unlike anything else in the year.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Cherry blossom viewing tips:</strong> Peak bloom typically lasts only 7-10 days, and the exact timing shifts each year depending on winter temperatures. Follow the Japan Meteorological Corporation's forecast closely as your trip approaches. The best viewing spots in Tokyo include Ueno Park, Chidorigafuchi (the moat near the Imperial Palace), Meguro River, Shinjuku Gyoen, and Sumida Park near Asakusa. For a less crowded experience, try Yanaka Cemetery or Koishikawa Korakuen Garden — both are stunning but see a fraction of the tourists.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Arrive early in the morning for photographs without crowds, or visit in the evening when many parks set up <strong className="text-foreground">yozakura</strong> (nighttime cherry blossom) lighting that creates a completely different atmosphere. Combine a cherry blossom walk with our{" "}
+              <Link to="/tours/asakusa" className="text-accent hover:underline">
+                Asakusa Walking Tour
+              </Link>{" "}
+              for blossoms along the Sumida River plus temple culture in one morning.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The trade-off for spring's beauty is <strong className="text-foreground">crowds and cost</strong>. Late March through early April is the most popular tourist season, and hotel prices can double or triple. Flights fill up months in advance, and popular restaurants require reservations weeks ahead. <strong className="text-foreground">Golden Week</strong> (late April to early May) adds another surge — this is Japan's longest holiday period, when domestic travelers flood every destination. If you visit during Golden Week, expect packed trains, sold-out accommodations, and long queues at major attractions.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Mid-to-late May, after Golden Week ends, is a hidden gem. The weather is warm and pleasant (18-25°C), the spring crowds have thinned, prices drop, and the fresh green foliage is beautiful in its own right. It's one of the most comfortable times to walk around the city, and you'll find that major sites are far more relaxed than they were just weeks earlier.
+            </p>
+
+            {/* Summer */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Summer (June - August)
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Summer in Tokyo is not for the faint of heart. The <strong className="text-foreground">rainy season</strong> (<strong className="text-foreground">tsuyu</strong>) typically runs from early June to mid-July, bringing persistent drizzle and overcast skies. It's not constant downpour — there are plenty of dry hours — but you should carry an umbrella everywhere and plan some indoor activities. The upside of the rainy season is that it produces spectacular <strong className="text-foreground">hydrangeas</strong> (ajisai) in every shade of blue, purple, and pink. Temples like Meiji Shrine's inner garden and Hakusan Shrine become seas of color, and the rain actually enhances the beauty of these flowers.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Once the rain clears, Tokyo hits peak summer intensity. July and August bring temperatures of 30-35°C with oppressive humidity that makes it feel even hotter. The heat is genuine and relentless — walking tours during midday can be exhausting. <strong className="text-foreground">Coping strategies:</strong> Start your days early (before 9 AM), take long lunch breaks in air-conditioned restaurants or shopping complexes, and save outdoor exploration for the cooler evening hours. Carry a hand towel (every Japanese person does), drink plenty of water, and don't be shy about ducking into a convenience store to cool down.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The reward for braving the heat is <strong className="text-foreground">summer festival season</strong>. The Sumida River Fireworks Festival in late July is one of Japan's oldest and most spectacular fireworks displays, with nearly 20,000 fireworks lighting up the sky over Asakusa. Local neighborhood <strong className="text-foreground">matsuri</strong> (festivals) happen nearly every weekend, featuring portable shrines paraded through the streets, traditional music, food stalls, and people wearing colorful <strong className="text-foreground">yukata</strong> (summer kimono). The energy at these festivals is electric, and they offer an authentic cultural experience that's hard to find at any other time of year.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Obon</strong> in mid-August is Japan's festival of the dead, when families return to their hometowns to honor ancestors. Tokyo actually empties out during Obon week — many restaurants and small businesses close, but tourist attractions are quieter than usual. It's a unique window into Japanese spiritual life, with Bon Odori dance festivals held in parks and temple grounds across the city. Hotel prices during Obon are moderate and availability is generally good, making it a surprisingly practical time to visit if you can handle the heat.
+            </p>
+
+            {/* Autumn */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Autumn (September - November)
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If I had to pick one season to recommend above all others, it would be autumn. The combination of <strong className="text-foreground">perfect weather, stunning foliage, and manageable crowds</strong> makes September through November the ideal window for most travelers. This is when Tokyo feels most inviting — the air is crisp, the skies are clear, and the city's parks and gardens put on a color show that rivals spring's cherry blossoms.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">September</strong> is a transitional month. The summer heat gradually fades, temperatures drop to a comfortable 22-28°C, and tourist numbers hit their annual low. It is also <strong className="text-foreground">typhoon season</strong>, and while direct hits on Tokyo are rare, you should monitor weather forecasts and have flexible plans. The silver lining is that September offers the best hotel rates of the year, flights are cheaper, and popular attractions are blissfully uncrowded. If your schedule is flexible enough to work around potential weather disruptions, September is a bargain hunter's dream.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">October</strong> brings what many consider Tokyo's finest weather: sunny skies, comfortable temperatures around 15-22°C, low humidity, and barely any rain. It's the perfect walking weather, and every outdoor activity feels effortless. Autumn foliage begins to appear in late October, starting with the ginkgo trees that line streets like Meiji Jingu Gaien's famous Icho Namiki avenue, which transforms into a tunnel of brilliant gold. Crowds are moderate — nowhere near spring levels — and prices remain reasonable.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">November</strong> is peak foliage season. The <strong className="text-foreground">koyo</strong> (autumn leaf viewing) reaches full intensity in mid-to-late November, with Japanese maples, ginkgoes, and zelkovas painting the city in reds, oranges, and golds. The best foliage spots in Tokyo include Rikugien Garden (which offers special evening illuminations), Shinjuku Gyoen, Meiji Jingu Gaien, Koishikawa Korakuen, and the grounds around Sensoji Temple. Day trips to{" "}
+              <Link to="/tours/nikko-day-trip" className="text-accent hover:underline">
+                Nikko
+              </Link>{" "}
+              and{" "}
+              <Link to="/tours/kamakura-day-trip" className="text-accent hover:underline">
+                Kamakura
+              </Link>{" "}
+              are particularly spectacular during this period, with mountain and temple settings that amplify the autumn colors beyond what you'll find in the city center.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Crowds do pick up in November as word has spread about Japan's autumn beauty, but they're still considerably lighter than the cherry blossom frenzy of spring. Hotel prices rise slightly but remain well below spring peak rates. You'll share the parks with Japanese families enjoying their own autumn tradition of leaf viewing, which adds to the cultural atmosphere rather than detracting from it.
+            </p>
+
+            {/* Winter */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Winter (December - February)
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tokyo's winter is cold but remarkably sunny. December through February brings temperatures of 2-10°C with very little rain or snow — the skies are often brilliantly clear, making it one of the best seasons for photography. Mt. Fuji is most visible in winter, and the crisp air creates sharp, vivid views across the city skyline. Pack warm layers, but don't let the cold deter you — it's invigorating rather than brutal, especially compared to northern European or North American winters.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The highlight of early winter is Tokyo's <strong className="text-foreground">winter illuminations</strong>. From late November through February, the city erupts in light displays that are staggering in their scale and artistry. Roppongi Hills, Marunouchi (near Tokyo Station), Omotesando, Shibuya, and Caretta Shiodome all host major illumination events, turning entire neighborhoods into glowing wonderlands. Many are free to enjoy, and the best displays draw millions of visitors over their run. An evening walk through the illuminations, followed by a warm bowl of ramen, is one of Tokyo's most magical winter experiences.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">New Year</strong> is the most significant holiday in the Japanese calendar. From late December, the city shifts into year-end mode: department stores hold massive sales, special New Year foods (osechi ryori) fill every market, and on December 31, temples ring their bells 108 times at midnight in a ceremony called <strong className="text-foreground">joya no kane</strong>. Then comes <strong className="text-foreground">hatsumode</strong> — the first shrine visit of the new year — when millions of Tokyoites head to Meiji Shrine, Sensoji, and other major shrines during the first three days of January. The atmosphere is festive and deeply traditional, with food stalls, fortune-drawing, and families dressed in kimono. It's one of the most culturally rich times to experience Tokyo.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              January and February are Tokyo's quietest tourist months. Major attractions that are packed during cherry blossom season feel almost private — you can walk through Meiji Shrine's forest with barely another tourist in sight. Hotels drop to their lowest annual rates, flights are cheap, and restaurants that normally require weeks of advance booking often have same-day availability. The only visual downside is that parks and gardens can look somewhat bare without their foliage, but this is balanced by the stark beauty of traditional architecture against winter skies, and the appearance of <strong className="text-foreground">plum blossoms</strong> (ume) in February, which signal that spring is on its way.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Winter is also the best season for <strong className="text-foreground">hot springs</strong>. A day trip to{" "}
+              <Link to="/tours/hakone-day-trip" className="text-accent hover:underline">
+                Hakone
+              </Link>{" "}
+              in winter combines clear Mt. Fuji views with the deeply relaxing experience of soaking in an outdoor onsen while cold air surrounds you. It's the quintessential Japanese winter activity, and the contrast between the steaming water and the chilly air is unforgettable.
+            </p>
+
+            {/* My Personal Recommendation */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              My Personal Recommendation
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              After guiding tours through every season, here are my honest picks depending on your priorities:
+            </p>
+            <ul className="space-y-4 mb-8">
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Best overall balance:</strong> Late October to mid-November. Perfect weather, gorgeous foliage, reasonable crowds, and fair prices. This is when I most enjoy guiding tours because everything just clicks — the light, the temperature, the atmosphere.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Cherry blossoms:</strong> Late March to early April. An unforgettable experience, but book everything — flights, hotels, and tours — at least 3-4 months in advance. Expect premium prices and significant crowds at all major viewing spots.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Best for budget travelers:</strong> January or September. Both months offer dramatically lower prices on flights and accommodation, plus thin crowds at every attraction. January gives you winter illuminations and cultural depth; September gives you lingering warmth and the start of autumn.
+              </li>
+            </ul>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              Ultimately, the best time to visit Tokyo is whenever you can make it work. Every season has moments that will take your breath away, and a knowledgeable guide can help you find the magic no matter when you arrive.
+            </p>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="text-2xl font-medium text-foreground mb-4">
+                Whenever you visit, a local guide makes Tokyo unforgettable
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                No matter which season you choose, having a local guide by your side transforms your trip. I'll take you to the best spots for whatever Tokyo is offering that week — cherry blossoms, autumn foliage, hidden festivals, or quiet winter temples. Browse our tours or design your own itinerary from scratch.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/tours" className="btn-accent">
+                  Browse Our Tours
+                </Link>
+                <Link to="/tours/custom" className="btn-outline">
+                  Design a Custom Tour
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Best Time to Visit Tokyo — A Month-by-Month Guide",
+            "description": "When should you visit Tokyo? A local guide breaks down weather, events, crowds, and costs for every month to help you plan the perfect trip.",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+            },
+            "datePublished": "2026-02-25",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/best-time-to-visit-tokyo",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default BestTimeToVisit;

--- a/src/pages/blog/BlogIndex.tsx
+++ b/src/pages/blog/BlogIndex.tsx
@@ -3,25 +3,54 @@ import { ArrowRight, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 
-const blogPosts = [
+interface BlogPost {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  author: string;
+  category: string;
+}
+
+const blogPosts: BlogPost[] = [
+  // Tokyo Area Guides
   {
-    slug: "tokyo-3-day-itinerary",
-    title: "The Perfect 3-Day Tokyo Itinerary — From a Local Guide",
+    slug: "asakusa-guide-what-to-see",
+    title: "Asakusa Guide — What to See Beyond Senso-ji Temple",
     description:
-      "Plan the perfect 3 days in Tokyo with insider tips from a licensed local guide. Covers Asakusa, Shibuya, Tsukiji, day trips, and hidden gems most tourists miss.",
+      "A local guide's insider tips for exploring Asakusa. Go beyond Senso-ji Temple to discover hidden shrines, street food spots, and the best times to visit.",
     date: "February 25, 2026",
     author: "Manabu, Licensed Tour Guide",
-    category: "Itineraries",
+    category: "Tokyo Area Guides",
   },
   {
-    slug: "is-it-worth-hiring-a-tour-guide-in-tokyo",
-    title: "Is It Worth Hiring a Private Tour Guide in Tokyo?",
+    slug: "shibuya-harajuku-guide",
+    title: "Shibuya & Harajuku — A Local Guide to Tokyo's Modern Side",
     description:
-      "Wondering if a private tour guide in Tokyo is worth the cost? A licensed guide explains when it makes sense, what you get, and who benefits most.",
+      "Explore Shibuya and Harajuku like a local. Insider tips on Shibuya Crossing, Takeshita Street, hidden cafes, and the best photo spots from a licensed guide.",
     date: "February 25, 2026",
     author: "Manabu, Licensed Tour Guide",
-    category: "Travel Tips",
+    category: "Tokyo Area Guides",
   },
+  {
+    slug: "shinjuku-guide",
+    title: "Shinjuku Guide — Tokyo's Neon-Lit Heart",
+    description:
+      "Navigate Shinjuku like a local. A guide to Golden Gai, Omoide Yokocho, Kabukicho, Shinjuku Gyoen, and the best food spots in Tokyo's busiest district.",
+    date: "February 25, 2026",
+    author: "Manabu, Licensed Tour Guide",
+    category: "Tokyo Area Guides",
+  },
+  {
+    slug: "tsukiji-guide-food-lover",
+    title: "Tsukiji Market Guide — A Food Lover's Walkthrough",
+    description:
+      "A local guide to Tsukiji Outer Market. What to eat, what to skip, best times to visit, and how to combine with Ginza for a perfect Tokyo food day.",
+    date: "February 25, 2026",
+    author: "Manabu, Licensed Tour Guide",
+    category: "Tokyo Area Guides",
+  },
+  // Day Trip Guides
   {
     slug: "kamakura-vs-hakone-vs-nikko-day-trip",
     title: "Kamakura vs Hakone vs Nikko — Which Day Trip Should You Choose?",
@@ -29,8 +58,53 @@ const blogPosts = [
       "Can't decide between Kamakura, Hakone, or Nikko? A local guide compares travel time, highlights, and who each trip is best for to help you choose.",
     date: "February 25, 2026",
     author: "Manabu, Licensed Tour Guide",
-    category: "Day Trips",
+    category: "Day Trip Guides",
   },
+  // Planning Your Trip
+  {
+    slug: "tokyo-3-day-itinerary",
+    title: "The Perfect 3-Day Tokyo Itinerary — From a Local Guide",
+    description:
+      "Plan the perfect 3 days in Tokyo with insider tips from a licensed local guide. Covers Asakusa, Shibuya, Tsukiji, day trips, and hidden gems most tourists miss.",
+    date: "February 25, 2026",
+    author: "Manabu, Licensed Tour Guide",
+    category: "Planning Your Trip",
+  },
+  {
+    slug: "best-time-to-visit-tokyo",
+    title: "Best Time to Visit Tokyo — A Month-by-Month Guide",
+    description:
+      "When should you visit Tokyo? A local guide breaks down weather, events, crowds, and costs for every month to help you plan the perfect trip.",
+    date: "February 25, 2026",
+    author: "Manabu, Licensed Tour Guide",
+    category: "Planning Your Trip",
+  },
+  {
+    slug: "japan-temple-shrine-etiquette",
+    title: "Temple & Shrine Etiquette in Japan — A Complete Guide",
+    description:
+      "Visiting temples and shrines in Japan? Learn the essential etiquette — how to pray, purify, bow, and behave respectfully from a licensed Japanese guide.",
+    date: "February 25, 2026",
+    author: "Manabu, Licensed Tour Guide",
+    category: "Planning Your Trip",
+  },
+  // Helpful Guides
+  {
+    slug: "is-it-worth-hiring-a-tour-guide-in-tokyo",
+    title: "Is It Worth Hiring a Private Tour Guide in Tokyo?",
+    description:
+      "Wondering if a private tour guide in Tokyo is worth the cost? A licensed guide explains when it makes sense, what you get, and who benefits most.",
+    date: "February 25, 2026",
+    author: "Manabu, Licensed Tour Guide",
+    category: "Helpful Guides",
+  },
+];
+
+const categories = [
+  "Tokyo Area Guides",
+  "Day Trip Guides",
+  "Planning Your Trip",
+  "Helpful Guides",
 ];
 
 const BlogIndex = () => {
@@ -56,42 +130,57 @@ const BlogIndex = () => {
         </div>
       </section>
 
-      {/* Blog Grid */}
+      {/* Blog Posts by Category */}
       <section className="py-16">
         <div className="container-section">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {blogPosts.map((post) => (
-              <Link
-                key={post.slug}
-                to={`/blog/${post.slug}`}
-                className="group bg-card border border-border rounded-lg overflow-hidden hover:shadow-[var(--shadow-medium)] hover:-translate-y-1 transition-all duration-300"
-              >
-                <div className="p-6">
-                  <p className="text-label text-accent mb-2">{post.category}</p>
-                  <h2 className="text-xl font-medium text-foreground group-hover:text-accent transition-colors mb-3">
-                    {post.title}
-                  </h2>
-                  <p className="text-muted-foreground text-sm leading-relaxed mb-4">
-                    {post.description}
-                  </p>
-                  <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                    <span className="flex items-center gap-1">
-                      <User className="w-3 h-3" />
-                      {post.author}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <Calendar className="w-3 h-3" />
-                      {post.date}
-                    </span>
-                  </div>
-                  <div className="mt-4 flex items-center gap-2 text-accent font-medium text-sm">
-                    <span>Read Article</span>
-                    <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-                  </div>
+          {categories.map((category) => {
+            const postsInCategory = blogPosts.filter(
+              (post) => post.category === category
+            );
+            if (postsInCategory.length === 0) return null;
+            return (
+              <div key={category} className="mb-16 last:mb-0">
+                <h2 className="heading-section text-foreground mb-8">
+                  {category}
+                </h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                  {postsInCategory.map((post) => (
+                    <Link
+                      key={post.slug}
+                      to={`/blog/${post.slug}`}
+                      className="group bg-card border border-border rounded-lg overflow-hidden hover:shadow-[var(--shadow-medium)] hover:-translate-y-1 transition-all duration-300"
+                    >
+                      <div className="p-6">
+                        <p className="text-label text-accent mb-2">
+                          {post.category}
+                        </p>
+                        <h3 className="text-xl font-medium text-foreground group-hover:text-accent transition-colors mb-3">
+                          {post.title}
+                        </h3>
+                        <p className="text-muted-foreground text-sm leading-relaxed mb-4">
+                          {post.description}
+                        </p>
+                        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                          <span className="flex items-center gap-1">
+                            <User className="w-3 h-3" />
+                            {post.author}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <Calendar className="w-3 h-3" />
+                            {post.date}
+                          </span>
+                        </div>
+                        <div className="mt-4 flex items-center gap-2 text-accent font-medium text-sm">
+                          <span>Read Article</span>
+                          <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+                        </div>
+                      </div>
+                    </Link>
+                  ))}
                 </div>
-              </Link>
-            ))}
-          </div>
+              </div>
+            );
+          })}
         </div>
       </section>
 

--- a/src/pages/blog/DayTripComparison.tsx
+++ b/src/pages/blog/DayTripComparison.tsx
@@ -263,8 +263,15 @@ const DayTripComparison = () => {
                 <strong className="text-foreground">If you have 2+ days for day trips:</strong> Do Kamakura + Hakone (most popular combination) or Kamakura + Nikko (for history lovers). Each destination offers something the others don't, so you won't feel like you're repeating the experience.
               </li>
             </ul>
-            <p className="text-muted-foreground leading-relaxed mb-8">
+            <p className="text-muted-foreground leading-relaxed mb-4">
               The most important thing is to choose based on what excites you, not what's "most popular." If you're genuinely passionate about history, Nikko will blow your mind even though it's the least-visited of the three. If you dream of seeing Mt. Fuji, Hakone is your best shot. And if you want the most balanced, easy-going experience, Kamakura delivers every time.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              Timing also matters — each destination has an optimal season. For a complete breakdown of when to plan your trip, check out our{" "}
+              <Link to="/blog/best-time-to-visit-tokyo" className="text-accent hover:underline">
+                Best Time to Visit Tokyo guide
+              </Link>
+              .
             </p>
 
             {/* CTA */}

--- a/src/pages/blog/ShibuyaHarajukuGuide.tsx
+++ b/src/pages/blog/ShibuyaHarajukuGuide.tsx
@@ -1,0 +1,261 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const ShibuyaHarajukuGuide = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Shibuya & Harajuku Guide: Beyond the Crossing | Tanuki Tabi Travel"
+        description="Explore Shibuya and Harajuku like a local. Insider tips on Shibuya Crossing, Takeshita Street, hidden cafes, and the best photo spots from a licensed guide."
+        canonicalPath="/blog/shibuya-harajuku-guide"
+      />
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Tokyo Area Guides</p>
+            <h1 className="heading-display text-foreground">
+              Shibuya & Harajuku — A Local Guide to Tokyo's Modern Side
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                February 25, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-8">
+              If Asakusa represents old Tokyo — the temples, the traditions, the quiet rituals of another era — then Shibuya and Harajuku are the city's creative pulse. These neighboring districts sit on the western side of central Tokyo, connected by a short walk or a single train stop, yet each carries a completely different energy. Shibuya is frenetic, commercial, and alive with neon and noise. Harajuku is a place of subcultures, fashion experiments, and architectural statements. Together they form what many visitors picture when they imagine modern Tokyo.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              But here's what most travel guides won't tell you: these neighborhoods are constantly evolving. What was trendy last year might be gone today, replaced by something newer, stranger, or more interesting. The Shibuya and Harajuku I guide people through now look quite different from the ones I showed visitors five years ago. Entire blocks have been rebuilt, new complexes have risen, and the youth culture has shifted in ways that only locals can track. This guide covers what's actually worth your time right now — not the outdated advice you'll find recycled across the internet.
+            </p>
+
+            {/* Shibuya Crossing */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Shibuya Crossing: How to Actually Enjoy It
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Let's start with the obvious. Shibuya Crossing is the world's busiest pedestrian intersection, and yes, it lives up to the hype — but only if you experience it correctly. Too many visitors walk across once, take a selfie, and move on. That's missing the point entirely. The scramble crossing is a living piece of urban theater, and the best way to appreciate it is from above before you wade into it yourself.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">The best viewing spots:</strong> The most famous overlook is the Starbucks on the second floor of the Tsutaya building, directly facing the crossing. It's iconic, but expect to wait for a window seat during peak hours. A better option for many visitors is Mag's Park, the rooftop observation space atop the Magnet by Shibuya 109 building. It's free, less crowded than you'd expect, and gives you a wide-angle perspective that photographs beautifully. For the ultimate panorama, Shibuya Sky — the observation deck on top of the Shibuya Scramble Square building — offers a 360-degree view from 230 meters up. It's ticketed and popular, so book online in advance, especially for sunset slots.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">When to cross:</strong> If you want the full sensory overload, come on a Friday or Saturday evening between 7 and 9 PM. That's when foot traffic peaks and up to 3,000 people flood the intersection every signal change. The neon reflections on the pavement after rain make for especially dramatic photos. Weekday mornings, by contrast, are surprisingly calm — you can cross almost leisurely and see the intersection as the local commuters experience it.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              But the scramble is just the start. Too many people treat the crossing as the destination rather than the gateway. Once you've watched it, crossed it, and captured your photos, the real Shibuya begins in the tangled streets that radiate outward from this famous intersection. That's where this guide really comes in.
+            </p>
+
+            {/* Beyond the Crossing */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Beyond the Crossing: Shibuya's Best Kept Secrets
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Most visitors never venture more than a block or two past the crossing, which means they miss the neighborhoods that give Shibuya its real character. Here are the spots I take people on my tours — the places that reward curiosity and a willingness to wander.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Nonbei Yokocho — Drunkard's Alley
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tucked behind the train tracks just a two-minute walk from Shibuya Station's north exit, Nonbei Yokocho is a narrow lane of tiny bars that feels like it belongs in a different decade. Think of it as Shibuya's answer to Shinjuku's Golden Gai — small, atmospheric drinking establishments that seat maybe six to eight people each. The difference is that Nonbei Yokocho is far less touristy and has a more relaxed, welcoming vibe. Some of these bars have been run by the same owners for 40 or 50 years. Evenings are the best time to visit, and don't be afraid to duck into a place that catches your eye — most welcome newcomers, even those who don't speak Japanese. A simple "osusume kudasai" (your recommendation, please) will get you started.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Center-gai and the Side Streets
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Center-gai (officially renamed "Basketball Street," though nobody calls it that) is Shibuya's main pedestrian shopping street, loud and crowded with fast-food chains and clothing stores. It's worth a walk-through for the atmosphere, but the real finds are on the narrow side streets that branch off it. These smaller alleys hide izakayas with handwritten menus, tiny ramen counters with lines out the door, and vintage clothing shops where you can find one-of-a-kind pieces. The rule of thumb in Shibuya is simple: if a street looks too narrow to bother with, it's probably worth exploring.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Shibuya Stream and the River Area
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              One of Shibuya's most dramatic recent transformations is the area around the Shibuya River, south of the station. The Shibuya Stream complex opened in 2018 and turned what was a hidden, concrete-covered waterway into an open-air riverside promenade with restaurants, cafes, and public seating areas. It's where office workers eat lunch and where couples stroll on weekend afternoons. The vibe is completely different from the chaos of the crossing — modern, relaxed, almost European in feel. Follow the river walk south and you'll find yourself in a surprisingly quiet residential area that most tourists have no idea exists.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Dogenzaka — More Than Its Reputation
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Dogenzaka is the sloping street that leads up the hill from the crossing, and it has a reputation as Shibuya's love hotel district. That reputation is deserved — you'll see plenty of colorful facades with hourly rates — but Dogenzaka is also home to some of the best vintage and secondhand clothing shops in Tokyo. Stores like Ragtag, Flamingo, and dozens of smaller independent shops sell everything from designer labels at a fraction of retail to perfectly curated vintage Americana. If you're into fashion or thrifting, Dogenzaka is worth an afternoon of browsing. The love hotels, by the way, are a fascinating part of Japanese urban culture in their own right, and I'm happy to explain their history and social role on tour — it's more interesting than you might expect.
+            </p>
+
+            {/* Harajuku */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Harajuku: More Than Takeshita Street
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Harajuku is synonymous with Japanese youth culture, and for many visitors it's the neighborhood they're most excited to see. But Harajuku is much more than the single street most people visit. Let me break down what's here and how to make the most of it.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Takeshita Street: A Reality Check
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Takeshita-dori is the famous pedestrian street that runs from Harajuku Station south toward Meiji-dori. It's colorful, loud, and packed with crepe shops, bubble tea stands, costume stores, and kawaii merchandise. Here's my honest assessment: it's very crowded and very touristy, but it's still fun. The key is managing your expectations. This isn't an "authentic local secret" — it's a spectacle, and spectacles have their own value. Visit on a weekday morning if you want to actually move freely, or brave the weekend crowds if you want the full experience. Either way, give yourself about 30 to 45 minutes. That's enough to soak it in without the sensory overload becoming exhausting.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Cat Street — The Real Fashion Street
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Running roughly parallel to Takeshita Street but one block south, Cat Street (Kyuushibuya-gawa Yuuhodou) is where Harajuku's fashion-conscious locals actually shop. Built along a former riverbed, it's a winding, tree-lined street with independent boutiques, designer flagship stores, vintage shops, and some of the best coffee in the area. The atmosphere is completely different from Takeshita — relaxed, curated, and genuinely stylish. This is where Japanese streetwear brands test new concepts, where up-and-coming designers open their first shops, and where you'll spot fashion-forward locals putting together outfits that wouldn't look out of place in a magazine. If you only have time for one Harajuku street, make it Cat Street.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Omotesando — An Architecture Walk
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Omotesando is the tree-lined boulevard that runs from Harajuku toward Aoyama, and it's one of the most architecturally significant streets in the world. Nearly every major luxury brand has commissioned a world-class architect for their flagship store here. Tadao Ando designed the Omotesando Hills complex, with its signature spiraling concrete ramp. Shigeru Ban created the Nicolas G. Hayek Center with its glass-and-steel facade that opens entirely to the street. The Dior building by SANAA shimmers like a translucent curtain. Even if you have no interest in shopping, walking Omotesando as an open-air architecture gallery is a remarkable experience. I always tell visitors to look up — the building facades tell stories that the storefronts at ground level never reveal.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Meiji Shrine — A Peaceful Contrast
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Just a five-minute walk from the neon chaos of Takeshita Street, Meiji Shrine (Meiji Jingu) sits inside a 170-acre forested park that feels like an entirely different world. Dedicated to Emperor Meiji and Empress Shoken, the shrine is one of Tokyo's most important Shinto sites. The transition from Harajuku's pop culture excess to the shrine's towering torii gates and gravel paths is one of the most dramatic contrasts in all of Tokyo — and it perfectly captures what makes this city so endlessly fascinating. Arrive early in the morning for the most serene experience, and keep an eye out for traditional wedding processions on weekends.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Yoyogi Park — Tokyo's Living Room
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Adjacent to Meiji Shrine, Yoyogi Park is where Tokyo comes to relax, rehearse, and perform. On weekends especially, you'll find street musicians, dance crews practicing choreography, cosplayers posing for photos, and families having picnics on the grass. During cherry blossom season it's one of the most popular hanami (flower viewing) spots in the city. The park is free, open, and offers a completely different perspective on Tokyo life — one that's less about consumption and more about community. Bring a blanket and something to drink, and just sit for a while. You'll see a side of Tokyo that most itineraries never mention.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you want to experience all of this with a local who can connect the dots and share the stories behind what you're seeing, our{" "}
+              <Link to="/tours/shibuya-harajuku" className="text-accent hover:underline">
+                Shibuya & Harajuku Walking Tour
+              </Link>{" "}
+              covers these neighborhoods in depth — from hidden backstreets to cultural context that transforms a simple walk into a real understanding of modern Tokyo.
+            </p>
+
+            {/* Where to Eat */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Where to Eat
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              One of the best things about Shibuya and Harajuku is the sheer density of food options, ranging from cheap street snacks to world-class dining. Here are my recommendations for visitors who want to eat well without relying on Google's top results (which tend to steer you toward tourist traps).
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Harajuku Street Food — The Classics
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Harajuku crepes are a Tokyo institution. The thin, folded crepes stuffed with whipped cream, fresh fruit, chocolate, and ice cream have been a Takeshita Street staple since the 1970s. Marion Crepes and Angels Heart are the originals, and they're still good. Cotton candy shops have exploded in popularity in recent years, with shops offering massive, colorful clouds of spun sugar that are as much about the Instagram photo as the taste. They're fun, ephemeral, and perfectly Harajuku. For something more substantial, the side streets around Takeshita hide excellent takoyaki (octopus ball) stands and small curry shops that cater to hungry locals rather than tourists.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Shibuya Ramen and Beyond
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Shibuya has some genuinely outstanding ramen shops, but the best ones are rarely the most visible. Look for the places with short lines of Japanese office workers at lunchtime — that's your signal. Fuunji, just north of the station, is legendary for its tsukemen (dipping noodles) with a rich, concentrated broth. For something different, the back streets behind Shibuya 109 hide excellent gyudon counters, standing soba shops, and hole-in-the-wall curry joints where a filling lunch costs under 1,000 yen. The Omotesando back streets — especially in the direction of Aoyama — are home to some of the most charming lunch cafes in Tokyo. These small, independently run spots serve beautiful set lunches (teishoku) with seasonal ingredients, often in spaces that feel more like someone's living room than a restaurant. Expect to pay 1,500 to 2,500 yen for a lunch that would cost three times as much in the main shopping areas.
+            </p>
+
+            {/* Evening Plans */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Evening Plans
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Shibuya transforms after dark. The neon intensifies, the crowds shift from shoppers to revelers, and the energy of the neighborhood changes completely. If you want to experience Tokyo nightlife, Shibuya is one of the best starting points — and here's how to do it safely and enjoyably.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Shibuya Nightlife Starting Points
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              For a relaxed evening, start at Nonbei Yokocho (the alley I mentioned earlier) or one of the craft beer bars near the station. Shibuya has an excellent craft beer scene, with spots like Mikkeller Tokyo and Goodbeer Faucets offering Japanese and international microbrews in stylish settings. If you're looking for something livelier, the streets around Center-gai have dozens of izakayas where you can order rounds of drinks and small plates in the classic Japanese drinking style. For clubbing, Shibuya is home to some of Tokyo's most iconic venues — though the scene starts late, typically after midnight.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Safe Bar-Hopping Tips for Tourists
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tokyo is one of the safest cities in the world for nightlife, but a few common-sense tips will improve your experience. Stick to places with visible menus and posted prices — this avoids any surprise charges. Be cautious of touts on the street who invite you to "special" bars; the legitimate places don't need to recruit customers from the sidewalk. Many smaller bars have a table charge (otoshi) of 300 to 500 yen per person, which typically includes a small appetizer — this is standard practice, not a scam. If you're unsure about a place, ask your hotel concierge or look for spots with reviews in English on Google Maps.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Last Train — Know Your Limits
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The most important piece of nightlife advice I give to every visitor: know your last train time. Most train and subway lines stop running between midnight and 12:30 AM, with the last departures from Shibuya Station varying by line and direction. Miss the last train and you're looking at either an expensive taxi ride (3,000 to 10,000 yen depending on distance), staying out until the first trains resume around 5 AM, or finding a manga cafe or capsule hotel for a few hours. The first option costs money, the second costs energy, and the third is an adventure in itself. My recommendation: set an alarm for 11:30 PM. That gives you a comfortable buffer to finish your drink, say goodbye, and make it to the platform without sprinting. If you decide to stay out all night, Shibuya has plenty of 24-hour establishments — just pace yourself.
+            </p>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="text-2xl font-medium text-foreground mb-4">
+                Want to explore Shibuya and Harajuku with a local who knows every backstreet?
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                From hidden vintage shops to the stories behind Omotesando's architectural masterpieces, our walking tour brings these neighborhoods to life in ways a guidebook never can. Let a licensed local guide show you the Shibuya and Harajuku that most visitors never see.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/tours/shibuya-harajuku" className="btn-accent">
+                  Book Our Shibuya & Harajuku Tour
+                </Link>
+                <Link to="/contact" className="btn-outline">
+                  Ask a Question
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Shibuya & Harajuku — A Local Guide to Tokyo's Modern Side",
+            "description": "Explore Shibuya and Harajuku like a local. Insider tips on Shibuya Crossing, Takeshita Street, hidden cafes, and the best photo spots from a licensed guide.",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+            },
+            "datePublished": "2026-02-25",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default ShibuyaHarajukuGuide;

--- a/src/pages/blog/ShinjukuGuide.tsx
+++ b/src/pages/blog/ShinjukuGuide.tsx
@@ -1,0 +1,435 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const ShinjukuGuide = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Shinjuku Guide: Nightlife, Food & Hidden Spots | Tanuki Tabi Travel"
+        description="Navigate Shinjuku like a local. A guide to Golden Gai, Omoide Yokocho, Kabukicho, Shinjuku Gyoen, and the best food spots in Tokyo's busiest district."
+        canonicalPath="/blog/shinjuku-guide"
+      />
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Tokyo Area Guides</p>
+            <h1 className="heading-display text-foreground">
+              Shinjuku Guide — Tokyo's Neon-Lit Heart
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                February 25, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-8">
+              Shinjuku Station handles 3.5 million passengers daily, making it the busiest
+              transport hub on the planet. If you arrive without a plan, it can feel
+              genuinely overwhelming — the station alone has over 200 exits, and the streets
+              above are a sensory assault of neon signage, rushing commuters, and competing
+              loudspeaker announcements. But once you learn how Shinjuku is laid out and
+              understand what each pocket of the district offers, this neighborhood transforms
+              from chaotic obstacle into one of Tokyo's most rewarding areas to explore. I've
+              been guiding visitors through Shinjuku for years, and it remains my favorite
+              district to show people at night. There is simply nowhere else in the world
+              quite like it.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              This guide covers everything you need to navigate Shinjuku with confidence —
+              from the skyscraper-lined west side to the entertainment-packed east side, from
+              tiny Golden Gai bars to the serene beauty of Shinjuku Gyoen. I'll share the
+              same tips I give my tour guests: where to go, what to skip, how much to budget,
+              and the etiquette that will make your experience smoother.
+            </p>
+
+            {/* Getting Oriented */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Getting Oriented: Shinjuku's Two Sides
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The key to understanding Shinjuku is knowing that the train tracks divide
+              it into two completely different worlds.{" "}
+              <strong className="text-foreground">West Shinjuku</strong> is the business
+              and government district — a grid of towering skyscrapers, corporate
+              headquarters, and wide avenues that feel almost American in their scale.
+              The Tokyo Metropolitan Government Building dominates the skyline here, and
+              its twin observation decks on the 45th floor offer free panoramic views of
+              the city. On clear days, you can see Mt. Fuji in the distance. This is also
+              where you'll find the Park Hyatt Tokyo, made famous by the film{" "}
+              <em>Lost in Translation</em> — the New York Bar on the 52nd floor is worth
+              a visit for the view alone, though drinks start around ¥2,500 and there is
+              a cover charge in the evening.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">East Shinjuku</strong> is where the
+              energy lives. Step out of the east exit and you're immediately pulled into
+              a river of people flowing toward Kabukicho, Golden Gai, and the countless
+              restaurants, izakayas, and entertainment venues that make this side of
+              Shinjuku feel alive 24 hours a day. The east side is louder, messier, more
+              colorful, and vastly more interesting for most visitors. If you only have
+              one evening in Shinjuku, spend it here.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Navigation tip:</strong> Don't try to
+              walk through the station to get from west to east. Use the south exit
+              concourse — it connects both sides at street level and is far less
+              confusing than the underground passages. Alternatively, the Southern
+              Terrace exit near Takashimaya Times Square gives you a clear orientation
+              point on the south side.
+            </p>
+
+            {/* Golden Gai */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Golden Gai: The World's Most Intimate Bar District
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Golden Gai is unlike anything else on Earth. Packed into six narrow alleys
+              barely wide enough for two people to pass, you'll find over 200 tiny bars —
+              most seating no more than six to eight people. These aren't sleek cocktail
+              lounges; they're cramped, characterful, smoke-scented rooms presided over
+              by a single bartender-owner, or "mama" or "master," who sets the rules, the
+              music, and the atmosphere. Each bar has its own identity — some specialize
+              in jazz, others in horror movies, punk rock, photography, or simply
+              conversation with the owner.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Etiquette matters here.</strong> Most
+              bars charge a cover (typically ¥500-1,500), which is clearly posted on or
+              near the door. This is standard practice, not a scam — the cover charge
+              helps these tiny businesses survive on just a handful of customers per
+              night. Always check the sign before entering. Some bars are regulars-only
+              spots where the owner serves the same small group of friends night after
+              night. These will sometimes have a sign indicating they're members-only or
+              will simply feel unwelcoming — don't force it. Move to the next door. Many
+              bars now actively welcome tourists and display English menus or "Welcome"
+              signs. Start with those if you're visiting for the first time.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Best time to visit:</strong> Weekday
+              evenings between 8 PM and 10 PM. This window gives you the authentic
+              atmosphere without the weekend crowds, and most bars will be open but not
+              yet packed. Friday and Saturday nights after 10 PM can be extremely
+              crowded, with lines forming outside the more popular spots. Budget around
+              ¥1,000-2,000 per bar (cover charge plus one or two drinks), and plan to
+              visit two or three bars over the course of an evening. That's the Golden
+              Gai rhythm — you're not meant to spend all night in one place. The joy is
+              in the hopping, the discovering, the random conversations with strangers
+              in a space so small your elbows are touching.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              One more thing: don't take photos inside without asking. Many bartenders
+              and regulars prefer privacy. The narrow alleys themselves are fair game
+              for photography, and they look spectacular at night with all the signs
+              glowing, but step inside and you should ask first. It's a small gesture
+              that goes a long way.
+            </p>
+
+            {/* Omoide Yokocho */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Omoide Yokocho (Memory Lane)
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tucked directly beside Shinjuku Station's west exit, Omoide Yokocho — also
+              known by its less polite nickname "Piss Alley" — is a narrow strip of
+              yakitori stalls and tiny eateries that has survived since the post-war
+              black market era of the 1940s. The atmosphere is the real draw here: smoke
+              rising from charcoal grills, lanterns swaying overhead, the clatter of
+              beer glasses, and the rumble of trains passing just meters above. At sunset,
+              when the golden light filters through the steam and smoke, Omoide Yokocho
+              is one of the most photogenic spots in all of Tokyo.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">An honest assessment:</strong> The
+              atmosphere is far better than the food. The yakitori is decent but not
+              exceptional — you can find superior grilled chicken at dedicated yakitori
+              restaurants elsewhere in Shinjuku for similar prices. What you're paying
+              for here is the experience of eating elbow-to-elbow with salarymen on tiny
+              stools, under bare light bulbs, in a setting that looks like a movie set
+              from the 1950s. Is it worth it? Absolutely — just come with the right
+              expectations. Order a beer, a few skewers of chicken skin and tsukune
+              (chicken meatball), and soak in the ambiance. Budget around ¥1,500-2,500
+              per person for a few skewers and drinks.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Timing:</strong> Visit around 5-6 PM
+              to grab a seat easily and catch the sunset light. By 7 PM, the most
+              popular stalls are packed and you may have to wait. Late at night (after
+              10 PM), it thins out again and takes on a different, quieter charm.
+            </p>
+
+            {/* Shinjuku Gyoen */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Shinjuku Gyoen: An Unexpected Oasis
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              It seems impossible that one of Tokyo's most beautiful gardens sits just
+              a ten-minute walk from the chaos of Kabukicho, but that contrast is part
+              of what makes Shinjuku Gyoen special. Originally a feudal lord's residence
+              during the Edo period, then an imperial garden, Shinjuku Gyoen opened to
+              the public after World War II and now spans 144 acres of meticulously
+              maintained landscapes. The park blends three distinct garden styles —
+              formal French, English landscape, and traditional Japanese — each flowing
+              into the next so naturally you barely notice the transitions.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Cherry blossom season</strong> is when
+              Shinjuku Gyoen truly shines. While Ueno Park draws massive crowds that can
+              feel more like a music festival than a hanami (flower viewing) experience,
+              Shinjuku Gyoen enforces a strict no-alcohol policy and limits entry when
+              capacity is reached. The result is a far more peaceful blossom-viewing
+              experience. The park also has over a dozen cherry tree varieties that bloom
+              at different times from mid-March through late April, giving you a longer
+              viewing window than most other spots in the city.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Entry is ¥500 for adults, and the park is closed on Mondays (or the
+              following day if Monday is a holiday). Hours vary by season but generally
+              run from 9 AM to 4:30 PM (last entry at 4 PM). Bring a bento from a
+              nearby convenience store or depachika and have lunch on the great lawn —
+              it's the perfect midday break from Shinjuku's intensity. The greenhouse
+              near the main gate houses an impressive tropical plant collection if you
+              want to extend your visit.
+            </p>
+
+            {/* Kabukicho */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Kabukicho: Tokyo's Entertainment Capital
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Kabukicho is Shinjuku's entertainment district, and it wears its reputation
+              loudly. The giant neon gateway arch, the towering video screens, the
+              competing sounds from pachinko parlors and karaoke chains — it's Tokyo at
+              maximum volume. Despite its somewhat seedy reputation,{" "}
+              <strong className="text-foreground">Kabukicho is generally safe for
+              tourists</strong>, even late at night. The area has been heavily cleaned up
+              in recent years, with increased police presence and the development of
+              family-friendly entertainment complexes.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Scams to watch for:</strong> The main
+              risk in Kabukicho comes from touts — people on the street trying to lure
+              you into bars or clubs. The rule is simple: if someone approaches you on
+              the street, decline and keep walking. Legitimate establishments don't need
+              to recruit customers from the sidewalk. Be especially cautious of anyone
+              offering "free" drinks or suspiciously cheap deals — these almost always
+              lead to inflated bills. Stick to places you've researched in advance or
+              that have clearly posted prices, and you'll be fine.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              For entertainment, the area has plenty of legitimate and fun options. The
+              Godzilla head perched atop Hotel Gracery is a must-see landmark — the best
+              view is from the street below or from the hotel's terrace cafe on the 8th
+              floor, where you can get remarkably close to the beast. Karaoke is also a
+              quintessential Kabukicho experience — large chains like Big Echo and
+              Karaoke Kan (the one from <em>Lost in Translation</em>) offer private rooms
+              at reasonable rates, especially during daytime and early evening happy
+              hours. If you've heard of the Robot Restaurant, note that it closed
+              permanently in 2021. The space has been replaced by other entertainment
+              venues, but nothing quite matches the original's controlled absurdity.
+            </p>
+
+            {/* Where to Eat */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Where to Eat in Shinjuku
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Shinjuku has thousands of restaurants, which makes choosing one both
+              exciting and paralysing. Here are my top recommendations by category to
+              help you narrow it down.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Department Store Basement Food Halls (Depachika)
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The basement floors of Isetan, Takashimaya, and Odakyu department stores
+              are culinary wonderlands that most tourists walk right past. Japanese
+              department store food halls — called{" "}
+              <strong className="text-foreground">depachika</strong> — stock an
+              extraordinary range of prepared foods, bento boxes, wagashi (traditional
+              sweets), fresh produce, and gourmet treats, all presented with the kind
+              of care and artistry that makes you feel guilty eating them. Isetan's
+              basement in particular is legendary among food lovers. Prices are
+              reasonable for the quality — a beautifully composed bento box runs
+              ¥800-1,500, and you can assemble an incredible picnic for Shinjuku Gyoen
+              without spending much at all. Visit around 6-7 PM for discounted items
+              as stalls mark down unsold food before closing.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Ramen and Noodles
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Shinjuku is ramen territory. Rather than heading straight for the
+              well-known "ramen streets" that can have hour-long waits and cater
+              heavily to tourists, seek out standalone shops on the side streets east
+              of the station. Fuunji, located near the south exit, is famous for its
+              concentrated tsukemen (dipping noodles) and draws a constant line — but
+              it moves fast and the bowl is worth the wait. For a more traditional
+              Tokyo-style shoyu (soy sauce) ramen, the shops in the alleys behind the
+              east exit offer the real deal at honest prices, usually ¥900-1,200 per
+              bowl.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Late-Night Options
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              One of Shinjuku's greatest strengths is that it never truly closes. After
+              midnight, when the trains stop running and the crowds thin slightly,
+              Shinjuku's late-night dining scene comes alive for a different audience —
+              bartenders finishing their shifts, night workers, and night owls who know
+              that some of the best food appears after dark. Izakayas (Japanese pub-style
+              restaurants) throughout east Shinjuku serve food until 2-3 AM or later.
+              The 24-hour gyudon (beef bowl) chains like Matsuya and Yoshinoya are
+              reliable, cheap, and surprisingly satisfying at 3 AM. For something more
+              special, look for late-night sushi counters and ramen shops that cater
+              to the post-drinking crowd — the quality is often excellent because the
+              clientele is discerning.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Budget Tips
+            </h3>
+            <ul className="space-y-4 mb-8">
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Ticket machines:</strong> Many
+                ramen shops and casual restaurants use vending machine ordering. Buy
+                your ticket at the machine by the door, hand it to the staff, and sit
+                down. No Japanese required — most machines have photos.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Lunch sets:</strong> Visit
+                high-end restaurants at lunch instead of dinner. Many offer lunch
+                courses at 30-50% of dinner prices with the same kitchen and quality.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Convenience stores:</strong> Don't
+                overlook 7-Eleven, Lawson, and FamilyMart for genuinely good onigiri
+                (rice balls), sandwiches, and hot foods. Japanese convenience store
+                food is in a league of its own.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Standing bars (tachinomi):</strong>{" "}
+                These no-seat bars near the station offer drinks and small plates at
+                rock-bottom prices — a beer and a snack for under ¥500.
+              </li>
+            </ul>
+
+            {/* Practical Tips */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Practical Tips for Visiting Shinjuku
+            </h2>
+            <ul className="space-y-4 mb-8">
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Station navigation:</strong> Use
+                the east exit for Golden Gai, Kabukicho, and nightlife. Use the west
+                exit for the government building and skyscrapers. Use the new south
+                exit for Takashimaya Times Square and Shinjuku Gyoen.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Last train:</strong> Trains stop
+                around midnight. Check your last train time before heading out for
+                the evening. If you miss it, you have three options: a taxi (expensive,
+                ¥3,000-10,000 depending on distance), a manga cafe or capsule hotel
+                (¥1,500-3,000 to rest until the 5 AM first train), or simply staying
+                out all night — Shinjuku is one of the few places in Tokyo where this
+                is entirely viable.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Best time of day:</strong> Visit
+                Shinjuku Gyoen in the morning, explore the department stores and food
+                halls in the afternoon, hit Omoide Yokocho at sunset, and save Golden
+                Gai and Kabukicho for after dark. This sequence follows the natural
+                rhythm of the district.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Free observation deck:</strong> The
+                Tokyo Metropolitan Government Building observation decks are open until
+                11 PM (north tower) and 5:30 PM (south tower). No reservation needed,
+                no entry fee. The night view from the north tower is genuinely stunning
+                and rivals paid observation decks across the city.
+              </li>
+            </ul>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="text-2xl font-medium text-foreground mb-4">
+                Experience Shinjuku With a Local Who Knows Which Doors to Open
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                Shinjuku is best experienced with a local guide who can navigate the
+                hidden alleys, introduce you to welcoming bar owners in Golden Gai, and
+                steer you away from tourist traps. Whether you want a curated evening
+                through the neon-lit backstreets or a full-day exploration of the
+                district, we'll design something perfect for you.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/tours/custom" className="btn-accent">
+                  Design a Custom Evening Tour
+                </Link>
+                <Link to="/contact" className="btn-outline">
+                  Contact Us
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Shinjuku Guide — Tokyo's Neon-Lit Heart",
+            "description":
+              "Navigate Shinjuku like a local. A guide to Golden Gai, Omoide Yokocho, Kabukicho, Shinjuku Gyoen, and the best food spots in Tokyo's busiest district.",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+            },
+            "datePublished": "2026-02-25",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/shinjuku-guide",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default ShinjukuGuide;

--- a/src/pages/blog/TempleEtiquette.tsx
+++ b/src/pages/blog/TempleEtiquette.tsx
@@ -1,0 +1,346 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const TempleEtiquette = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Temple & Shrine Etiquette in Japan: Do's and Don'ts | Tanuki Tabi Travel"
+        description="Visiting temples and shrines in Japan? Learn the essential etiquette — how to pray, purify, bow, and behave respectfully from a licensed Japanese guide."
+        canonicalPath="/blog/japan-temple-shrine-etiquette"
+      />
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Planning Your Trip</p>
+            <h1 className="heading-display text-foreground">
+              Temple & Shrine Etiquette in Japan — A Complete Guide
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                February 25, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-4">
+              One of the most common questions I hear on my tours is: "Am I doing this right?" Whether it's standing at a shrine wondering how many times to clap, or hesitating at a temple entrance unsure whether to bow, visitors often worry about making mistakes at Japan's sacred sites. I completely understand the feeling — nobody wants to accidentally offend.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Here's the good news: Japanese people genuinely appreciate any effort you make to participate respectfully. You don't need to be perfect. The fact that you're reading this guide already shows the kind of thoughtfulness that locals notice and value. Most Japanese visitors themselves aren't entirely sure of every ritual detail — they simply approach these places with a quiet, sincere attitude.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              That said, knowing the basics will make your experience far more meaningful. Instead of standing awkwardly while others pray, you'll be able to join in and understand what you're doing. This guide covers everything you need to know — from the fundamental difference between temples and shrines, to step-by-step instructions for prayer, purification, and general behavior. Let's start with the most basic question of all.
+            </p>
+
+            {/* Temple vs Shrine */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Temple vs Shrine: What's the Difference?
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Before we dive into etiquette, it's essential to understand the distinction between temples and shrines, because the customs at each are different. This is the single most important thing to grasp, and once you do, everything else falls into place naturally.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Temples (寺 / tera)</strong> are Buddhist. You can identify them by their large entrance gates called <strong className="text-foreground">sanmon</strong>, the presence of incense burners, statues of Buddha or bodhisattvas, and pagodas. The atmosphere tends to be contemplative and quiet. Famous examples include Senso-ji in Asakusa, Kinkaku-ji (the Golden Pavilion) in Kyoto, and Kotoku-in in Kamakura, home to the Great Buddha. Temple names typically end in "-ji," "-dera," or "-in."
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Shrines (神社 / jinja)</strong> are Shinto, Japan's indigenous spiritual tradition. The unmistakable marker of a shrine is the <strong className="text-foreground">torii gate</strong> — that iconic vermillion gate you see in countless photos of Japan. You'll also notice shimenawa (sacred braided ropes), komainu (guardian lion-dog statues), and a distinctly open, nature-connected feel. Shrine names typically end in "-jinja," "-jingu," "-taisha," or "-gu." Meiji Shrine in Harajuku and Fushimi Inari in Kyoto are perhaps the most famous.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Here's something that surprises many visitors: <strong className="text-foreground">many sacred sites contain both a temple and a shrine</strong>. Buddhism and Shinto have coexisted in Japan for over a thousand years, and the two traditions often share the same grounds. A perfect example is the{" "}
+              <Link to="/tours/asakusa" className="text-accent hover:underline">
+                Asakusa area
+              </Link>
+              , where the famous Senso-ji Temple sits right next to Asakusa Shrine. They look similar at first glance, but the rituals are different — which is exactly why knowing the distinction matters.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              A simple rule of thumb: if you see a torii gate, it's a shrine. If you see a large Buddha statue or an incense burner, it's a temple. When in doubt, look for signage — most major sites have English-language information boards near the entrance.
+            </p>
+
+            {/* Shrine Step-by-Step */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              At a Shrine: Step-by-Step
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Shinto shrines follow a specific sequence of rituals that has remained largely unchanged for centuries. Here's the complete process from the moment you arrive to the moment you leave.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Entering Through the Torii Gate
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              As you approach the torii gate, pause briefly and offer a <strong className="text-foreground">shallow bow</strong> before passing through. This is your greeting to the kami (deity) who resides within the shrine grounds. Think of it as knocking before entering someone's home. Once through the gate, <strong className="text-foreground">walk along the sides of the approach path</strong>, not straight down the center. The center of the path, called the <strong className="text-foreground">sei-chu</strong>, is considered the pathway for the deity. Walking along the left or right side shows respect by leaving the deity's path clear. You'll notice that most Japanese visitors naturally drift to one side.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Temizu: The Hand-Washing Purification
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Before approaching the main hall, you'll find a water pavilion called the <strong className="text-foreground">temizuya</strong> (or chozuya). This is where you purify yourself before meeting the deity. The ritual represents washing away the impurities of the outside world. Here's the correct sequence:
+            </p>
+            <ul className="space-y-4 mb-8">
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Step 1:</strong> Pick up the ladle (hishaku) with your right hand and scoop water from the basin.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Step 2:</strong> Pour water over your left hand, letting it flow off your fingertips.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Step 3:</strong> Transfer the ladle to your left hand and pour water over your right hand.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Step 4:</strong> Transfer the ladle back to your right hand, cup a small amount of water in your left palm, and use it to rinse your mouth. (Do not drink directly from the ladle.) Quietly spit the water beside the basin, not back into it.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Step 5:</strong> Tilt the ladle vertically so the remaining water runs down the handle, cleaning it for the next person. Replace the ladle face-down on the stand.
+              </li>
+            </ul>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Don't worry about memorizing every detail — many temizuya now have instruction signs in English, and since the pandemic, some have been closed or simplified. If the water isn't flowing or the ladles have been removed, you can simply skip this step.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Prayer: Ni-hai, Ni-hakushu, Ichi-hai
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              At the main hall (haiden), you'll see a wooden offering box (saisen-bako) and a thick rope with a bell. Here's the standard prayer ritual:
+            </p>
+            <ul className="space-y-4 mb-8">
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Toss a coin</strong> into the offering box. A <strong className="text-foreground">¥5 coin</strong> is traditional — the word for five yen, "go-en," is a homophone for "good connection" or "good fortune." But any amount is fine.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Ring the bell</strong> by shaking the rope gently (if there is one). This alerts the deity to your presence.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Bow deeply twice</strong> (ni-hai) — about a 90-degree angle from the waist.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Clap your hands twice</strong> (ni-hakushu) — hold your hands at chest height and clap firmly. The sound is said to attract the deity's attention and express joy.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">With your hands together, offer a moment of silent prayer or reflection.</strong> You can make a wish, express gratitude, or simply clear your mind.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Bow deeply once more</strong> (ichi-hai) to conclude.
+              </li>
+            </ul>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The phrase to remember is <strong className="text-foreground">ni-hai, ni-hakushu, ichi-hai</strong> — two bows, two claps, one bow. A small number of shrines have their own variations (Izumo Taisha uses four claps instead of two), but 2-2-1 is correct at the vast majority of shrines across Japan.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Omikuji and Ema
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              After praying, many visitors enjoy two popular shrine activities. <strong className="text-foreground">Omikuji</strong> are paper fortune slips that you draw randomly (usually for ¥100-200). Fortunes range from dai-kichi (great blessing) to dai-kyo (great curse). If you draw a good fortune, keep it with you as a lucky charm. If you draw a bad fortune, the tradition is to <strong className="text-foreground">tie it to the designated wire rack or tree branches</strong> at the shrine, symbolically leaving the bad luck behind. The shrine's spiritual power is believed to neutralize it.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              <strong className="text-foreground">Ema</strong> are small wooden plaques where you write a wish or prayer. Purchase one from the shrine office (usually ¥500-1,000), write your wish on the blank side (it's perfectly fine to write in English — the kami understand all languages), and hang it on the designated ema rack. You'll see hundreds of wishes hanging together, which in itself is a beautiful sight. Take a moment to read some — you'll find everything from exam prayers to health wishes to marriage hopes, giving you a touching window into what matters to people.
+            </p>
+
+            {/* Temple Step-by-Step */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              At a Temple: Step-by-Step
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Buddhist temple etiquette overlaps with shrine customs in some ways but differs in several important respects. The overall atmosphere tends to be quieter and more contemplative, reflecting Buddhism's emphasis on inner peace and mindfulness.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Incense: Purifying with Smoke
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Many temples have a large incense burner (jokoro) near the entrance of the main hall. This is one of the most distinctive temple experiences. Purchase an incense stick from the nearby stand (usually ¥100), light it from the communal flame, and place it upright in the sand-filled burner. Then, use your hands to <strong className="text-foreground">waft the smoke toward yourself</strong>. The smoke is believed to have healing properties — direct it toward any part of your body that needs attention. Many visitors wave smoke toward their heads for wisdom, or toward an injured area for healing. You'll see local visitors doing this enthusiastically, and it's a lovely moment of shared ritual.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              An important note: when lighting incense, if the flame doesn't go out on its own, <strong className="text-foreground">wave the stick gently to extinguish the flame</strong> rather than blowing on it. In Japanese Buddhist tradition, blowing with your mouth is considered impure because breath carries the "impurities" of the body. This is a small detail, but one that locals will notice and appreciate.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Prayer: Silent and Respectful
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              At a temple, the prayer ritual is different from a shrine. Approach the main hall, toss a coin into the offering box, and then <strong className="text-foreground">press your palms together (gassho) and bow your head silently</strong>. Close your eyes and offer a moment of silent prayer or reflection. <strong className="text-foreground">Do not clap your hands</strong> — clapping is a Shinto tradition exclusive to shrines. This is the single most common mistake visitors make, and now that you know the difference, you'll be ahead of many tourists. At a temple: silence. At a shrine: clapping. Simple.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Some temples, particularly those in the Zen tradition, may also have specific seated meditation areas where you can sit quietly for a few minutes. If meditation sessions are offered, they're a wonderful way to experience Buddhist practice directly — but always follow the instructions of the temple staff.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Removing Shoes
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Many temples require you to <strong className="text-foreground">remove your shoes</strong> before entering indoor areas, particularly main halls, tatami rooms, and garden viewing areas. Look for rows of shoes near the entrance or a shoe rack — these are clear signals to remove yours. Most temples provide plastic bags to carry your shoes or have shoe lockers available. Wearing clean, hole-free socks is a practical tip that will save you potential embarrassment. In the colder months, temple floors can be quite cold, so warm socks are a genuine comfort.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Photography Rules
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Photography policies vary widely between temples. Outdoor areas and gardens are almost always fine to photograph. However, many temples <strong className="text-foreground">prohibit photography inside their main halls</strong>, particularly near altar areas and sacred statues. Always look for signage — a camera icon with a red line through it is universal. When in doubt, ask a staff member or a monk. Even where photography is permitted, use your camera respectfully: no flash, no selfie sticks near sacred objects, and no posing in ways that could be seen as disrespectful (leaning on statues, mimicking Buddhist poses as a joke, and so on). Silence your shutter sound as well — the repeated click of cameras in a quiet prayer hall is genuinely disruptive.
+            </p>
+
+            {/* General Etiquette */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              General Etiquette for Both Temples and Shrines
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Beyond the specific rituals at each type of sacred site, there are several universal rules of behavior that apply wherever you go. These are the basics that will carry you through any temple or shrine visit in Japan with confidence.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Dress Code
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Japan doesn't enforce strict dress codes at most temples and shrines the way some religious sites in other countries do. You won't be turned away for wearing shorts or a tank top. That said, <strong className="text-foreground">covering your shoulders and knees is considered respectful</strong> at major sites, especially if you plan to enter inner halls or attend a ceremony. Casual and comfortable clothing is absolutely fine — just avoid anything that could be considered overly revealing or disrespectful. Hats should be removed when entering indoor areas and during prayer.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Noise and Behavior
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Keep your voice low.</strong> Temples and shrines are places of worship, not tourist attractions — even though millions of tourists visit them. Many Japanese visitors come to pray sincerely, and a loud conversation can disrupt their experience. You don't need to whisper, but be conscious of your volume, especially inside halls and near prayer areas. Put your phone on silent. If you're traveling with children, gently encourage them to use indoor voices.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Offerings and Money
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              As mentioned earlier, <strong className="text-foreground">¥5 coins are considered the luckiest offering</strong> because "go-en" sounds like the Japanese word for "good connection" or "good fortune." Some people offer ¥50 (for extra luck) or ¥25 ("double good fortune"). Avoid ¥10 coins if you're superstitious — "to-en" can sound like "far connection," implying disconnection. In practice, any amount is perfectly acceptable and appreciated. Just be sure to have small coins ready before you approach the offering box — fumbling with your wallet in front of the prayer area holds up the line.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Things to Avoid
+            </h3>
+            <ul className="space-y-4 mb-8">
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Don't point at statues or sacred objects.</strong> Pointing is generally considered rude in Japan, and doubly so when directed at a deity or sacred image. If you need to indicate something, use an open hand.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Don't touch sacred objects</strong> unless explicitly invited to do so. Some temples have specific statues that visitors are encouraged to touch (like the healing smoke at Senso-ji), but these are clearly marked.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Don't eat or drink while walking</strong> within the temple or shrine grounds. This applies to water bottles as well — if you need a drink, step to the side and stand still. Eating while walking (tabearuki) is generally frowned upon in Japan, but it's especially inappropriate on sacred grounds.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Don't step on thresholds.</strong> When entering a temple gate or building, step over the raised wooden threshold at the bottom of the doorway, not on it. The threshold is considered a boundary between worlds, and stepping on it is disrespectful.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Don't litter or smoke</strong> on the grounds. This should go without saying, but it bears mentioning. Many temple and shrine grounds are maintained by volunteers and monks who take great pride in their cleanliness.
+              </li>
+            </ul>
+
+            {/* Famous Temples & Shrines */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Famous Temples & Shrines to Visit
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Now that you know the etiquette, where should you put it into practice? Here are some of Japan's most iconic sacred sites that we frequently visit on our tours — each offering a unique experience and a chance to apply what you've learned.
+            </p>
+            <ul className="space-y-4 mb-8">
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Senso-ji Temple, Asakusa</strong> — Tokyo's oldest and most visited temple, dating back to 645 AD. The massive Kaminarimon (Thunder Gate) with its enormous red lantern is one of Japan's most recognizable landmarks. The Nakamise-dori approach is lined with traditional shops selling snacks, souvenirs, and crafts. Despite the crowds, Senso-ji retains a powerful spiritual atmosphere, especially early in the morning or in the evening when the lanterns glow. Our{" "}
+                <Link to="/tours/asakusa" className="text-accent hover:underline">
+                  Asakusa walking tour
+                </Link>{" "}
+                includes both Senso-ji and the adjacent Asakusa Shrine, giving you the perfect chance to practice both temple and shrine etiquette in one visit.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Meiji Shrine, Harajuku</strong> — Dedicated to Emperor Meiji and Empress Shoken, this grand Shinto shrine sits in the middle of a 170-acre forest right in the heart of Tokyo. Walking through the towering torii gate and along the gravel path surrounded by ancient trees, you'll forget you're in one of the world's busiest cities. Meiji Shrine is ideal for experiencing the torii approach, temizu purification, and the full 2-2-1 prayer ritual. We visit on our{" "}
+                <Link to="/tours/shibuya-harajuku" className="text-accent hover:underline">
+                  Shibuya & Harajuku tour
+                </Link>
+                , combining the shrine experience with the electric energy of Takeshita Street and Shibuya Crossing.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Tsurugaoka Hachimangu, Kamakura</strong> — The most important shrine in Kamakura, originally established in 1063. A dramatic, tree-lined approach road leads from the coast up to the hillside shrine, passing through massive torii gates. The shrine is dedicated to Hachiman, the patron deity of warriors, and its history is deeply intertwined with the samurai culture of medieval Japan. Explore it on our{" "}
+                <Link to="/tours/kamakura-day-trip" className="text-accent hover:underline">
+                  Kamakura day trip
+                </Link>
+                , which also includes the Great Buddha and serene bamboo groves.
+              </li>
+              <li className="text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Toshogu Shrine, Nikko</strong> — A UNESCO World Heritage Site and the most lavishly decorated shrine in all of Japan. Built as the mausoleum of Tokugawa Ieyasu, the founder of the Tokugawa shogunate, Toshogu features over 5,000 intricate carvings including the famous "see no evil, speak no evil, hear no evil" monkeys and the legendary Sleeping Cat (Nemuri-neko). The artistry here is staggering, and a guide is essential to decode the layers of symbolism in every panel. Join our{" "}
+                <Link to="/tours/nikko-day-trip" className="text-accent hover:underline">
+                  Nikko day trip
+                </Link>{" "}
+                to experience this masterpiece along with stunning natural scenery.
+              </li>
+            </ul>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="text-2xl font-medium text-foreground mb-4">
+                Want to experience temples and shrines with a guide who explains every ritual?
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                Knowing the etiquette is one thing — having someone beside you to explain the history, symbolism, and hidden details brings these sacred sites to life. On our tours, I walk you through every step of the rituals, share stories that guidebooks miss, and answer all your questions in real time. Whether it's your first shrine visit or your tenth, there's always something new to discover.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/tours" className="btn-accent">
+                  Browse Walking Tours
+                </Link>
+                <Link to="/contact" className="btn-outline">
+                  Contact Us
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Temple & Shrine Etiquette in Japan — A Complete Guide",
+            "description": "Visiting temples and shrines in Japan? Learn the essential etiquette — how to pray, purify, bow, and behave respectfully from a licensed Japanese guide.",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+            },
+            "datePublished": "2026-02-25",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default TempleEtiquette;

--- a/src/pages/blog/Tokyo3DayItinerary.tsx
+++ b/src/pages/blog/Tokyo3DayItinerary.tsx
@@ -62,7 +62,11 @@ const Tokyo3DayItinerary = () => {
               Morning: Asakusa — Where Old Tokyo Lives
             </h3>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              Start your Tokyo journey where the city itself began — Asakusa. This neighborhood is home to Senso-ji, Tokyo's oldest temple, founded in the 7th century. Walk through the iconic Kaminarimon (Thunder Gate) and down Nakamise-dori, a shopping street that has been serving visitors for centuries.
+              Start your Tokyo journey where the city itself began — Asakusa. This neighborhood is home to Senso-ji, Tokyo's oldest temple, founded in the 7th century. Walk through the iconic Kaminarimon (Thunder Gate) and down Nakamise-dori, a shopping street that has been serving visitors for centuries. For a deeper dive into the area, read our{" "}
+              <Link to="/blog/asakusa-guide-what-to-see" className="text-accent hover:underline">
+                complete Asakusa guide
+              </Link>
+              .
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
               <strong className="text-foreground">Local tip:</strong> Arrive before 9 AM to experience Senso-ji without the crowds. The morning light through the incense smoke creates a magical atmosphere that you simply cannot get later in the day. The temple grounds are open 24 hours, but the Nakamise shops open around 10 AM — so you get the best of both worlds if you time it right.
@@ -138,7 +142,11 @@ const Tokyo3DayItinerary = () => {
               Late Morning: Harajuku — Youth Culture Explosion
             </h3>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              From Meiji Shrine's southern exit, you'll emerge directly onto Harajuku's famous Takeshita Street — one of the most dramatic transitions in Tokyo. In seconds, you go from a 100-year-old shrine forest to a neon-lit street packed with crepe shops, vintage clothing stores, and Japanese pop culture.
+              From Meiji Shrine's southern exit, you'll emerge directly onto Harajuku's famous Takeshita Street — one of the most dramatic transitions in Tokyo. In seconds, you go from a 100-year-old shrine forest to a neon-lit street packed with crepe shops, vintage clothing stores, and Japanese pop culture. See our{" "}
+              <Link to="/blog/shibuya-harajuku-guide" className="text-accent hover:underline">
+                Shibuya & Harajuku guide
+              </Link>{" "}
+              for all the insider tips.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
               Walk Takeshita Street for the sensory overload, then head to Omotesando — often called "Tokyo's Champs-Élysées" — for world-class architecture by Tadao Ando, Kengo Kuma, and Toyo Ito. The contrast between Harajuku's kawaii culture and Omotesando's sleek sophistication tells you everything about Tokyo's ability to contain multitudes.
@@ -172,7 +180,11 @@ const Tokyo3DayItinerary = () => {
               Evening: Shinjuku Nightlife
             </h3>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              End day two in Shinjuku, Tokyo's entertainment capital. For drinks, head to Golden Gai — a tiny network of over 200 small bars, each seating about 6-8 people. It's intimate, quirky, and a completely unique experience. Look for bars with English menus or "Foreigner Welcome" signs if you're nervous about the language barrier.
+              End day two in Shinjuku, Tokyo's entertainment capital. For drinks, head to Golden Gai — a tiny network of over 200 small bars, each seating about 6-8 people. It's intimate, quirky, and a completely unique experience. Look for bars with English menus or "Foreigner Welcome" signs if you're nervous about the language barrier. Read our{" "}
+              <Link to="/blog/shinjuku-guide" className="text-accent hover:underline">
+                complete Shinjuku guide
+              </Link>{" "}
+              for more details on Golden Gai etiquette and the best food spots.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
               For dinner, try Omoide Yokocho ("Memory Lane") — a narrow alley of yakitori (grilled chicken) stalls that has been serving workers since the 1940s. It's smoky, crowded, and absolutely authentic. Vegetarians should note that options are limited here, but nearby Shinjuku has restaurants for every dietary need.
@@ -187,7 +199,11 @@ const Tokyo3DayItinerary = () => {
               Option A: Central Tokyo — Food, Gardens & History
             </h3>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              <strong className="text-foreground">Morning — Tsukiji Outer Market:</strong> Even though the inner wholesale market moved to Toyosu, Tsukiji Outer Market is still the best food destination in Tokyo. Arrive by 8-9 AM for the freshest offerings: sushi for breakfast (yes, it's a thing), tamagoyaki (Japanese omelet), fresh oysters, and wagyu beef skewers. Take your time and graze — it's the best way to experience the market.
+              <strong className="text-foreground">Morning — Tsukiji Outer Market:</strong> Even though the inner wholesale market moved to Toyosu, Tsukiji Outer Market is still the best food destination in Tokyo. Arrive by 8-9 AM for the freshest offerings: sushi for breakfast (yes, it's a thing), tamagoyaki (Japanese omelet), fresh oysters, and wagyu beef skewers. Take your time and graze — it's the best way to experience the market. Check our{" "}
+              <Link to="/blog/tsukiji-guide-food-lover" className="text-accent hover:underline">
+                Tsukiji food lover's guide
+              </Link>{" "}
+              for what to eat and what to skip.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
               For a guided food exploration, our{" "}
@@ -265,7 +281,11 @@ const Tokyo3DayItinerary = () => {
               Tokyo is a year-round destination. Spring (March-May) brings cherry blossoms and pleasant weather. Summer (June-August) is hot and humid but offers festivals and fireworks. Autumn (October-November) has stunning foliage and comfortable temperatures. Winter (December-February) is cold but clear, with fewer tourists and beautiful illuminations.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              Peak tourist seasons are cherry blossom season (late March to mid-April) and autumn foliage (mid-November to early December). Book accommodations and tours early during these periods. Golden Week (late April to early May) is a Japanese national holiday — domestic travel peaks and some businesses close.
+              Peak tourist seasons are cherry blossom season (late March to mid-April) and autumn foliage (mid-November to early December). Book accommodations and tours early during these periods. Golden Week (late April to early May) is a Japanese national holiday — domestic travel peaks and some businesses close. For a detailed month-by-month breakdown, see our{" "}
+              <Link to="/blog/best-time-to-visit-tokyo" className="text-accent hover:underline">
+                Best Time to Visit Tokyo guide
+              </Link>
+              .
             </p>
 
             <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
@@ -279,7 +299,11 @@ const Tokyo3DayItinerary = () => {
               Temple & Shrine Etiquette
             </h3>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              At shrines: bow slightly before passing through the torii gate, walk on the sides (the center path is for the deity), purify your hands at the water basin, and bow-clap-bow when praying. At temples: remove shoes when entering buildings, don't point at statues, and speak quietly. Your guide will explain all customs in detail, but these basics will help you feel confident.
+              At shrines: bow slightly before passing through the torii gate, walk on the sides (the center path is for the deity), purify your hands at the water basin, and bow-clap-bow when praying. At temples: remove shoes when entering buildings, don't point at statues, and speak quietly. Your guide will explain all customs in detail, but these basics will help you feel confident. For the full step-by-step guide, read our{" "}
+              <Link to="/blog/japan-temple-shrine-etiquette" className="text-accent hover:underline">
+                Temple & Shrine Etiquette guide
+              </Link>
+              .
             </p>
             <p className="text-muted-foreground leading-relaxed mb-8">
               The most important thing is simply to be respectful and observant. Japanese people are incredibly welcoming to tourists who show an interest in their culture, even if you don't get every custom perfectly right.

--- a/src/pages/blog/TsukijiGuide.tsx
+++ b/src/pages/blog/TsukijiGuide.tsx
@@ -1,0 +1,233 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const TsukijiGuide = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Tsukiji Market Guide for Food Lovers | What to Eat & Skip | Tanuki Tabi Travel"
+        description="A local guide to Tsukiji Outer Market. What to eat, what to skip, best times to visit, and how to combine with Ginza for a perfect Tokyo food day."
+        canonicalPath="/blog/tsukiji-guide-food-lover"
+      />
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Tokyo Area Guides</p>
+            <h1 className="heading-display text-foreground">
+              Tsukiji Market Guide — A Food Lover's Walkthrough
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                February 25, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-4">
+              If you love food — and I mean truly love food, not just eating but understanding where it comes from and how it's prepared — then Tsukiji Outer Market deserves a spot near the top of your Tokyo itinerary. Yes, the famous inner wholesale market moved to Toyosu in 2018, and yes, you'll still hear people say "Tsukiji is closed." They're wrong. The outer market is alive, thriving, and arguably better for visitors than the old wholesale floor ever was.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              As a licensed guide who walks through Tsukiji several times each week, I've watched the market evolve over the years. Some of the old wholesale vendors have gone, but the roughly 400 shops and restaurants that make up the outer market have only gotten better at serving food lovers. The stalls are more accessible, the variety is extraordinary, and the quality of what you can eat here — often prepared right in front of you — rivals or surpasses many sit-down restaurants in the city.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              This guide is everything I tell my tour guests before we walk through the market together. I'll cover what to eat, what to skip, when to go, and how to combine Tsukiji with a stroll through nearby Ginza for a perfect Tokyo food day.
+            </p>
+
+            {/* Tsukiji vs Toyosu */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Tsukiji vs Toyosu: Which Should You Visit?
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              This is the question I get asked most often, so let me clear it up. <strong className="text-foreground">Tsukiji Outer Market</strong> and <strong className="text-foreground">Toyosu Market</strong> are two completely different experiences, and choosing between them depends on what you're looking for.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tsukiji Outer Market is a dense, walkable network of narrow lanes packed with food stalls, specialty shops, and small restaurants. You can walk in at any time during opening hours — no reservation needed. The experience is tactile and immediate: you'll smell grilled seafood, watch vendors slice fish with extraordinary precision, sample fresh tamagoyaki straight off the grill, and eat some of the best sushi of your life standing at a counter barely wide enough for your elbows. It's chaotic, intimate, and completely authentic.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Toyosu Market, on the other hand, is the modern wholesale facility that replaced Tsukiji's inner market. The main draw is the <strong className="text-foreground">tuna auction</strong> — a genuinely fascinating spectacle where multi-million-yen bluefin tuna are sold in minutes. However, viewing requires an online reservation that books up quickly, and the market itself is viewed from behind glass observation decks. There are some restaurants inside Toyosu, but the food variety and street-food atmosphere don't compare to Tsukiji.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              My recommendation: <strong className="text-foreground">visit Tsukiji for the food experience</strong>. If you're a serious seafood enthusiast and can secure a tuna auction reservation at Toyosu, add that as a separate early-morning trip. But for most food lovers, Tsukiji delivers a far more satisfying and memorable experience.
+            </p>
+
+            {/* What to Eat */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              What to Eat at Tsukiji
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              With hundreds of stalls competing for your attention (and your appetite), knowing what to prioritize makes the difference between a good visit and an extraordinary one. Here's what I recommend to every guest, along with the insider details that help you choose wisely.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Fresh Sushi — Stand-Up vs Sit-Down
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tsukiji has both stand-up sushi counters and proper sit-down sushi restaurants, and both can be excellent. The stand-up spots (tachigui-zushi) tend to be faster and cheaper — you'll pay around 2,000 to 3,000 yen for a solid set of 8 to 10 pieces. The experience is quintessentially Japanese: elbow to elbow with salarymen on their lunch break, watching the itamae (sushi chef) shape each piece by hand inches from your face. The fish is absurdly fresh because many of these restaurants source directly from the market's wholesalers every morning.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Sit-down restaurants offer a more relaxed experience with higher-end selections. Expect to pay 3,000 to 6,000 yen for an omakase (chef's choice) set. Some of these restaurants, like Sushi Dai and Daiwa Sushi, became famous worldwide and can have queues of two hours or more. Honestly, the quality difference between the famous spots and the lesser-known counters is marginal — you're paying for the name, not the fish. I'll share which specific stalls I recommend on our walking tour.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Tamagoyaki (Japanese Egg Omelette)
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tsukiji's tamagoyaki is legendary, and for good reason. These thick, slightly sweet Japanese omelettes are grilled in special rectangular pans right in front of you, layer by layer, resulting in a pillowy, caramelized block of egg that's nothing like what you'd find in a Western kitchen. The two most famous shops — Yamachou and Shouro — have been perfecting their recipes for decades. Yamachou tends toward a sweeter, dessert-like style, while Shouro offers a more savory, dashi-forward version. Try both if you can. A stick of tamagoyaki costs around 100 to 200 yen, making it one of the best bargains in the entire market.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Grilled Seafood Skewers
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Walking through Tsukiji's outer lanes, you'll encounter stall after stall of grilled seafood on skewers — scallops, squid, king crab legs, prawns, and seasonal fish. The best stalls grill to order, so the seafood is piping hot and slightly charred on the outside while remaining tender and juicy inside. Look for stalls where you can see the actual raw product before it hits the grill — this is a sign of freshness and confidence. <strong className="text-foreground">Giant Hokkaido scallops</strong> (hotate) are a standout, typically grilled with a touch of soy sauce and butter. At around 500 to 800 yen per skewer, they're not the cheapest snack, but the size and quality make them absolutely worth it.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Uni (Sea Urchin)
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you've never tried fresh uni, Tsukiji is the place to have your first experience. The difference between good uni and mediocre uni is enormous — fresh, high-quality uni should taste sweet and briny, like the ocean distilled into a creamy, custard-like morsel. Bad uni tastes metallic and bitter. Here's how to pick the good stuff: <strong className="text-foreground">look for uni that's bright orange or golden yellow</strong>, with firm, distinct lobes that hold their shape. Avoid anything that looks mushy, watery, or brownish. Many stalls sell individual uni boxes where you can inspect the product before buying. Expect to pay 500 to 1,500 yen depending on the grade and origin — Hokkaido uni is generally considered the finest, but Sanriku (from the northeast coast) is excellent too and often less expensive.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Wagyu Beef on a Stick
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tsukiji isn't just seafood. Several stalls specialize in grilled wagyu beef skewers, and the quality can be outstanding. The best vendors use A4 or A5 grade wagyu — the same quality served in high-end yakiniku restaurants — grilled over charcoal and seasoned simply with salt or a light soy glaze. A single skewer typically costs 800 to 1,500 yen depending on the cut and grade. The marbling melts on your tongue in a way that regular beef simply cannot replicate. It's an indulgence, but this is Tsukiji — indulgence is the point.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Matcha Desserts
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              After all that savory food, you'll want something sweet, and Tsukiji delivers here too. Several shops specialize in matcha soft serve, matcha daifuku (mochi stuffed with sweet red bean paste and matcha cream), and matcha tiramisu. Matsueda is one of my favorites — their matcha soft serve uses high-grade Uji matcha from Kyoto, and the flavor is intense, slightly bitter, and deeply aromatic. A cone costs around 400 to 500 yen. There are also excellent dorayaki (pancake sandwiches with red bean filling) and fresh fruit mochi if matcha isn't your thing.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              What to Skip
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Not everything at Tsukiji is worth your stomach space. <strong className="text-foreground">Be cautious of the sushi restaurants with aggressive touts standing outside</strong> trying to pull you in — the best sushi spots at Tsukiji don't need to recruit customers from the street. Also skip the pre-packaged sushi trays wrapped in plastic that some shops sell near the market's outer edges. These are made in advance and can sit for hours. At a market where freshness is the whole point, eating sushi that was prepared at 6 AM and sits until noon defeats the purpose entirely. Finally, avoid the overpriced "luxury" seafood bowls (kaisen-don) that cost 4,000 to 5,000 yen at the tourist-heavy entrances — you can get equal or better quality deeper inside the market for half the price.
+            </p>
+
+            {/* When to Go */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              When to Go
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Timing matters enormously at Tsukiji. The outer market is a working market, not a theme park, and its rhythms reflect the fishing industry that created it. <strong className="text-foreground">The best time to visit is weekday mornings between 9:00 and 11:00 AM.</strong> At this hour, all the stalls are open and fully stocked, the grills are hot, the fish is at peak freshness, and the crowds haven't yet reached their midday peak. You'll have room to browse, ask questions, and eat without feeling rushed.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Avoid weekends if at all possible.</strong> Saturday mornings bring both tourists and local shoppers, and the narrow lanes become genuinely congested. It's still a worthwhile experience, but you'll spend more time navigating crowds than enjoying food. Sunday is a different problem entirely — <strong className="text-foreground">most stalls are closed on Sundays</strong>, so a Sunday visit will be disappointing. Some Wednesdays also see partial closures, as individual shops set their own schedules.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              Many stalls begin closing by 1:00 to 2:00 PM, and by 3:00 PM the market is largely shut down. If you arrive after noon, you'll find reduced selection and some of the best items already sold out. Plan your visit as a morning activity, arrive hungry, and give yourself at least 90 minutes to two hours for a thorough walkthrough.
+            </p>
+
+            {/* Combine with Ginza */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Combine with Ginza for the Perfect Half-Day
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              One of Tsukiji's greatest advantages is its location. <strong className="text-foreground">Ginza, Tokyo's most elegant shopping and cultural district, is just a 10-minute walk away.</strong> This makes for a natural and satisfying half-day itinerary: spend the morning eating your way through Tsukiji, then stroll into Ginza for a completely different Tokyo experience in the afternoon.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The walk between the two areas takes you along Harumi-dori street, crossing from the market's bustling, utilitarian atmosphere into Ginza's world of polished architecture and luxury boutiques. The contrast is striking and intentional — it's one of my favorite transitions in all of Tokyo. In Ginza, you can admire the stunning architecture of buildings like the Ginza Six complex and the Mikimoto flagship store, browse the legendary Wako department store with its iconic clock tower, or peek inside the traditional Kabuki-za Theater, even if you're not attending a full performance (single-act tickets are available and surprisingly affordable).
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Ginza is also home to some of Tokyo's finest kissaten (traditional coffee houses), where you can sit down with a perfectly brewed pour-over coffee and reflect on the morning's culinary adventures. This morning-Tsukiji-to-afternoon-Ginza route is exactly what we cover in our{" "}
+              <Link to="/tours/tsukiji-ginza" className="text-accent hover:underline">
+                Tsukiji & Ginza Walking Tour
+              </Link>
+              , and it's one of our most popular itineraries for a reason — it packs two of Tokyo's most distinctive neighborhoods into a single, seamless experience.
+            </p>
+
+            {/* Toyosu Quick Overview */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Toyosu Market: Quick Overview
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you're a serious seafood enthusiast and the tuna auction is on your bucket list, Toyosu Market is worth the effort — but it requires planning. The market is located on a man-made island in Tokyo Bay, accessible via the Yurikamome Line (get off at Shijo-mae Station). The entire journey from central Tokyo takes about 30 to 40 minutes depending on your starting point.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The <strong className="text-foreground">tuna auction viewing</strong> is the main reason to visit. It takes place in the early morning hours, typically starting around 5:30 AM, and visitors watch from a glass-enclosed observation deck above the auction floor. <strong className="text-foreground">Reservations must be made online in advance</strong> through the Tokyo Metropolitan Government's website, and popular dates fill up weeks ahead. Without a reservation, you can still visit the market's observation corridors to watch the wholesale operations through glass walls, but you won't see the auction itself.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              Toyosu also has a restaurant area with sushi shops and seafood restaurants that are generally very good — many are run by the same families who operated at the old Tsukiji inner market. However, the atmosphere is sterile and institutional compared to Tsukiji's organic charm. If you only have time for one, choose Tsukiji. If you have time for both, do the Toyosu auction at dawn and Tsukiji for brunch — it makes for an unforgettable food morning.
+            </p>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="text-2xl font-medium text-foreground mb-4">
+                Want a local food expert to guide you through Tsukiji's best stalls?
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                On our Tsukiji & Ginza Walking Tour, I'll take you to the stalls the guidebooks miss, help you navigate the market's maze of lanes, and make sure you eat the freshest, best-value food available that morning. We'll finish with a leisurely walk through Ginza's elegant streets. No tourist traps, no wasted bites — just the real Tsukiji experience.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/tours/tsukiji-ginza" className="btn-accent">
+                  Book Tsukiji & Ginza Tour
+                </Link>
+                <Link to="/contact" className="btn-outline">
+                  Ask a Question
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Tsukiji Market Guide — A Food Lover's Walkthrough",
+            "description": "A local guide to Tsukiji Outer Market. What to eat, what to skip, best times to visit, and how to combine with Ginza for a perfect Tokyo food day.",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+            },
+            "datePublished": "2026-02-25",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/tsukiji-guide-food-lover",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default TsukijiGuide;

--- a/src/pages/tours/TokyoFoodTour.tsx
+++ b/src/pages/tours/TokyoFoodTour.tsx
@@ -1,0 +1,491 @@
+import { Link } from "react-router-dom";
+import {
+  ArrowRight,
+  UtensilsCrossed,
+  MapPin,
+  Clock,
+  Users,
+  Heart,
+  Sparkles,
+  ShieldCheck,
+  Leaf,
+  WheatOff,
+  AlertTriangle,
+  Check,
+  X,
+  BookOpen,
+} from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const features = [
+  {
+    icon: Heart,
+    title: "Not a Fixed Menu",
+    description:
+      "Your guide adapts to your tastes and dietary needs in real time. Love spicy food? We'll find the best tantanmen shop. Prefer sweets? We'll detour to a hidden wagashi artisan. This tour is built around you.",
+  },
+  {
+    icon: MapPin,
+    title: "Local Spots Only",
+    description:
+      "No tourist-trap restaurants with plastic food displays and English menus marked up 40%. We go where locals eat — the ramen counter with eight stools, the tempura shop that's been family-run for three generations.",
+  },
+  {
+    icon: BookOpen,
+    title: "Cultural Context",
+    description:
+      "Learn why each dish matters. Why is tsukemono served with every meal? What makes Edomae sushi different? How did ramen go from Chinese import to Japanese obsession? Every bite comes with a story.",
+  },
+  {
+    icon: Sparkles,
+    title: "Flexible Timing",
+    description:
+      "Choose a morning market crawl starting at dawn, a midday lunch tour through bustling neighborhoods, or an evening izakaya hop through lantern-lit alleyways. Your schedule, your pace.",
+  },
+];
+
+const foodExperiences = [
+  {
+    title: "Tsukiji Outer Market Morning Crawl",
+    foods: "Sushi, tamagoyaki, seafood skewers, fresh wasabi",
+    description:
+      "Start your day where Tokyo's chefs start theirs. The Tsukiji Outer Market is still the beating heart of Tokyo's food culture, even after the inner wholesale market moved to Toyosu. We'll navigate the narrow lanes together, tasting freshly grilled scallops from vendors who've been here for decades, watching masters slice maguro with single-stroke precision, and trying tamagoyaki — the sweet, layered egg omelet that's been perfected here over generations. Your guide will explain the market's 90-year history and help you order confidently at stalls where the menu is only in Japanese.",
+  },
+  {
+    title: "Asakusa Traditional Street Food",
+    foods: "Ningyo-yaki, melon-pan, hand-pulled soba, age-manju",
+    description:
+      "Asakusa is Tokyo's old downtown, and its food reflects centuries of tradition. Along Nakamise Street and the surrounding backstreets, we'll try ningyo-yaki — small cakes filled with sweet red bean paste, baked in molds shaped like the Seven Lucky Gods. We'll find the best melon-pan (crispy-topped sweet bread) fresh from the oven, visit a soba shop where noodles are still made by hand daily, and discover age-manju — deep-fried steamed buns with a satisfying crunch that gives way to soft, sweet filling. This is comfort food with centuries of history behind it.",
+  },
+  {
+    title: "Ramen Discovery Tour",
+    foods: "Tonkotsu, shoyu, miso, tsukemen, gyoza",
+    description:
+      "Tokyo is arguably the ramen capital of the world, with over 10,000 ramen shops across the city. Each neighborhood has its loyalties, each shop its closely guarded recipe. We'll explore the major styles — rich, creamy tonkotsu from Kyushu, clear and elegant shoyu from Tokyo's own tradition, bold miso ramen born in Hokkaido — and we'll visit shops where the master has spent years perfecting a single bowl. Your guide will teach you proper ramen etiquette (yes, slurping is not just acceptable, it's expected) and help you customize your order with confidence.",
+  },
+  {
+    title: "Izakaya Evening Experience",
+    foods: "Yakitori, sake flights, edamame, karaage, small plates",
+    description:
+      "As the lanterns flicker on in Tokyo's yokocho (alleyway bar districts), a different food world comes alive. Izakaya are Japan's answer to the gastropub — informal, convivial, and bursting with flavor. We'll visit izakaya where salarymen unwind after work, tasting perfectly charcoal-grilled yakitori (each cut of chicken has its own name and ideal preparation), sipping through a curated sake flight, and sharing small plates that showcase seasonal ingredients. Your guide handles all ordering and explains the unwritten rules that make izakaya culture uniquely Japanese.",
+  },
+  {
+    title: "Depachika Tour",
+    foods: "Wagashi, bento boxes, French pastries, pickles, seasonal sweets",
+    description:
+      "The basement floors of Tokyo's department stores — known as depachika — are food wonderlands that most tourists walk right past. These are not ordinary food courts. They're curated collections of Japan's finest food artisans, from wagashi (traditional sweets) makers who've held imperial warrants for centuries to French-trained pastry chefs creating Tokyo-exclusive confections. We'll sample our way through exquisite bento boxes, discover regional specialties from across Japan, and find the perfect edible souvenirs to bring home.",
+  },
+];
+
+const dietaryOptions = [
+  {
+    icon: Leaf,
+    title: "Vegetarian & Vegan",
+    description:
+      "Tokyo's food scene has embraced plant-based dining with creativity and care. We know shojin ryori (Buddhist temple cuisine) restaurants, dedicated vegan ramen shops, and traditional spots that naturally feature vegetable-forward dishes. Your guide ensures every stop works for you.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Halal",
+    description:
+      "Finding halal food in Tokyo can be challenging without local knowledge. We'll guide you to certified halal restaurants and street food vendors, and we know which traditional dishes are naturally halal-friendly. No guesswork, no language barriers.",
+  },
+  {
+    icon: WheatOff,
+    title: "Gluten-Free",
+    description:
+      "Soy sauce is in almost everything in Japanese cooking, and it contains wheat. But with a knowledgeable guide, gluten-free dining in Tokyo is absolutely possible. We'll navigate menus, communicate with chefs, and find naturally gluten-free options like sashimi, rice dishes, and yakitori with salt seasoning.",
+  },
+  {
+    icon: AlertTriangle,
+    title: "Allergies & Restrictions",
+    description:
+      "Shellfish, nuts, eggs, dairy — whatever your allergy, your guide will communicate directly with each vendor and restaurant in Japanese to ensure your safety. We carry allergy cards in Japanese and know how to ask the right questions. Your peace of mind is non-negotiable.",
+  },
+];
+
+const relatedTours = [
+  {
+    title: "Tsukiji & Ginza Tour",
+    path: "/tours/tsukiji-ginza",
+    description: "Explore Tsukiji Market's food culture and Ginza's upscale dining scene.",
+  },
+  {
+    title: "Custom Private Tour",
+    path: "/tours/custom",
+    description: "Build a fully personalized Tokyo experience around your interests.",
+  },
+  {
+    title: "Asakusa Walking Tour",
+    path: "/tours/asakusa",
+    description: "Discover old Tokyo's temples, streets, and traditional food culture.",
+  },
+];
+
+const relatedArticles = [
+  {
+    title: "A Food Lover's Guide to Tsukiji Market",
+    path: "/blog/tsukiji-guide-food-lover",
+    description: "What to eat, when to go, and how to navigate Tokyo's iconic market.",
+  },
+  {
+    title: "What to See in Asakusa — A Local's Guide",
+    path: "/blog/asakusa-guide-what-to-see",
+    description: "Temple visits, street food, and hidden spots most tourists miss.",
+  },
+];
+
+const TokyoFoodTour = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Tokyo Food Tour | Private Guided Food Experience | Tanuki Tabi Travel"
+        description="Taste Tokyo's best food with a local licensed guide. From Tsukiji street food to hidden ramen shops, customize your private food tour experience."
+        canonicalPath="/tours/tokyo-food-tour"
+      />
+
+      {/* Hero Section */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-2xl">
+            <p className="text-label text-accent mb-3">Food Tours</p>
+            <h1 className="heading-display text-foreground">
+              Tokyo Private Food Tour
+            </h1>
+            <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
+              Discover Tokyo's culinary soul — from street food stalls to
+              neighborhood favorites. A private, guided journey through the
+              flavors that define this city, tailored entirely to your tastes.
+            </p>
+            <div className="mt-8">
+              <Link to="/contact" className="btn-accent">
+                Book Your Food Tour
+                <ArrowRight className="ml-2 w-4 h-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* What Makes This Tour Special */}
+      <section className="py-16">
+        <div className="container-section">
+          <div className="text-center max-w-2xl mx-auto mb-12">
+            <p className="text-label text-accent mb-3">Why This Tour</p>
+            <h2 className="heading-section text-foreground">
+              What Makes This Tour Special
+            </h2>
+            <p className="mt-4 text-body">
+              This is not a cookie-cutter food tour with fixed stops and a
+              rehearsed script. It is a personalized food adventure guided by
+              someone who knows where locals actually eat.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+            {features.map((feature) => (
+              <div
+                key={feature.title}
+                className="card-elevated p-6 text-center"
+              >
+                <div className="w-14 h-14 rounded-full bg-accent/10 flex items-center justify-center mx-auto mb-4">
+                  <feature.icon className="w-7 h-7 text-accent" />
+                </div>
+                <h3 className="heading-card text-foreground mb-2">
+                  {feature.title}
+                </h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {feature.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Sample Food Experiences */}
+      <section className="py-16 bg-secondary/30">
+        <div className="container-section">
+          <div className="text-center max-w-2xl mx-auto mb-12">
+            <p className="text-label text-accent mb-3">Taste Tokyo</p>
+            <h2 className="heading-section text-foreground">
+              Sample Food Experiences
+            </h2>
+            <p className="mt-4 text-body">
+              Every food tour is customized, but here are some of the
+              experiences we can build your day around. Mix and match, or let
+              your guide surprise you.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {foodExperiences.map((experience) => (
+              <div key={experience.title} className="card-elevated">
+                <div className="p-6">
+                  <div className="flex items-center gap-2 mb-3">
+                    <UtensilsCrossed className="w-5 h-5 text-accent flex-shrink-0" />
+                    <h3 className="heading-card text-foreground">
+                      {experience.title}
+                    </h3>
+                  </div>
+                  <p className="text-xs text-accent font-medium uppercase tracking-widest mb-3">
+                    {experience.foods}
+                  </p>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    {experience.description}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Dietary Accommodations */}
+      <section className="py-16">
+        <div className="container-section">
+          <div className="text-center max-w-2xl mx-auto mb-12">
+            <p className="text-label text-accent mb-3">Everyone Welcome</p>
+            <h2 className="heading-section text-foreground">
+              Dietary Accommodations
+            </h2>
+            <p className="mt-4 text-body">
+              Navigating dietary restrictions in Japan can feel daunting — the
+              language barrier is real, ingredients are not always obvious, and
+              many dishes contain hidden allergens. That is exactly why having a
+              local guide matters. We handle everything so you can eat with
+              confidence.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+            {dietaryOptions.map((option) => (
+              <div key={option.title} className="card-elevated p-6">
+                <div className="w-12 h-12 rounded-full bg-accent/10 flex items-center justify-center mb-4">
+                  <option.icon className="w-6 h-6 text-accent" />
+                </div>
+                <h3 className="heading-card text-foreground mb-2">
+                  {option.title}
+                </h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {option.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Tour Details */}
+      <section className="py-16 bg-card border-y border-border">
+        <div className="container-section">
+          <div className="text-center max-w-2xl mx-auto mb-12">
+            <h2 className="heading-section text-foreground">Tour Details</h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-12">
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <Clock className="w-5 h-5 text-accent" />
+                <h3 className="text-xl font-medium text-foreground">
+                  Duration
+                </h3>
+              </div>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>
+                  <strong className="text-foreground">Half day:</strong> 3-4
+                  hours
+                </li>
+                <li>
+                  <strong className="text-foreground">Full day:</strong> 6-7
+                  hours
+                </li>
+                <li>Morning, afternoon, or evening start times available</li>
+              </ul>
+            </div>
+
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <Users className="w-5 h-5 text-accent" />
+                <h3 className="text-xl font-medium text-foreground">Price</h3>
+              </div>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>Private tour — contact for a personalized quote</li>
+                <li>Pricing depends on duration, group size, and areas covered</li>
+                <li>
+                  <Link
+                    to="/contact"
+                    className="text-accent hover:underline font-medium"
+                  >
+                    Request a quote
+                  </Link>
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <Check className="w-5 h-5 text-accent" />
+                <h3 className="text-xl font-medium text-foreground">
+                  Included
+                </h3>
+              </div>
+              <ul className="space-y-2 text-muted-foreground">
+                <li className="flex items-start gap-2">
+                  <Check className="w-4 h-4 text-accent mt-1 flex-shrink-0" />
+                  Licensed local guide
+                </li>
+                <li className="flex items-start gap-2">
+                  <Check className="w-4 h-4 text-accent mt-1 flex-shrink-0" />
+                  Customized route planning
+                </li>
+                <li className="flex items-start gap-2">
+                  <Check className="w-4 h-4 text-accent mt-1 flex-shrink-0" />
+                  Cultural context and food stories
+                </li>
+                <li className="flex items-start gap-2">
+                  <Check className="w-4 h-4 text-accent mt-1 flex-shrink-0" />
+                  Restaurant navigation and ordering help
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <X className="w-5 h-5 text-muted-foreground" />
+                <h3 className="text-xl font-medium text-foreground">
+                  Not Included
+                </h3>
+              </div>
+              <ul className="space-y-2 text-muted-foreground">
+                <li className="flex items-start gap-2">
+                  <X className="w-4 h-4 text-muted-foreground mt-1 flex-shrink-0" />
+                  Food and drinks (pay as you go)
+                </li>
+                <li className="flex items-start gap-2">
+                  <X className="w-4 h-4 text-muted-foreground mt-1 flex-shrink-0" />
+                  Transportation costs
+                </li>
+              </ul>
+              <p className="mt-4 text-sm text-muted-foreground">
+                <strong className="text-foreground">Food budget:</strong>{" "}
+                Expect to spend around ¥3,000-5,000 per person depending on
+                the tour type and your appetite.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="py-16 bg-primary text-primary-foreground">
+        <div className="container-section text-center">
+          <h2 className="heading-section">
+            Tell Us What You Love to Eat
+          </h2>
+          <p className="mt-4 text-primary-foreground/70 max-w-xl mx-auto">
+            Whether you are a sushi purist, a ramen fanatic, or someone who
+            wants to try everything — we will create your perfect Tokyo food
+            day. Share your preferences, dietary needs, and food dreams, and
+            your guide will handle the rest.
+          </p>
+          <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+            <Link to="/contact" className="btn-accent">
+              Plan Your Food Tour
+              <ArrowRight className="ml-2 w-4 h-4" />
+            </Link>
+            <Link
+              to="/tours"
+              className="inline-flex items-center justify-center px-6 py-3 border-2 border-primary-foreground/30 text-primary-foreground font-medium rounded-md transition-all duration-200 hover:bg-primary-foreground/10"
+            >
+              Browse All Tours
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Related Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <div className="grid lg:grid-cols-2 gap-16">
+            {/* Related Tours */}
+            <div>
+              <p className="text-label text-accent mb-3">Related Tours</p>
+              <h2 className="heading-section text-foreground mb-6">
+                Explore More Tokyo Tours
+              </h2>
+              <div className="space-y-4">
+                {relatedTours.map((tour) => (
+                  <Link
+                    key={tour.path}
+                    to={tour.path}
+                    className="block card-elevated p-5 group hover:border-accent/30 transition-colors"
+                  >
+                    <h3 className="heading-card text-foreground group-hover:text-accent transition-colors">
+                      {tour.title}
+                    </h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {tour.description}
+                    </p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            {/* Related Articles */}
+            <div>
+              <p className="text-label text-accent mb-3">Read More</p>
+              <h2 className="heading-section text-foreground mb-6">
+                From the Blog
+              </h2>
+              <div className="space-y-4">
+                {relatedArticles.map((article) => (
+                  <Link
+                    key={article.path}
+                    to={article.path}
+                    className="block card-elevated p-5 group hover:border-accent/30 transition-colors"
+                  >
+                    <h3 className="heading-card text-foreground group-hover:text-accent transition-colors">
+                      {article.title}
+                    </h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {article.description}
+                    </p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* TouristTrip Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "TouristTrip",
+            "name": "Tokyo Private Food Tour",
+            "description":
+              "Private guided food tour of Tokyo with a licensed guide",
+            "touristType": "Food enthusiasts",
+            "provider": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "offers": {
+              "@type": "Offer",
+              "priceCurrency": "JPY",
+              "availability": "https://schema.org/InStock",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default TokyoFoodTour;

--- a/src/pages/tours/TokyoNightTour.tsx
+++ b/src/pages/tours/TokyoNightTour.tsx
@@ -1,0 +1,413 @@
+import { Link } from "react-router-dom";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const nightExperiences = [
+  {
+    title: "Golden Gai Bar Hopping",
+    area: "Shinjuku",
+    description:
+      "Over 200 tiny bars crammed into six narrow alleys, each seating just 5-10 people. Every bar has its own personality — jazz bars, punk bars, film bars, bars where the owner only speaks through a puppet. Your guide knows which ones welcome first-timers and which to skip.",
+  },
+  {
+    title: "Omoide Yokocho",
+    area: "Memory Lane, Shinjuku",
+    description:
+      "Yakitori smoke drifts through narrow lanes under the rumble of trains overhead. This postwar alley of tiny food stalls has barely changed since the 1940s. Order grilled chicken skewers and cold beer elbow-to-elbow with salarymen winding down their day.",
+  },
+  {
+    title: "Shibuya Crossing at Night",
+    area: "Shibuya",
+    description:
+      "The world's busiest pedestrian crossing takes on a completely different energy after dark. Neon signs blaze from every building, giant screens pulse with light, and up to 3,000 people cross in a single green light. It's Tokyo at its most electric.",
+  },
+  {
+    title: "Yurakucho & Shinbashi",
+    area: "Central Tokyo",
+    description:
+      "Tucked under the elevated train tracks, these open-air izakaya alleys are where office workers come to drink, eat, and decompress. This is authentic, unfiltered Tokyo nightlife — no tourists, no English menus, just real local culture. Your guide makes it accessible.",
+  },
+  {
+    title: "Roppongi",
+    area: "Minato",
+    description:
+      "Tokyo's international nightlife district offers rooftop bars with skyline views, world-class cocktail lounges, and late-night dining from every cuisine imaginable. Whether you want a sophisticated cocktail or a dance floor, Roppongi delivers.",
+  },
+  {
+    title: "Nakamise & Senso-ji at Night",
+    area: "Asakusa",
+    description:
+      "Tokyo's oldest temple is beautifully illuminated after the crowds leave. The massive red lantern of Kaminarimon Gate glows against the dark sky, and the main hall is dramatically lit with almost no one around. A completely different experience from the daytime visit.",
+  },
+];
+
+const TokyoNightTour = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Tokyo Night Tour | Private Evening Experience | Tanuki Tabi Travel"
+        description="Experience Tokyo after dark with a local guide. Explore neon-lit streets, hidden bars, izakayas, and nightlife spots safely with a licensed private guide."
+        canonicalPath="/tours/tokyo-night-tour"
+      />
+
+      {/* Hero Section */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <p className="text-label text-accent mb-3">Evening Tour</p>
+            <h1 className="heading-display text-foreground">
+              Tokyo Private Night Tour
+            </h1>
+            <p className="mt-6 text-xl text-muted-foreground leading-relaxed">
+              Tokyo transforms after dark. Let a local show you why.
+            </p>
+            <p className="mt-4 text-muted-foreground leading-relaxed">
+              When the sun sets, a different city emerges. Neon signs ignite
+              narrow alleyways, izakaya lanterns flicker to life, and millions of
+              Tokyoites pour into the streets for the night. This is the Tokyo
+              most visitors miss — and it's the Tokyo you'll remember forever.
+            </p>
+            <div className="mt-8">
+              <Link to="/contact" className="btn-accent">
+                Book Your Night Tour
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Why Tokyo at Night? */}
+      <section className="py-16">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <h2 className="heading-section text-foreground mb-6">
+              Why Tokyo at Night?
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tokyo is a completely different city after sunset. The neon lights,
+              the izakaya alleys, the energy of Shibuya Crossing at night —
+              these are experiences you simply cannot get during the day. The
+              daytime crowds thin out, the atmosphere shifts, and the city
+              reveals a warmer, more intimate side that most tourists never see.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              But nighttime Tokyo can also be intimidating. Most bars are tiny,
+              unmarked, and have no English signage. Some establishments are
+              welcoming to visitors; others are not. Knowing the difference is
+              everything — and that's exactly what a local guide provides.
+            </p>
+            <p className="text-muted-foreground leading-relaxed">
+              Whether you're a cocktail enthusiast, a street food lover, or
+              someone who wants to understand how Tokyoites actually spend their
+              evenings, this tour opens doors that would otherwise stay closed.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Sample Night Experiences */}
+      <section className="py-16 bg-secondary/30">
+        <div className="container-section">
+          <div className="mb-10">
+            <p className="text-label text-accent mb-3">Where We Go</p>
+            <h2 className="heading-section text-foreground">
+              Sample Night Experiences
+            </h2>
+            <p className="mt-4 text-body max-w-2xl">
+              Every night tour is customized to your interests. Here are some of
+              the experiences we can include — we'll pick the perfect combination
+              for you.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {nightExperiences.map((experience) => (
+              <div key={experience.title} className="card-elevated p-6">
+                <p className="text-label text-accent mb-2">
+                  {experience.area}
+                </p>
+                <h3 className="heading-card text-foreground mb-3">
+                  {experience.title}
+                </h3>
+                <p className="text-muted-foreground leading-relaxed">
+                  {experience.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* What to Expect */}
+      <section className="py-16">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <h2 className="heading-section text-foreground mb-6">
+              What to Expect
+            </h2>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              Your night tour is a relaxed, flexible evening out in Tokyo with a
+              knowledgeable local by your side. Here's how it works.
+            </p>
+
+            <div className="space-y-8">
+              <div>
+                <h3 className="text-xl font-medium text-foreground mb-2">
+                  Duration & Timing
+                </h3>
+                <p className="text-muted-foreground leading-relaxed">
+                  Typically 3-4 hours, starting around 6 PM and wrapping up by
+                  10 PM. We can adjust the start time based on your schedule and
+                  the season — summer sunsets are later, so we might start at 7
+                  PM. The pace is yours to set; we're not rushing through a
+                  checklist.
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-xl font-medium text-foreground mb-2">
+                  Your Guide Handles Everything
+                </h3>
+                <p className="text-muted-foreground leading-relaxed">
+                  Navigating Tokyo nightlife solo means deciphering handwritten
+                  Japanese menus, figuring out unspoken bar etiquette, and hoping
+                  you've chosen a place that welcomes visitors. Your guide
+                  handles all of this — ordering in Japanese, explaining dishes
+                  and drinks, managing cover charges, and reading the room so you
+                  can simply enjoy the experience. Many of the best spots have no
+                  English signage at all, and your guide's relationships with bar
+                  owners open doors that guidebooks cannot.
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-xl font-medium text-foreground mb-2">
+                  Safety & Peace of Mind
+                </h3>
+                <p className="text-muted-foreground leading-relaxed">
+                  Tokyo is one of the safest major cities in the world, even at
+                  night. That said, a small number of establishments in
+                  entertainment districts use aggressive touts or inflated
+                  pricing aimed at tourists. Your guide knows exactly which areas
+                  and venues to avoid, so you experience only the genuine side of
+                  Tokyo's nightlife. You'll never need to worry about being
+                  overcharged or ending up somewhere uncomfortable.
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-xl font-medium text-foreground mb-2">
+                  Alcohol Entirely Optional
+                </h3>
+                <p className="text-muted-foreground leading-relaxed">
+                  While Tokyo's bar scene is a highlight, non-drinking guests
+                  enjoy this tour equally. Japan has a wonderful culture of
+                  non-alcoholic beverages — from artisan teas and Japanese sodas
+                  to elaborate mocktails. Many of our best nightlife spots are
+                  actually about the food, the atmosphere, and the people
+                  watching. The neon-lit streets, temple illuminations, and
+                  energy of the city at night are spectacular whether you have a
+                  cocktail or a Calpis soda in hand.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Practical Notes */}
+      <section className="py-16 bg-card border-y border-border">
+        <div className="container-section">
+          <h2 className="heading-section text-foreground mb-8">
+            Practical Notes
+          </h2>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-2">
+                Dress Code
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                Smart casual is perfect. You'll be walking between venues, so
+                comfortable shoes are essential. No need for anything formal —
+                clean jeans and a nice top work well. Some upscale bars may have
+                a slightly dressier atmosphere, which we'll factor into your
+                route.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-2">
+                Budget for Food & Drinks
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                Plan for approximately ~5,000-~8,000 per person for food and
+                drinks throughout the evening. This typically covers 2-3 venues
+                with food and beverages at each. Some Golden Gai bars have a
+                small cover charge (~500-~1,000), which your guide will explain
+                in advance.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-2">
+                Last Train & Getting Home
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                Tokyo's last trains run between 11:30 PM and midnight. Your
+                guide will make sure you know the exact last train time for your
+                station and help you get to the platform. If you prefer to stay
+                out later, we'll help arrange a taxi or explain the night bus
+                options back to your hotel.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-2">
+                Pricing
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                Tour pricing depends on group size and specific requests.{" "}
+                <Link
+                  to="/contact"
+                  className="text-accent hover:underline font-medium"
+                >
+                  Contact us for a personalized quote
+                </Link>
+                . The guide fee covers planning, guiding, and all local
+                expertise. Food and drink costs are paid directly at each venue.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="py-16 bg-primary text-primary-foreground">
+        <div className="container-section">
+          <div className="max-w-2xl mx-auto text-center">
+            <h2 className="text-3xl md:text-4xl font-serif font-medium mb-4">
+              Ready for Tokyo After Dark?
+            </h2>
+            <p className="text-lg opacity-90 leading-relaxed mb-8">
+              Tell us your style and we'll plan your perfect night. Whether
+              you're drawn to hidden jazz bars, sizzling yakitori alleys, or the
+              electric glow of Shibuya at midnight — we'll craft an evening
+              you'll never forget.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link
+                to="/contact"
+                className="btn-accent bg-background text-foreground hover:bg-background/90"
+              >
+                Plan Your Night Tour
+              </Link>
+              <Link
+                to="/tours"
+                className="btn-outline border-primary-foreground text-primary-foreground hover:bg-primary-foreground/10"
+              >
+                Browse All Tours
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <h2 className="heading-section text-foreground mb-8">
+            Related Tours & Guides
+          </h2>
+          <div className="grid md:grid-cols-2 gap-12">
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">
+                Related Tours
+              </h3>
+              <ul className="space-y-3">
+                <li>
+                  <Link
+                    to="/tours/custom"
+                    className="text-accent hover:underline font-medium"
+                  >
+                    Custom Private Tour
+                  </Link>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    — Design your own Tokyo experience around any interest
+                  </span>
+                </li>
+                <li>
+                  <Link
+                    to="/tours/shibuya-harajuku"
+                    className="text-accent hover:underline font-medium"
+                  >
+                    Shibuya & Harajuku Tour
+                  </Link>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    — Explore Tokyo's youth culture hub during the day
+                  </span>
+                </li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-foreground mb-4">
+                Read More
+              </h3>
+              <ul className="space-y-3">
+                <li>
+                  <Link
+                    to="/blog/shinjuku-guide"
+                    className="text-accent hover:underline font-medium"
+                  >
+                    Shinjuku Area Guide
+                  </Link>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    — Everything you need to know about Tokyo's busiest district
+                  </span>
+                </li>
+                <li>
+                  <Link
+                    to="/blog/shibuya-harajuku-guide"
+                    className="text-accent hover:underline font-medium"
+                  >
+                    Shibuya & Harajuku Guide
+                  </Link>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    — A local's guide to Shibuya Crossing, Takeshita Street, and
+                    beyond
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* TouristTrip Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "TouristTrip",
+            name: "Tokyo Private Night Tour",
+            description:
+              "Private guided evening tour of Tokyo with a licensed guide",
+            touristType: "Nightlife enthusiasts",
+            provider: {
+              "@type": "Organization",
+              name: "Tanuki Tabi Travel",
+              url: "https://tanuki-tabi-travel.com",
+            },
+            offers: {
+              "@type": "Offer",
+              priceCurrency: "JPY",
+              availability: "https://schema.org/InStock",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default TokyoNightTour;


### PR DESCRIPTION
- Add 4 area guide blog posts: Asakusa, Shibuya & Harajuku, Shinjuku, Tsukiji
- Add 2 planning blog posts: Best Time to Visit Tokyo, Temple & Shrine Etiquette
- Add 2 experience tour pages: Tokyo Food Tour, Tokyo Night Tour
- Update BlogIndex with category-based organization (Tokyo Area Guides, Day Trip Guides, Planning Your Trip, Helpful Guides)
- Add Experience Tours section to Tours listing page
- Update Header navigation with Experience Tours dropdown section
- Update Footer with links to all new pages
- Add internal cross-links between existing and new blog posts
- Update sitemap.xml with all new pages and /booking
- All pages include BlogPosting/TouristTrip Schema.org markup
- Build passes with zero TypeScript errors

https://claude.ai/code/session_018wiR6Je9wRjDwpx2pKVckA