### PR TITLE
Update hero image filename in About pages

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -3,7 +3,7 @@ import { Award, Globe, Briefcase, Heart, MapPin, Languages, Shield, Users, BookO
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import guidePortrait from "@/assets/About_page_Manabu_team_photo.webp";
-import heroImage from "@/assets/hero-asakusa.jpg";
+import heroImage from "@/assets/asakusa-temple.jpg";
 
 const stats = [
   { label: "Tours Completed", value: "500+" },

--- a/src/pages/es/EsAbout.tsx
+++ b/src/pages/es/EsAbout.tsx
@@ -4,7 +4,7 @@ import { Award, Globe, Briefcase, Heart, MapPin, Languages, Shield, Users, BookO
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import guidePortrait from "@/assets/About_page_Manabu_team_photo.webp";
-import heroImage from "@/assets/hero-asakusa.jpg";
+import heroImage from "@/assets/asakusa-temple.jpg";
 
 const stats = [
   { label: "Tours Completados", value: "500+" },


### PR DESCRIPTION
## Summary
Updated the hero image import filename across About page components to use a more descriptive asset name.

## Changes
- Updated hero image import in `src/pages/About.tsx` from `hero-asakusa.jpg` to `asakusa-temple.jpg`
- Updated hero image import in `src/pages/es/EsAbout.tsx` from `hero-asakusa.jpg` to `asakusa-temple.jpg`

## Details
This change renames the hero image asset reference to be more descriptive and specific about the content (Asakusa Temple). Both the English and Spanish About page components have been updated to maintain consistency across localized versions.

https://claude.ai/code/session_01DuNVavfduCR2MwpH7ptc1e