### PR TITLE
fix: add SSG prerendering and SEO improvements for Google indexing

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,22 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tokyo Private Tour Guide | Licensed Walking Tours | Tanuki Tabi Travel</title>
-    <meta name="description" content="Explore Tokyo with a government-licensed private tour guide. 516+ tours completed with 4.86★ rating. Custom walking tours of Asakusa, Shibuya, Ginza & more. Book your personal Tokyo experience." />
     <meta name="author" content="Manabu - Government-Licensed Tour Guide" />
     <meta name="google-site-verification" content="VnhwzF1aG0HWEowI9D68NkcX69nlmLf4n4dM2aeaBRE" />
-
-    <meta property="og:title" content="Tokyo Private Tour Guide | Licensed Walking Tours | Tanuki Tabi Travel" />
-    <meta property="og:description" content="Explore Tokyo with a government-licensed private tour guide. 516+ tours completed with 4.86★ rating. Custom walking tours of Asakusa, Shibuya, Ginza & more." />
+    <!--helmet-head-->
+    <title>Tokyo Private Tour Guide | Custom Walking Tours | Tanuki Tabi Travel</title>
+    <meta name="description" content="Explore Tokyo with a licensed private tour guide. Custom walking tours of Asakusa, Ginza, Akihabara and more. Personalized itineraries for your interests." />
+    <link rel="canonical" href="https://tanuki-tabi-travel.com/" />
+    <meta property="og:title" content="Tokyo Private Tour Guide | Custom Walking Tours | Tanuki Tabi Travel" />
+    <meta property="og:description" content="Explore Tokyo with a licensed private tour guide. Custom walking tours of Asakusa, Ginza, Akihabara and more. Personalized itineraries for your interests." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tanuki-tabi-travel.com" />
     <meta property="og:site_name" content="Tanuki Tabi Travel" />
     <meta property="og:image" content="https://tanuki-tabi-travel.com/og-image.png" />
-
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Tokyo Private Tour Guide | Licensed Walking Tours | Tanuki Tabi Travel" />
-    <meta name="twitter:description" content="Explore Tokyo with a government-licensed private tour guide. 516+ tours completed with 4.86★ rating." />
+    <meta name="twitter:title" content="Tokyo Private Tour Guide | Custom Walking Tours | Tanuki Tabi Travel" />
+    <meta name="twitter:description" content="Explore Tokyo with a licensed private tour guide. Custom walking tours of Asakusa, Ginza, Akihabara and more." />
     <meta name="twitter:image" content="https://tanuki-tabi-travel.com/og-image.png" />
