### PR TITLE
feat: add /es/tours listing page, /es/faq page, update SEO metadata p…

### DIFF
--- a/prerender.mjs
+++ b/prerender.mjs
@@ -35,6 +35,7 @@ const routes = [
   "/blog/japan-temple-shrine-etiquette",
   // Spanish pages
   "/es",
+  "/es/tours",
   "/es/tours/asakusa",
   "/es/tours/yanaka",
   "/es/tours/shibuya-harajuku",
@@ -46,6 +47,7 @@ const routes = [
   "/es/tours/custom",
   "/es/contact",
   "/es/about",
+  "/es/faq",
 ];
 
 async function prerender() {

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -152,6 +152,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://tanuki-tabi-travel.com/es/tours</loc>
+    <lastmod>2026-03-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://tanuki-tabi-travel.com/es/tours/asakusa</loc>
     <lastmod>2026-03-06</lastmod>
     <changefreq>monthly</changefreq>
@@ -213,6 +219,12 @@
   </url>
   <url>
     <loc>https://tanuki-tabi-travel.com/es/contact</loc>
+    <lastmod>2026-03-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://tanuki-tabi-travel.com/es/faq</loc>
     <lastmod>2026-03-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -28,6 +28,8 @@ import EsYanaka from "./pages/es/tours/EsYanaka";
 import EsKamakura from "./pages/es/tours/EsKamakura";
 import EsContact from "./pages/es/EsContact";
 import EsAbout from "./pages/es/EsAbout";
+import EsTours from "./pages/es/EsTours";
+import EsFaq from "./pages/es/EsFaq";
 import EsShibuyaHarajuku from "./pages/es/tours/EsShibuyaHarajuku";
 import EsTsukijiGinza from "./pages/es/tours/EsTsukijiGinza";
 import EsImperialPalace from "./pages/es/tours/EsImperialPalace";
@@ -63,6 +65,7 @@ const AppRoutes = () => (
         <Route path="/blog/japan-temple-shrine-etiquette" element={<TempleEtiquette />} />
         {/* Spanish Pages */}
         <Route path="/es" element={<EsIndex />} />
+        <Route path="/es/tours" element={<EsTours />} />
         <Route path="/es/tours/asakusa" element={<EsAsakusa />} />
         <Route path="/es/tours/yanaka" element={<EsYanaka />} />
         <Route path="/es/tours/kamakura-day-trip" element={<EsKamakura />} />
@@ -74,6 +77,7 @@ const AppRoutes = () => (
         <Route path="/es/tours/custom" element={<EsCustom />} />
         <Route path="/es/contact" element={<EsContact />} />
         <Route path="/es/about" element={<EsAbout />} />
+        <Route path="/es/faq" element={<EsFaq />} />
         {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -120,6 +120,11 @@ const FAQ = () => {
         title="FAQ | Tokyo Private Tour Guide Questions | Tanuki Tabi Travel"
         description="Answers to common questions about Tokyo private tours with Tanuki Tabi Travel — booking, pricing, cancellations, and what to expect on your guided walk."
         canonicalPath="/faq"
+        hreflang={[
+          { lang: "en", path: "/faq" },
+          { lang: "es", path: "/es/faq" },
+          { lang: "x-default", path: "/faq" },
+        ]}
       />
 
       {/* Header */}

--- a/src/pages/Tours.tsx
+++ b/src/pages/Tours.tsx
@@ -123,6 +123,11 @@ const Tours = () => {
         title="Tokyo Tours & Day Trips | Private Guided Tours | Tanuki Tabi Travel"
         description="Browse private Tokyo walking tours led by a certified guide. Asakusa, Shibuya, Harajuku, Yanaka, Kamakura day trips and more — all fully personalized."
         canonicalPath="/tours"
+        hreflang={[
+          { lang: "en", path: "/tours" },
+          { lang: "es", path: "/es/tours" },
+          { lang: "x-default", path: "/tours" },
+        ]}
       />
 
       {/* Header */}

--- a/src/pages/es/EsFaq.tsx
+++ b/src/pages/es/EsFaq.tsx
@@ -1,0 +1,231 @@
+// TRANSLATION REVIEW NEEDED: Please have a native Spanish speaker review this content before publishing
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+import { Link } from "react-router-dom";
+
+interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+interface FAQCategory {
+  title: string;
+  items: FAQItem[];
+}
+
+const faqCategories: FAQCategory[] = [
+  {
+    title: "Reservas y Precios",
+    items: [
+      {
+        question: "¿Cuánto cuesta un tour privado?",
+        answer: "Nuestros tours a pie por Tokio oscilan entre ¥25,000 y ¥40,000 por grupo, dependiendo del tour y la duración. Las excursiones de un día a Kamakura (¥50,000), Hakone (¥55,000) y Nikko (¥60,000) tienen precios diferentes. Consulta cada página de tour para tarifas específicas, o contáctanos para un presupuesto personalizado.",
+      },
+      {
+        question: "¿Cómo reservo un tour?",
+        answer: "Simplemente visita nuestra página de Contacto y cuéntanos tu fecha preferida, tamaño del grupo e intereses. Responderemos en un plazo de 24 horas con disponibilidad y un itinerario sugerido.",
+      },
+      {
+        question: "¿Con cuánta antelación debo reservar?",
+        answer: "Recomendamos reservar al menos 1-2 semanas antes, especialmente durante las temporadas altas (marzo-mayo para los cerezos en flor, octubre-noviembre para el otoño). Las reservas de último momento a veces son posibles — ¡solo pregunta!",
+      },
+      {
+        question: "¿Cuál es la política de cancelación?",
+        answer: "Cancelación gratuita hasta 48 horas antes del tour. Las cancelaciones dentro de las 48 horas se cobran en su totalidad. En caso de alertas meteorológicas graves (tifones, etc.), recibirás un reembolso completo o la opción de reprogramar.",
+      },
+      {
+        question: "¿Puedo reservar para una sola persona?",
+        answer: "¡Sí! Los viajeros individuales son muy bienvenidos. El precio puede variar respecto a las tarifas de grupo — contáctanos para un presupuesto.",
+      },
+    ],
+  },
+  {
+    title: "Sobre los Tours",
+    items: [
+      {
+        question: '¿Qué es un "Guía con Licencia del Gobierno"?',
+        answer: "El Intérprete-Guía con Licencia Nacional del Gobierno (全国通訳案内士) es una certificación nacional emitida por el gobierno japonés. Requiere aprobar exámenes rigurosos sobre historia, geografía, cultura japonesa y competencia en idiomas. Es la única certificación profesional de guía turístico reconocida a nivel nacional en Japón.",
+      },
+      {
+        question: "¿Son privados sus tours?",
+        answer: "Sí, todos nuestros tours son 100% privados. Solo estás tú y tu grupo con tu guía — sin desconocidos, sin horarios fijos. Tú marcas el ritmo.",
+      },
+      {
+        question: "¿Qué pasa si llueve?",
+        answer: "Los tours se realizan con lluvia o sol — Tokio tiene muchas zonas cubiertas, paradas interiores y pasajes subterráneos. Tu guía adaptará la ruta según el clima. Solo cancelamos por alertas meteorológicas graves (tifones, etc.), en cuyo caso recibirás un reembolso completo o podrás reprogramar.",
+      },
+      {
+        question: "¿Pueden acomodar restricciones alimentarias?",
+        answer: "Absolutamente. Avísanos con antelación y tu guía recomendará restaurantes que atienden necesidades vegetarianas, veganas, halal, sin gluten o con alergias específicas.",
+      },
+      {
+        question: "¿Sus tours son aptos para niños?",
+        answer: "¡Sí! Recibimos regularmente familias con niños de todas las edades. Nuestras rutas son mayormente planas y aptas para carritos. Tu guía ajustará el ritmo y el contenido para mantener a los viajeros más jóvenes interesados.",
+      },
+      {
+        question: "¿Pueden acomodar usuarios de silla de ruedas?",
+        answer: "Hacemos todo lo posible para que los tours sean accesibles. Por favor, avísanos con antelación y planificaremos una ruta que evite escaleras y use entradas accesibles. Algunos sitios históricos tienen accesibilidad limitada — tu guía planificará en consecuencia.",
+      },
+    ],
+  },
+  {
+    title: "Excursiones de un Día",
+    items: [
+      {
+        question: "¿Cómo llegamos a Kamakura / Hakone / Nikko?",
+        answer: "En tren desde el centro de Tokio. Tu guía te recoge en tu hotel o en una estación conveniente y se encarga de toda la navegación. Los billetes de tren no están incluidos en el precio del tour, pero tu guía te ayudará a comprarlos.",
+      },
+      {
+        question: "¿Vale la pena hacer una excursión con guía en vez de ir por mi cuenta?",
+        answer: 'Aunque ciertamente puedes visitar estos destinos por tu cuenta, un guía aporta tres beneficios clave: (1) navegación eficiente de sistemas de transporte complejos, (2) contexto cultural e histórico profundo en cada sitio, y (3) flexibilidad para ajustar el itinerario según el clima, las multitudes y tu nivel de energía. La mayoría de los viajeros nos dicen que el guía transformó su experiencia de "visitar lugares" a "entender Japón."',
+      },
+      {
+        question: "¿Puedo combinar una excursión con un tour por Tokio?",
+        answer: "¡Sí! Muchos huéspedes reservan un tour a pie por Tokio un día y una excursión otro. Ofrecemos paquetes de varios días — contáctanos para más detalles.",
+      },
+    ],
+  },
+  {
+    title: "Información Práctica",
+    items: [
+      {
+        question: "¿Dónde nos encontramos?",
+        answer: "Tu guía puede recogerte en el vestíbulo de tu hotel, en una estación de tren cercana o en cualquier ubicación conveniente del centro de Tokio. Confirmaremos el punto de encuentro al reservar.",
+      },
+      {
+        question: "¿Qué debo llevar puesto / traer?",
+        answer: "Zapatos cómodos para caminar son esenciales. Recomendamos vestirse por capas (el clima de Tokio cambia rápidamente), una botella de agua y protección solar en verano. Tu guía te aconsejará sobre cualquier necesidad específica para el tour elegido.",
+      },
+      {
+        question: "¿Debo dejar propina?",
+        answer: "La propina no es costumbre en Japón y no se espera. Si disfrutaste del tour, ¡una reseña amable siempre se agradece!",
+      },
+    ],
+  },
+];
+
+const allFaqs = faqCategories.flatMap((cat) => cat.items);
+
+const EsFaq = () => {
+  const [openIndex, setOpenIndex] = useState<string | null>(null);
+
+  const toggleFAQ = (key: string) => {
+    setOpenIndex(openIndex === key ? null : key);
+  };
+
+  return (
+    <Layout>
+      <SEO
+        title="Preguntas Frecuentes sobre Tours en Tokio en Español | Tanuki Tabi Travel"
+        description="Respuestas a las preguntas más frecuentes sobre los tours privados en Tokio con Tanuki Tabi Travel — reservas, precios, cancelaciones y qué esperar del tour."
+        canonicalPath="/es/faq"
+        hreflang={[
+          { lang: "en", path: "/faq" },
+          { lang: "es", path: "/es/faq" },
+          { lang: "x-default", path: "/faq" },
+        ]}
+      />
+
+      {/* Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-2xl">
+            <p className="text-label text-accent mb-3">Preguntas</p>
+            <h1 className="heading-display text-foreground">
+              Preguntas Frecuentes
+            </h1>
+            <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
+              Encuentra respuestas a las preguntas más comunes sobre nuestros tours.
+              ¿No encuentras lo que buscas?{" "}
+              <Link to="/es/contact" className="text-accent hover:underline">
+                Contáctanos directamente
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ Categories */}
+      <section className="py-16">
+        <div className="container-section">
+          <div className="max-w-3xl mx-auto space-y-12">
+            {faqCategories.map((category) => (
+              <div key={category.title}>
+                <h2 className="heading-card text-foreground mb-6">{category.title}</h2>
+                <div className="space-y-4">
+                  {category.items.map((faq, index) => {
+                    const key = `${category.title}-${index}`;
+                    return (
+                      <div
+                        key={key}
+                        className="bg-card border border-border rounded-lg overflow-hidden"
+                      >
+                        <button
+                          onClick={() => toggleFAQ(key)}
+                          className="w-full flex items-center justify-between p-6 text-left hover:bg-secondary/50 transition-colors"
+                        >
+                          <span className="text-lg font-medium text-foreground pr-4">
+                            {faq.question}
+                          </span>
+                          <ChevronDown
+                            className={`w-5 h-5 text-muted-foreground shrink-0 transition-transform duration-200 ${
+                              openIndex === key ? "rotate-180" : ""
+                            }`}
+                          />
+                        </button>
+                        {openIndex === key && (
+                          <div className="px-6 pb-6 animate-fade-in">
+                            <p className="text-muted-foreground leading-relaxed">
+                              {faq.answer}
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 bg-card border-y border-border">
+        <div className="container-section text-center">
+          <h2 className="heading-card text-foreground">¿Aún Tienes Preguntas?</h2>
+          <p className="mt-4 text-muted-foreground max-w-xl mx-auto">
+            Estaré encantado de responder cualquier otra pregunta que tengas sobre los tours o tu visita a Tokio.
+          </p>
+          <Link to="/es/contact" className="btn-accent mt-8 inline-flex">
+            Contáctame
+          </Link>
+        </div>
+      </section>
+
+      {/* FAQPage Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            "mainEntity": allFaqs.map((faq) => ({
+              "@type": "Question",
+              "name": faq.question,
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": faq.answer,
+              },
+            })),
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default EsFaq;

--- a/src/pages/es/EsIndex.tsx
+++ b/src/pages/es/EsIndex.tsx
@@ -181,7 +181,7 @@ const EsIndex = () => {
             </p>
 
             <div className="mt-8 flex flex-col sm:flex-row gap-4 animate-fade-in-up" style={{ animationDelay: "0.4s" }}>
-              <Link to="/es/tours/asakusa" className="btn-accent">
+              <Link to="/es/tours" className="btn-accent">
                 Ver Tours
                 <ArrowRight className="ml-2 w-4 h-4" />
               </Link>

--- a/src/pages/es/EsTours.tsx
+++ b/src/pages/es/EsTours.tsx
@@ -1,0 +1,253 @@
+// TRANSLATION REVIEW NEEDED: Please have a native Spanish speaker review this content before publishing
+import { Link } from "react-router-dom";
+import { Clock, Users, ArrowRight } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+import tourUeno from "@/assets/tour-ueno.jpg";
+import shibuyaCrossing from "@/assets/shibuya-crossing.jpg";
+import tsukijiMarket from "@/assets/tsukiji-market.jpg";
+import imperialPalace from "@/assets/imperial-palace.jpg";
+import hamarikyu from "@/assets/hamarikyu.jpg";
+
+interface EsTourCardProps {
+  id: string;
+  title: string;
+  description: string;
+  duration: string;
+  price: string;
+  difficulty: string;
+  image: string;
+}
+
+const EsTourCard = ({ id, title, description, duration, price, difficulty, image }: EsTourCardProps) => (
+  <Link to={`/es/tours/${id}`} className="group card-elevated">
+    <div className="relative aspect-[4/3] overflow-hidden">
+      <img
+        src={image}
+        alt={title}
+        className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+      />
+      <div className="absolute top-4 left-4">
+        <span className="text-label px-3 py-1.5 bg-background/90 backdrop-blur-sm rounded-full">
+          {difficulty}
+        </span>
+      </div>
+    </div>
+    <div className="p-6">
+      <h3 className="heading-card text-foreground group-hover:text-accent transition-colors">
+        {title}
+      </h3>
+      <p className="mt-2 text-body line-clamp-2">{description}</p>
+      <div className="mt-4 flex items-center gap-4 text-sm text-muted-foreground">
+        <div className="flex items-center gap-1.5">
+          <Clock className="w-4 h-4" />
+          <span>{duration}</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Users className="w-4 h-4" />
+          <span>Privado</span>
+        </div>
+      </div>
+      <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+        <div>
+          <span className="text-xs text-muted-foreground">Desde</span>
+          <p className="text-lg font-semibold text-foreground">{price}</p>
+        </div>
+        <div className="flex items-center gap-2 text-accent font-medium text-sm group-hover:gap-3 transition-all">
+          <span>Ver Detalles</span>
+          <ArrowRight className="w-4 h-4" />
+        </div>
+      </div>
+    </div>
+  </Link>
+);
+
+const tokyoTours = [
+  {
+    id: "asakusa",
+    title: "Tour por Asakusa",
+    description: "Descubre el corazón del viejo Tokio. Visita el Templo Senso-ji, explora tiendas tradicionales y prueba la comida callejera auténtica.",
+    duration: "3 horas",
+    price: "¥30,000",
+    difficulty: "Fácil",
+    image: "/images/tours/asakusa-kaminarimon-gate.jpg",
+  },
+  {
+    id: "yanaka",
+    title: "Descubrimiento de Ueno y Yanaka",
+    description: "Experimenta el encanto nostálgico de los barrios antiguos de Tokio. Pasea por templos tradicionales, senderos de cementerios y cafés locales escondidos.",
+    duration: "4 horas",
+    price: "¥40,000",
+    difficulty: "Fácil",
+    image: tourUeno,
+  },
+  {
+    id: "shibuya-harajuku",
+    title: "Tour por Shibuya y Harajuku",
+    description: "Explora el centro de la cultura juvenil de Tokio. Desde el famoso cruce de Shibuya hasta las calles de moda de Harajuku y el Santuario Meiji.",
+    duration: "3.5 horas",
+    price: "¥35,000",
+    difficulty: "Fácil",
+    image: shibuyaCrossing,
+  },
+  {
+    id: "tsukiji-ginza",
+    title: "Tour por Tsukiji y Ginza",
+    description: "Experimenta las delicias culinarias de Tokio en el Mercado Exterior de Tsukiji y pasea por el elegante distrito comercial de Ginza.",
+    duration: "3 horas",
+    price: "¥30,000",
+    difficulty: "Fácil",
+    image: tsukijiMarket,
+  },
+  {
+    id: "imperial-palace",
+    title: "Palacio Imperial y Marunouchi",
+    description: "Descubre el corazón histórico y el distrito empresarial moderno de Tokio. Pasea por los Jardines del Este y contempla el Palacio Imperial.",
+    duration: "2.5 horas",
+    price: "¥25,000",
+    difficulty: "Fácil",
+    image: imperialPalace,
+  },
+  {
+    id: "custom",
+    title: "Tour Privado Personalizado",
+    description: "Crea tu experiencia perfecta en Tokio. Cuéntame tus intereses y diseñaré un itinerario personalizado solo para ti.",
+    duration: "Flexible",
+    price: "Desde ¥10,000/hora",
+    difficulty: "Personalizable",
+    image: hamarikyu,
+  },
+];
+
+const dayTrips = [
+  {
+    id: "kamakura-day-trip",
+    title: "Excursión a Kamakura",
+    description: "Explora el Gran Buda de Kamakura, templos ancestrales y el encanto costero en una excursión privada de un día desde Tokio.",
+    duration: "7-8 horas",
+    price: "¥50,000",
+    difficulty: "Fácil-Moderado",
+    image: "/images/tours/kamakura-great-buddha.jpg",
+  },
+  {
+    id: "hakone-day-trip",
+    title: "Excursión a Hakone",
+    description: "Contempla el Monte Fuji, navega por el Lago Ashi, sube en teleférico sobre valles volcánicos y vive la cultura de aguas termales.",
+    duration: "8-10 horas",
+    price: "¥55,000",
+    difficulty: "Fácil",
+    image: "/images/tours/hakone-lake-ashi-fuji.jpg",
+  },
+  {
+    id: "nikko-day-trip",
+    title: "Excursión a Nikko",
+    description: "Visita el Santuario Toshogu, Patrimonio de la Humanidad, impresionantes cascadas y paisajes de montaña en una excursión desde Tokio.",
+    duration: "9-10 horas",
+    price: "¥60,000",
+    difficulty: "Moderado",
+    image: hamarikyu,
+  },
+];
+
+const EsTours = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Tours Privados en Tokio en Español | Tanuki Tabi Travel"
+        description="Explora todos los tours privados por Tokio con Manabu, guía japonés nativo en español. Asakusa, Shibuya, Kamakura, Hakone y más. Itinerario 100% personalizado."
+        canonicalPath="/es/tours"
+        hreflang={[
+          { lang: "en", path: "/tours" },
+          { lang: "es", path: "/es/tours" },
+          { lang: "x-default", path: "/tours" },
+        ]}
+      />
+
+      {/* Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-2xl">
+            <p className="text-label text-accent mb-3">Explora Tokio</p>
+            <h1 className="heading-display text-foreground">Tours Privados y Excursiones</h1>
+            <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
+              Descubre la rica cultura de Tokio a través de tours a pie inmersivos, o explora más allá de la ciudad con excursiones privadas a Kamakura, Hakone y Nikko.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Tokyo Walking Tours */}
+      <section className="py-16">
+        <div className="container-section">
+          <h2 className="heading-section text-foreground mb-8">Tours a Pie por Tokio</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {tokyoTours.map((tour) => (
+              <EsTourCard key={tour.id} {...tour} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Day Trips from Tokyo */}
+      <section className="py-16 bg-secondary/30">
+        <div className="container-section">
+          <div className="mb-8">
+            <p className="text-label text-accent mb-3">Excursiones</p>
+            <h2 className="heading-section text-foreground">Excursiones de un Día desde Tokio</h2>
+            <p className="mt-4 text-body max-w-2xl">
+              Explora fuera de Tokio con un guía privado. Cada excursión incluye servicio de guía durante todo el día, navegación de transporte y comentarios culturales.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {dayTrips.map((tour) => (
+              <EsTourCard key={tour.id} {...tour} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Info Section */}
+      <section className="py-16 bg-card border-y border-border">
+        <div className="container-section">
+          <div className="grid md:grid-cols-3 gap-12">
+            <div>
+              <h3 className="text-xl font-medium text-foreground mb-3">
+                Qué Incluye
+              </h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>• Guía local profesional con licencia</li>
+                <li>• Información cultural e historias locales</li>
+                <li>• Oportunidades fotográficas</li>
+                <li>• Ritmo y paradas flexibles</li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium text-foreground mb-3">
+                Detalles del Tour
+              </h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>• Solo tours privados</li>
+                <li>• Guía en español</li>
+                <li>• Horarios de mañana o tarde</li>
+                <li>• Con lluvia o sol (con ajustes)</li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="text-xl font-medium text-foreground mb-3">
+                Información de Reserva
+              </h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>• Reserva con al menos 48 horas de antelación</li>
+                <li>• Cancelación gratuita hasta 24h antes</li>
+                <li>• Pago el día del tour</li>
+                <li>• Tours personalizados disponibles</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default EsTours;

--- a/src/pages/es/tours/EsCustom.tsx
+++ b/src/pages/es/tours/EsCustom.tsx
@@ -9,8 +9,8 @@ const EsCustom = () => {
   return (
     <Layout>
       <SEO
-        title="Tour Privado Personalizado en Tokio en Español | Diseña tu Itinerario"
-        description="Diseña tu tour perfecto en Tokio con Manabu, guía japonés nativo con licencia oficial. Itinerario 100% personalizado según tus intereses. Desde ¥10,000/hora."
+        title="Tour Privado Personalizado en Tokio en Español | Diseña tu Ruta"
+        description="Diseña tu tour perfecto por Tokio con Manabu, guía japonés nativo en español. Cuéntanos tus intereses y creamos un itinerario exclusivo para ti. Desde ¥10,000/hora."
         canonicalPath="/es/tours/custom"
         hreflang={[
           { lang: "en", path: "/tours/custom" },
@@ -32,7 +32,7 @@ const EsCustom = () => {
         <div className="container-section">
           <div className="max-w-4xl">
             <h1 className="heading-display text-foreground">
-              Tour Privado Personalizado — Tu Tokio, a Tu Manera
+              Tour Privado Personalizado con Guía en Español
             </h1>
             <p className="mt-6 text-lg text-muted-foreground leading-relaxed">
               Cuéntame tus intereses y crearé un itinerario personalizado solo para ti. Ya sea que te apasione la gastronomía, la historia, el anime, la fotografía o algo completamente único — diseñemos juntos tu día perfecto en Tokio.

--- a/src/pages/es/tours/EsHakone.tsx
+++ b/src/pages/es/tours/EsHakone.tsx
@@ -8,8 +8,8 @@ const EsHakone = () => {
   return (
     <Layout>
       <SEO
-        title="Excursión Privada a Hakone en Español desde Tokio | Monte Fuji y Aguas Termales"
-        description="Excursión privada a Hakone con guía japonés nativo en español. Monte Fuji, Lago Ashi, teleférico y aguas termales en un día completo desde Tokio. Desde ¥55,000."
+        title="Excursión Privada a Hakone en Español desde Tokio | Monte Fuji y Lago Ashi"
+        description="Excursión privada a Hakone con guía japonés nativo en español. Monte Fuji, lago Ashi en barco y cultura de aguas termales en un día completo desde Tokio. Desde ¥55,000."
         canonicalPath="/es/tours/hakone-day-trip"
         hreflang={[
           { lang: "en", path: "/tours/hakone-day-trip" },

--- a/src/pages/es/tours/EsImperialPalace.tsx
+++ b/src/pages/es/tours/EsImperialPalace.tsx
@@ -11,8 +11,8 @@ const EsImperialPalace = () => {
   return (
     <Layout>
       <SEO
-        title="Tour del Palacio Imperial y Marunouchi en Español | Guía Japonés Nativo | Tokio"
-        description="Descubre el Palacio Imperial y Marunouchi con Manabu, guía japonés nativo. Jardines del Este, puente Nijubashi y estación de Tokio. Tour privado de 2.5 horas. Desde ¥25,000."
+        title="Tour por el Palacio Imperial de Tokio en Español | Guía Privado"
+        description="Visita los Jardines del Este del Palacio Imperial y Marunouchi con un guía japonés nativo en español. Historia y modernidad de Tokio en 2.5 horas. Desde ¥25,000."
         canonicalPath="/es/tours/imperial-palace"
         hreflang={[
           { lang: "en", path: "/tours/imperial-palace" },

--- a/src/pages/es/tours/EsNikko.tsx
+++ b/src/pages/es/tours/EsNikko.tsx
@@ -9,8 +9,8 @@ const EsNikko = () => {
   return (
     <Layout>
       <SEO
-        title="Excursión Privada a Nikko en Español desde Tokio | Santuarios UNESCO y Naturaleza"
-        description="Excursión privada a Nikko con guía japonés nativo en español. Santuario Toshogu UNESCO, cascadas Kegon y paisaje de montaña. Día completo desde Tokio. Desde ¥60,000."
+        title="Excursión Privada a Nikko en Español desde Tokio | Patrimonio UNESCO"
+        description="Visita el Santuario Toshogu, Patrimonio de la Humanidad, con un guía japonés nativo en español. Cascadas y paisajes de montaña en un día completo desde Tokio. Desde ¥60,000."
         canonicalPath="/es/tours/nikko-day-trip"
         hreflang={[
           { lang: "en", path: "/tours/nikko-day-trip" },

--- a/src/pages/es/tours/EsShibuyaHarajuku.tsx
+++ b/src/pages/es/tours/EsShibuyaHarajuku.tsx
@@ -9,7 +9,7 @@ const EsShibuyaHarajuku = () => {
     <Layout>
       <SEO
         title="Tour por Shibuya y Harajuku en Español | Guía Japonés Nativo | Tokio"
-        description="Explora Shibuya y Harajuku con Manabu, guía japonés nativo con licencia oficial. Cruce de Shibuya, Takeshita, Santuario Meiji. Tour privado de 3.5 horas. Desde ¥35,000."
+        description="Recorre el famoso cruce de Shibuya y las calles de Harajuku con un guía japonés nativo en español. Santuario Meiji incluido. Tour privado 3.5 horas desde ¥35,000."
         canonicalPath="/es/tours/shibuya-harajuku"
         hreflang={[
           { lang: "en", path: "/tours/shibuya-harajuku" },

--- a/src/pages/es/tours/EsTsukijiGinza.tsx
+++ b/src/pages/es/tours/EsTsukijiGinza.tsx
@@ -8,8 +8,8 @@ const EsTsukijiGinza = () => {
   return (
     <Layout>
       <SEO
-        title="Tour por Tsukiji y Ginza en Español | Guía Japonés Nativo | Tokio"
-        description="Descubre Tsukiji y Ginza con Manabu, guía japonés nativo. Mercado de Tsukiji, degustaciones y el elegante distrito de Ginza. Tour privado de 3 horas. Desde ¥30,000."
+        title="Tour por Tsukiji y Ginza en Español | Gastronomía y Lujo en Tokio"
+        description="Descubre el mercado exterior de Tsukiji y el elegante barrio de Ginza con un guía japonés nativo en español. Gastronomía local e historia en 3 horas. Desde ¥30,000."
         canonicalPath="/es/tours/tsukiji-ginza"
         hreflang={[
           { lang: "en", path: "/tours/tsukiji-ginza" },


### PR DESCRIPTION
…er spec

- Create /es/tours (Spanish tour listing page) with localized EsTourCard
- Create /es/faq (Spanish FAQ page) with fully translated Q&A content
- Update title/description on 6 existing tour pages to match spec exactly
- Add routes for /es/tours and /es/faq in AppRoutes
- Add /es/tours and /es/faq to sitemap.xml and prerender.mjs
- Update /es/ hero "Ver Tours" link to point to /es/tours (was /es/tours/asakusa)
- Add hreflang to English Tours.tsx and FAQ.tsx for Spanish counterparts

https://claude.ai/code/session_016eN7Vm2AD2BGrYJ7J5Q5Th