### PR TITLE
feat: adjust brand colors and hero to match design mockup

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -63,9 +63,9 @@ export const Header = () => {
     return (
       <header className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-md border-b border-border/50">
         <nav className="container-section">
-          <div className="flex items-center justify-between h-16 md:h-20">
+          <div className="flex items-center justify-between h-20 md:h-28">
             <Link to="/es" className="flex items-center">
-              <img src="/images/logo.png" alt="Tanuki Tabi Travel" className="h-10 md:h-14 w-auto" />
+              <img src="/images/logo.png" alt="Tanuki Tabi Travel" className="h-12 md:h-[80px] w-auto" />
             </Link>
 
             {/* Desktop Navigation */}
@@ -342,10 +342,10 @@ export const Header = () => {
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-md border-b border-border/50">
       <nav className="container-section">
-        <div className="flex items-center justify-between h-16 md:h-20">
+        <div className="flex items-center justify-between h-20 md:h-28">
           {/* Logo */}
           <Link to="/" className="flex items-center">
-            <img src="/images/logo.png" alt="Tanuki Tabi Travel" className="h-10 md:h-14 w-auto" />
+            <img src="/images/logo.png" alt="Tanuki Tabi Travel" className="h-12 md:h-[80px] w-auto" />
           </Link>
 
           {/* Desktop Navigation */}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -10,7 +10,7 @@ export const Layout = ({ children }: LayoutProps) => {
   return (
     <div className="min-h-screen flex flex-col">
       <Header />
-      <main className="flex-1 pt-16 md:pt-20">
+      <main className="flex-1 pt-20 md:pt-28">
         {children}
       </main>
       <Footer />

--- a/src/index.css
+++ b/src/index.css
@@ -29,8 +29,8 @@
     --muted: 60 10% 93%;
     --muted-foreground: 0 0% 42%;
 
-    /* Gold accent — warm gold for CTAs, accents, hover states */
-    --accent: 48 88% 38%;
+    /* Gold accent — warm gold for CTAs, accents, hover states (#C9A84C) */
+    --accent: 44 54% 54%;
     --accent-foreground: 0 0% 5%;
 
     /* Subtle sage green for highlights */
@@ -38,7 +38,7 @@
     --highlight-foreground: 60 20% 97%;
 
     /* Gold accent for premium feel (same as accent) */
-    --gold: 48 88% 38%;
+    --gold: 44 54% 54%;
     --gold-foreground: 0 0% 5%;
 
     --destructive: 0 84% 60%;
@@ -46,14 +46,14 @@
 
     --border: 60 10% 88%;
     --input: 60 10% 88%;
-    --ring: 48 88% 38%;
+    --ring: 44 54% 54%;
 
     --radius: 0.5rem;
 
     /* Custom gradients */
     --gradient-hero: linear-gradient(180deg, hsl(60 20% 97% / 0) 0%, hsl(60 20% 97% / 0.8) 50%, hsl(60 20% 97%) 100%);
     --gradient-card: linear-gradient(135deg, hsl(60 15% 95%) 0%, hsl(60 10% 92%) 100%);
-    --gradient-accent: linear-gradient(135deg, hsl(48 88% 38%) 0%, hsl(43 85% 42%) 100%);
+    --gradient-accent: linear-gradient(135deg, hsl(44 54% 54%) 0%, hsl(44 60% 48%) 100%);
 
     /* Shadows */
     --shadow-soft: 0 4px 20px -4px hsl(0 0% 10% / 0.08);
@@ -65,10 +65,10 @@
     --sidebar-foreground: 0 0% 10%;
     --sidebar-primary: 0 0% 5%;
     --sidebar-primary-foreground: 60 20% 97%;
-    --sidebar-accent: 48 88% 38%;
+    --sidebar-accent: 44 54% 54%;
     --sidebar-accent-foreground: 0 0% 5%;
     --sidebar-border: 60 10% 88%;
-    --sidebar-ring: 48 88% 38%;
+    --sidebar-ring: 44 54% 54%;
   }
 
   .dark {
@@ -90,13 +90,13 @@
     --muted: 0 0% 14%;
     --muted-foreground: 0 0% 55%;
 
-    --accent: 48 80% 42%;
+    --accent: 44 54% 50%;
     --accent-foreground: 0 0% 5%;
 
     --highlight: 150 25% 40%;
     --highlight-foreground: 60 10% 92%;
 
-    --gold: 48 80% 42%;
+    --gold: 44 54% 50%;
     --gold-foreground: 0 0% 5%;
 
     --destructive: 0 70% 45%;
@@ -104,16 +104,16 @@
 
     --border: 0 0% 18%;
     --input: 0 0% 18%;
-    --ring: 48 80% 42%;
+    --ring: 44 54% 50%;
 
     --sidebar-background: 0 0% 9%;
     --sidebar-foreground: 60 10% 92%;
     --sidebar-primary: 60 10% 92%;
     --sidebar-primary-foreground: 0 0% 7%;
-    --sidebar-accent: 48 80% 42%;
+    --sidebar-accent: 44 54% 50%;
     --sidebar-accent-foreground: 0 0% 5%;
     --sidebar-border: 0 0% 18%;
-    --sidebar-ring: 48 80% 42%;
+    --sidebar-ring: 44 54% 50%;
   }
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -168,7 +168,7 @@ const Index = () => {
             alt="Group photo with guests during a private Tokyo walking tour"
             className="w-full h-full object-cover"
           />
-          <div className="absolute inset-0 bg-gradient-to-r from-black/70 via-black/40 to-transparent" />
+          <div className="absolute inset-0 bg-black/50" />
         </div>
 
         <div className="relative container-section py-20">
@@ -177,7 +177,7 @@ const Index = () => {
               Tokyo Walks with Manabu —{" "}
               <span className="text-accent">Your Licensed Local Guide</span>
             </h1>
-            <p className="mt-6 text-lg text-white/90 leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.3s" }}>
+            <p className="mt-6 text-lg text-accent leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.3s" }}>
               500+ tours completed. 4.86★ average rating. Government-licensed guide.
             </p>
             <p className="mt-3 text-base text-white/70 leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.35s" }}>

--- a/src/pages/es/EsIndex.tsx
+++ b/src/pages/es/EsIndex.tsx
@@ -169,7 +169,7 @@ const EsIndex = () => {
             alt="Foto grupal con invitados durante un tour privado a pie por Tokio"
             className="w-full h-full object-cover"
           />
-          <div className="absolute inset-0 bg-gradient-to-r from-black/70 via-black/40 to-transparent" />
+          <div className="absolute inset-0 bg-black/50" />
         </div>
 
         <div className="relative container-section py-20">
@@ -178,7 +178,7 @@ const EsIndex = () => {
               Tokyo con Manabu —{" "}
               <span className="text-accent">Tu Guía Local Certificado</span>
             </h1>
-            <p className="mt-6 text-lg text-white/90 leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.3s" }}>
+            <p className="mt-6 text-lg text-accent leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.3s" }}>
               Más de 500 tours completados. Valoración media de 4.86★. Guía con licencia oficial del gobierno japonés.
             </p>
             <p className="mt-3 text-base text-white/70 leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.35s" }}>


### PR DESCRIPTION
- Gold accent updated from #B8960C to #C9A84C (warmer, lighter gold)
- Logo height increased to 80px on desktop, header height adjusted
- Hero overlay changed from gradient to uniform bg-black/50
- Hero subtitle line now uses gold (#C9A84C) color
- Layout padding updated to match taller header