+    <!--/helmet-head-->
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && vite build --ssr src/entry-server.tsx --outDir dist/server && node prerender.mjs && rm -rf dist/server",
+    "build:client": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/prerender.mjs
+++ b/prerender.mjs
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const resolve = (p) => path.resolve(__dirname, p);
+
+// All routes to prerender (static routes only; dynamic :id routes need explicit entries)
+const routes = [
+  "/",
+  "/about",
+  "/tours",
+  "/tours/asakusa",
+  "/tours/yanaka",
+  "/tours/shibuya-harajuku",
+  "/tours/tsukiji-ginza",
+  "/tours/imperial-palace",
+  "/tours/custom",
+  "/tours/kamakura-day-trip",
+  "/tours/hakone-day-trip",
+  "/tours/nikko-day-trip",
+  "/tours/tokyo-food-tour",
+  "/tours/tokyo-night-tour",
+  "/contact",
+  "/faq",
+  "/blog",
+  "/blog/tokyo-3-day-itinerary",
+  "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo",
+  "/blog/kamakura-vs-hakone-vs-nikko-day-trip",
+  "/blog/asakusa-guide-what-to-see",
+  "/blog/shibuya-harajuku-guide",
+  "/blog/shinjuku-guide",
+  "/blog/tsukiji-guide-food-lover",
+  "/blog/best-time-to-visit-tokyo",
+  "/blog/japan-temple-shrine-etiquette",
+];
+
+async function prerender() {
+  // Read the built index.html template
+  const template = fs.readFileSync(resolve("dist/index.html"), "utf-8");
+
+  // Import the server entry (built by vite build --ssr)
+  const { render } = await import("./dist/server/entry-server.js");
+
+  let successCount = 0;
+  let errorCount = 0;
+
+  for (const url of routes) {
+    try {
+      const { html, helmet } = render(url);
+
+      let page = template;
+
+      // Replace the empty root div with pre-rendered content
+      page = page.replace(
+        '<div id="root"></div>',
+        `<div id="root">${html}</div>`
+      );
+
+      // Replace helmet-managed head tags if helmet data is available
+      if (helmet) {
+        const helmetTags = [
+          helmet.title.toString(),
+          helmet.meta.toString(),
+          helmet.link.toString(),
+        ]
+          .filter(Boolean)
+          .join("\n    ");
+
+        // Replace everything between <!--helmet-head--> and <!--/helmet-head-->
+        page = page.replace(
+          /<!--helmet-head-->[\s\S]*?<!--\/helmet-head-->/,
+          `<!--helmet-head-->\n    ${helmetTags}\n    <!--/helmet-head-->`
+        );
+      }
+
+      // Write the file
+      const filePath =
+        url === "/"
+          ? resolve("dist/index.html")
+          : resolve(`dist${url}/index.html`);
+
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, page);
+      successCount++;
+      console.log(`  Pre-rendered: ${url}`);
+    } catch (e) {
+      errorCount++;
+      console.error(`  Error pre-rendering ${url}:`, e.message);
+    }
+  }
+
+  console.log(
+    `\nPre-rendering complete: ${successCount} succeeded, ${errorCount} failed out of ${routes.length} routes.`
+  );
+
+  if (errorCount > 0) {
+    process.exit(1);
+  }
+}
+
+prerender();

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,69 +3,69 @@
   <!-- Main Pages -->
   <url>
     <loc>https://tanuki-tabi-travel.com/</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/about</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://tanuki-tabi-travel.com/tours</loc>
+    <lastmod>2026-03-02</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://tanuki-tabi-travel.com/contact</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://tanuki-tabi-travel.com/privacy-policy</loc>
-    <lastmod>2026-02-25</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
-    <loc>https://tanuki-tabi-travel.com/tour-policies</loc>
-    <lastmod>2026-02-25</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.4</priority>
+    <loc>https://tanuki-tabi-travel.com/faq</loc>
+    <lastmod>2026-03-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <!-- Tour Detail Pages -->
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/asakusa</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/yanaka</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/shibuya-harajuku</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/tsukiji-ginza</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/imperial-palace</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/custom</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -73,77 +73,43 @@
   <!-- Day Trip Pages -->
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/kamakura-day-trip</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/hakone-day-trip</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/nikko-day-trip</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
-  </url>
-
-  <!-- FAQ -->
-  <url>
-    <loc>https://tanuki-tabi-travel.com/faq</loc>
-    <lastmod>2026-02-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
   </url>
 
   <!-- Experience Tours -->
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/tokyo-food-tour</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/tours/tokyo-night-tour</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
-  </url>
-
-  <!-- Booking (redirects to /contact) -->
-  <url>
-    <loc>https://tanuki-tabi-travel.com/booking</loc>
-    <lastmod>2026-02-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
 
   <!-- Blog -->
   <url>
     <loc>https://tanuki-tabi-travel.com/blog</loc>
-    <lastmod>2026-02-25</lastmod>
+    <lastmod>2026-03-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://tanuki-tabi-travel.com/blog/tokyo-3-day-itinerary</loc>
-    <lastmod>2026-02-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo</loc>
-    <lastmod>2026-02-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip</loc>
-    <lastmod>2026-02-25</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/blog/asakusa-guide-what-to-see</loc>
@@ -170,6 +136,18 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/tokyo-3-day-itinerary</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://tanuki-tabi-travel.com/blog/best-time-to-visit-tokyo</loc>
     <lastmod>2026-02-25</lastmod>
     <changefreq>monthly</changefreq>
@@ -177,6 +155,12 @@
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo</loc>
     <lastmod>2026-02-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,61 +1,10 @@
