### PR TITLE
fix: add aggregateRating to About page structured data

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -374,6 +374,12 @@ const About = () => {
             "@type": "LocalBusiness",
             "name": "Tanuki Tabi Travel",
             "url": "https://tanuki-tabi-travel.com",
+            "aggregateRating": {
+              "@type": "AggregateRating",
+              "ratingValue": "4.86",
+              "reviewCount": "516",
+              "bestRating": "5",
+            },
             "review": allReviews.map((r) => ({
               "@type": "Review",
               "reviewBody": r.text,


### PR DESCRIPTION
The About page's JSON-LD LocalBusiness schema had review data but was
missing the aggregateRating object, causing Google Search Console to
report "aggregateRating オブジェクトが指定されていないレビューが複数あります".

https://claude.ai/code/session_01Lu4b81pKgPgJGegHFvW5ak