### PR TITLE
feat: add ScrollToTop component to scroll to page top on navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import { BrowserRouter } from "react-router-dom";
 import AppRoutes from "./AppRoutes";
+import ScrollToTop from "./components/ScrollToTop";
 
 const App = () => (
   <BrowserRouter>
+    <ScrollToTop />
     <AppRoutes />
   </BrowserRouter>
 );

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useLayoutEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  // Disable browser's automatic scroll restoration
+  useEffect(() => {
+    if ("scrollRestoration" in window.history) {
+      window.history.scrollRestoration = "manual";
+    }
+  }, []);
+
+  // Use useLayoutEffect to scroll before the browser paints
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
Prevents browser scroll restoration and uses useLayoutEffect to ensure pages always start at the top after client-side route changes.