-import { Toaster } from "@/components/ui/toaster";
-import { Toaster as Sonner } from "@/components/ui/sonner";
-import { TooltipProvider } from "@/components/ui/tooltip";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import Index from "./pages/Index";
-import Tours from "./pages/Tours";
-import TourDetail from "./pages/TourDetail";
-import TokyoFoodTour from "./pages/tours/TokyoFoodTour";
-import TokyoNightTour from "./pages/tours/TokyoNightTour";
-import About from "./pages/About";
-import Contact from "./pages/Contact";
-import FAQ from "./pages/FAQ";
-import BlogIndex from "./pages/blog/BlogIndex";
-import Tokyo3DayItinerary from "./pages/blog/Tokyo3DayItinerary";
-import IsItWorthHiringGuide from "./pages/blog/IsItWorthHiringGuide";
-import DayTripComparison from "./pages/blog/DayTripComparison";
-import AsakusaGuide from "./pages/blog/AsakusaGuide";
-import ShibuyaHarajukuGuide from "./pages/blog/ShibuyaHarajukuGuide";
-import ShinjukuGuide from "./pages/blog/ShinjukuGuide";
-import TsukijiGuide from "./pages/blog/TsukijiGuide";
-import BestTimeToVisit from "./pages/blog/BestTimeToVisit";
-import TempleEtiquette from "./pages/blog/TempleEtiquette";
-import NotFound from "./pages/NotFound";
-
-const queryClient = new QueryClient();
+import { BrowserRouter } from "react-router-dom";
+import AppRoutes from "./AppRoutes";
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/tours" element={<Tours />} />
-          <Route path="/tours/tokyo-food-tour" element={<TokyoFoodTour />} />
-          <Route path="/tours/tokyo-night-tour" element={<TokyoNightTour />} />
-          <Route path="/tours/:id" element={<TourDetail />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route path="/faq" element={<FAQ />} />
-          <Route path="/blog" element={<BlogIndex />} />
-          <Route path="/blog/tokyo-3-day-itinerary" element={<Tokyo3DayItinerary />} />
-          <Route path="/blog/is-it-worth-hiring-a-tour-guide-in-tokyo" element={<IsItWorthHiringGuide />} />
-          <Route path="/blog/kamakura-vs-hakone-vs-nikko-day-trip" element={<DayTripComparison />} />
-          <Route path="/blog/asakusa-guide-what-to-see" element={<AsakusaGuide />} />
-          <Route path="/blog/shibuya-harajuku-guide" element={<ShibuyaHarajukuGuide />} />
-          <Route path="/blog/shinjuku-guide" element={<ShinjukuGuide />} />
-          <Route path="/blog/tsukiji-guide-food-lover" element={<TsukijiGuide />} />
-          <Route path="/blog/best-time-to-visit-tokyo" element={<BestTimeToVisit />} />
-          <Route path="/blog/japan-temple-shrine-etiquette" element={<TempleEtiquette />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+  <BrowserRouter>
+    <AppRoutes />
+  </BrowserRouter>
 );
 
 export default App;

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,0 +1,59 @@
+import { Routes, Route } from "react-router-dom";
+import { Toaster } from "@/components/ui/toaster";
+import { Toaster as Sonner } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import Index from "./pages/Index";
+import Tours from "./pages/Tours";
+import TourDetail from "./pages/TourDetail";
+import TokyoFoodTour from "./pages/tours/TokyoFoodTour";
+import TokyoNightTour from "./pages/tours/TokyoNightTour";
+import About from "./pages/About";
+import Contact from "./pages/Contact";
+import FAQ from "./pages/FAQ";
+import BlogIndex from "./pages/blog/BlogIndex";
+import Tokyo3DayItinerary from "./pages/blog/Tokyo3DayItinerary";
+import IsItWorthHiringGuide from "./pages/blog/IsItWorthHiringGuide";
+import DayTripComparison from "./pages/blog/DayTripComparison";
+import AsakusaGuide from "./pages/blog/AsakusaGuide";
+import ShibuyaHarajukuGuide from "./pages/blog/ShibuyaHarajukuGuide";
+import ShinjukuGuide from "./pages/blog/ShinjukuGuide";
+import TsukijiGuide from "./pages/blog/TsukijiGuide";
+import BestTimeToVisit from "./pages/blog/BestTimeToVisit";
+import TempleEtiquette from "./pages/blog/TempleEtiquette";
+import NotFound from "./pages/NotFound";
+
+const queryClient = new QueryClient();
+
+const AppRoutes = () => (
+  <QueryClientProvider client={queryClient}>
+    <TooltipProvider>
+      <Toaster />
+      <Sonner />
+      <Routes>
+        <Route path="/" element={<Index />} />
+        <Route path="/tours" element={<Tours />} />
+        <Route path="/tours/tokyo-food-tour" element={<TokyoFoodTour />} />
+        <Route path="/tours/tokyo-night-tour" element={<TokyoNightTour />} />
+        <Route path="/tours/:id" element={<TourDetail />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/contact" element={<Contact />} />
+        <Route path="/faq" element={<FAQ />} />
+        <Route path="/blog" element={<BlogIndex />} />
+        <Route path="/blog/tokyo-3-day-itinerary" element={<Tokyo3DayItinerary />} />
+        <Route path="/blog/is-it-worth-hiring-a-tour-guide-in-tokyo" element={<IsItWorthHiringGuide />} />
+        <Route path="/blog/kamakura-vs-hakone-vs-nikko-day-trip" element={<DayTripComparison />} />
+        <Route path="/blog/asakusa-guide-what-to-see" element={<AsakusaGuide />} />
+        <Route path="/blog/shibuya-harajuku-guide" element={<ShibuyaHarajukuGuide />} />
+        <Route path="/blog/shinjuku-guide" element={<ShinjukuGuide />} />
+        <Route path="/blog/tsukiji-guide-food-lover" element={<TsukijiGuide />} />
+        <Route path="/blog/best-time-to-visit-tokyo" element={<BestTimeToVisit />} />
+        <Route path="/blog/japan-temple-shrine-etiquette" element={<TempleEtiquette />} />
+        {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </TooltipProvider>
+  </QueryClientProvider>
+);
+
+export default AppRoutes;

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -1,0 +1,18 @@
+import { renderToString } from "react-dom/server";
+import { StaticRouter } from "react-router-dom/server";
+import { HelmetProvider, HelmetServerState } from "react-helmet-async";
+import AppRoutes from "./AppRoutes";
+
+export function render(url: string) {
+  const helmetContext: { helmet?: HelmetServerState } = {};
+
+  const html = renderToString(
+    <HelmetProvider context={helmetContext}>
+      <StaticRouter location={url}>
+        <AppRoutes />
+      </StaticRouter>
+    </HelmetProvider>
+  );
+
+  return { html, helmet: helmetContext.helmet };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,17 @@
-import { createRoot } from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
 import { HelmetProvider } from "react-helmet-async";
 import App from "./App.tsx";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(
+const rootElement = document.getElementById("root")!;
+const app = (
   <HelmetProvider>
     <App />
   </HelmetProvider>
 );
+
+if (rootElement.innerHTML.trim().length > 0) {
+  hydrateRoot(rootElement, app);
+} else {
+  createRoot(rootElement).render(app);
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -97,8 +97,8 @@ const About = () => {
   return (
     <Layout>
       <SEO
-        title="About Your Guide Manabu | Licensed Tokyo Tour Guide | Tanuki Tabi Travel"
-        description="Meet Manabu, a government-licensed tour guide (全国通訳案内士) with 516+ tours and 4.86★ rating. Discover why travelers trust Tanuki Tabi Travel."
+        title="About Us | Meet Your Tokyo Tour Guide | Tanuki Tabi Travel"
+        description="Meet Manabu, founder of Tanuki Tabi Travel. A Kyoto University graduate and licensed guide offering personalized Tokyo walking tours since 2023."
         canonicalPath="/about"
       />
 
@@ -390,6 +390,26 @@ const About = () => {
                 "bestRating": "5",
               },
             })),
+          }),
+        }}
+      />
+
+      {/* JSON-LD Person Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Person",
+            "name": "Manabu",
+            "jobTitle": "Government-Licensed Tour Guide",
+            "worksFor": {
+              "@type": "LocalBusiness",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "knowsLanguage": ["Japanese", "English", "Spanish"],
+            "knowsAbout": ["Tokyo", "Japanese Culture", "Japanese History", "Walking Tours"],
           }),
         }}
       />

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -78,8 +78,8 @@ const Contact = () => {
   return (
     <Layout>
       <SEO
-        title="Book a Tour | Contact Tanuki Tabi Travel | Tokyo Private Tours"
-        description="Ready to explore Tokyo? Contact us to book your private walking tour or ask questions. Fast response guaranteed."
+        title="Book a Private Tokyo Tour | Tanuki Tabi Travel"
+        description="Book your private Tokyo walking tour. Fill out our simple form and receive a custom itinerary within 24 hours."
         canonicalPath="/contact"
       />
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -145,8 +145,8 @@ const Index = () => {
   return (
     <Layout>
       <SEO
-        title="Tokyo Private Tour Guide | Licensed Walking Tours | Tanuki Tabi Travel"
-        description="Explore Tokyo with a government-licensed private tour guide. 516+ tours completed with 4.86★ rating. Custom walking tours of Asakusa, Shibuya, Ginza & more. Book your personal Tokyo experience."
+        title="Tokyo Private Tour Guide | Custom Walking Tours | Tanuki Tabi Travel"
+        description="Explore Tokyo with a licensed private tour guide. Custom walking tours of Asakusa, Ginza, Akihabara and more. Personalized itineraries for your interests."
         canonicalPath="/"
       />
 
@@ -401,11 +401,12 @@ const Index = () => {
         dangerouslySetInnerHTML={{
           __html: JSON.stringify({
             "@context": "https://schema.org",
-            "@type": "LocalBusiness",
+            "@type": ["LocalBusiness", "TouristInformationCenter"],
             "name": "Tanuki Tabi Travel",
             "description": "Private walking tours of Tokyo with a government-licensed guide",
             "url": "https://tanuki-tabi-travel.com",
             "email": "info@tanuki-tabi-travel.com",
+            "priceRange": "¥25,000 - ¥60,000",
             "areaServed": {
               "@type": "City",
               "name": "Tokyo",

--- a/src/pages/blog/BlogIndex.tsx
+++ b/src/pages/blog/BlogIndex.tsx
@@ -111,8 +111,8 @@ const BlogIndex = () => {
   return (
     <Layout>
       <SEO
-        title="Blog | Tokyo Travel Tips & Guide Stories | Tanuki Tabi Travel"
-        description="Travel tips, itineraries, and insider recommendations from a licensed Tokyo tour guide. Plan your perfect Tokyo trip with local knowledge."
+        title="Tokyo Travel Blog | Tips & Guides | Tanuki Tabi Travel"
+        description="Travel tips, cultural insights, and guides for visiting Tokyo. Written by a local licensed tour guide."
         canonicalPath="/blog"
       />
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,4 +15,24 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  ssr: {
+    // Bundle these CJS packages into the SSR output so Node ESM can import them
+    noExternal: [
+      "react-helmet-async",
+      "embla-carousel-react",
+      "embla-carousel",
+      "lucide-react",
+      "sonner",
+      "next-themes",
+      "class-variance-authority",
+      "clsx",
+      "tailwind-merge",
+      "cmdk",
+      "react-day-picker",
+      "input-otp",
+      "react-resizable-panels",
+      "recharts",
+      "vaul",
+    ],
+  },
 }));


### PR DESCRIPTION
- Add build-time static HTML generation for all 26 routes using Vite SSR and react-dom/server renderToString, so crawlers see full page content instead of empty <div id="root"></div>
- Extract routes into AppRoutes.tsx for shared use between client (BrowserRouter) and server (StaticRouter) rendering
- Create entry-server.tsx and prerender.mjs for the SSG build pipeline
- Use hydrateRoot for prerendered pages, createRoot for non-prerendered
- Update page titles/descriptions per SEO spec (homepage, about, blog, contact)
- Add Person JSON-LD schema to About page
- Add TouristInformationCenter type and priceRange to homepage JSON-LD
- Update sitemap.xml: remove non-existent pages, add /tours listing, update lastmod dates
- Configure Vite SSR noExternal for CJS compatibility
- Clean up dist/server after prerendering so it's not deployed

https://claude.ai/code/session_011fXAccuxuvk5WZfYCpjHZJ