### PR TITLE
Refactor section headers and "How It Works" step indicators

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { ArrowRight, Award, Users, Shield, Star } from "lucide-react";
+import { ArrowRight, Award, Users, Shield, Star, MapPin, Heart, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { TourCard } from "@/components/tours/TourCard";
@@ -208,9 +208,7 @@ const Index = () => {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
             {trustSignals.map((signal) => (
               <div key={signal.title} className="text-center group">
-                <div className="w-14 h-14 rounded-full bg-accent/10 flex items-center justify-center mx-auto mb-4 group-hover:bg-accent/20 transition-colors">
-                  <signal.icon className="w-7 h-7 text-accent" />
-                </div>
+                <signal.icon className="w-7 h-7 text-accent mx-auto mb-4" strokeWidth={1.2} />
                 <h3 className="text-lg font-semibold text-foreground">
                   {signal.title}
                 </h3>
@@ -276,7 +274,8 @@ const Index = () => {
       <section className="py-20 md:py-28 bg-secondary/30">
         <div className="container-section">
           <div className="text-center max-w-2xl mx-auto mb-12">
-            <p className="text-label text-accent mb-3">Explore Tokyo</p>
+            <p className="text-label text-accent mb-4">Explore Tokyo</p>
+            <div className="w-10 h-px bg-accent mx-auto mb-6" />
             <h2 className="heading-section text-foreground">Featured Tours</h2>
             <p className="mt-4 text-body">
               Choose from carefully curated walking tours or create your own custom experience.
@@ -317,7 +316,8 @@ const Index = () => {
         <div className="container-section">
           <div className="grid lg:grid-cols-2 gap-16 items-center">
             <div>
-              <p className="text-label text-accent mb-3">Your Guide</p>
+              <p className="text-label text-accent mb-4">Your Guide</p>
+              <div className="w-10 h-px bg-accent mb-6" />
               <h2 className="heading-section text-foreground">
                 Meet Manabu — Your Licensed Tokyo Guide
               </h2>
@@ -355,43 +355,38 @@ const Index = () => {
       {/* How It Works */}
       <section className="py-20 md:py-28 bg-secondary/30">
         <div className="container-section">
-          <div className="text-center max-w-2xl mx-auto mb-12">
-            <p className="text-label text-accent mb-3">Simple Booking</p>
+          <div className="text-center max-w-2xl mx-auto mb-14">
+            <p className="text-label text-accent mb-4">Simple Booking</p>
+            <div className="w-10 h-px bg-accent mx-auto mb-6" />
             <h2 className="heading-section text-foreground">How It Works</h2>
           </div>
 
           <div className="grid md:grid-cols-3 gap-12">
             <div className="text-center">
-              <div className="w-16 h-16 rounded-full bg-accent text-white flex items-center justify-center mx-auto mb-6 text-2xl font-serif font-semibold">
-                1
-              </div>
+              <MapPin className="w-8 h-8 text-accent mx-auto mb-5" strokeWidth={1.2} />
               <h3 className="text-xl font-semibold text-foreground mb-3">
-                Choose a Tour
+                Choose Your Experience
               </h3>
-              <p className="text-muted-foreground leading-relaxed">
-                Browse our curated tours or request a custom itinerary tailored to your interests.
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Browse curated tours or tell me your dream day in Tokyo.
               </p>
             </div>
             <div className="text-center">
-              <div className="w-16 h-16 rounded-full bg-accent text-white flex items-center justify-center mx-auto mb-6 text-2xl font-serif font-semibold">
-                2
-              </div>
+              <Heart className="w-8 h-8 text-accent mx-auto mb-5" strokeWidth={1.2} />
               <h3 className="text-xl font-semibold text-foreground mb-3">
-                Share Your Interests
+                Share What Excites You
               </h3>
-              <p className="text-muted-foreground leading-relaxed">
-                Tell us what excites you — food, history, photography, pop culture — and we'll personalize your experience.
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                History, food, hidden alleys — I'll build the route around you.
               </p>
             </div>
             <div className="text-center">
-              <div className="w-16 h-16 rounded-full bg-accent text-white flex items-center justify-center mx-auto mb-6 text-2xl font-serif font-semibold">
-                3
-              </div>
+              <User className="w-8 h-8 text-accent mx-auto mb-5" strokeWidth={1.2} />
               <h3 className="text-xl font-semibold text-foreground mb-3">
-                Explore Tokyo
+                Walk Tokyo Together
               </h3>
-              <p className="text-muted-foreground leading-relaxed">
-                Meet your guide and discover Tokyo at your own pace. No crowds, no rush — just an authentic experience.
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                No scripts. No crowds. Just you, your guide, and the city.
               </p>
             </div>
           </div>
@@ -432,7 +427,8 @@ const Index = () => {
       <section className="py-20 md:py-28">
         <div className="container-section">
           <div className="text-center max-w-2xl mx-auto mb-12">
-            <p className="text-label text-accent mb-3">Guest Reviews</p>
+            <p className="text-label text-accent mb-4">Guest Reviews</p>
+            <div className="w-10 h-px bg-accent mx-auto mb-6" />
             <h2 className="heading-section text-foreground">What Travelers Say</h2>
           </div>
 

--- a/src/pages/es/EsIndex.tsx
+++ b/src/pages/es/EsIndex.tsx
@@ -1,6 +1,6 @@
 // TRANSLATION REVIEW NEEDED: Please have a native Spanish speaker review this content before publishing
 import { Link } from "react-router-dom";
-import { ArrowRight, Award, Users, Shield, Star } from "lucide-react";
+import { ArrowRight, Award, Users, Shield, Star, MapPin, Heart, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { TourCard } from "@/components/tours/TourCard";
@@ -206,9 +206,7 @@ const EsIndex = () => {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
             {trustSignals.map((signal) => (
               <div key={signal.title} className="text-center group">
-                <div className="w-14 h-14 rounded-full bg-accent/10 flex items-center justify-center mx-auto mb-4 group-hover:bg-accent/20 transition-colors">
-                  <signal.icon className="w-7 h-7 text-accent" />
-                </div>
+                <signal.icon className="w-7 h-7 text-accent mx-auto mb-4" strokeWidth={1.2} />
                 <h3 className="text-lg font-medium text-foreground">
                   {signal.title}
                 </h3>
@@ -268,7 +266,8 @@ const EsIndex = () => {
       <section className="py-20 md:py-28 bg-secondary/30">
         <div className="container-section">
           <div className="text-center max-w-2xl mx-auto mb-12">
-            <p className="text-label text-accent mb-3">Explora Tokio</p>
+            <p className="text-label text-accent mb-4">Explora Tokio</p>
+            <div className="w-10 h-px bg-accent mx-auto mb-6" />
             <h2 className="heading-section text-foreground">Tours Disponibles en Español</h2>
             <p className="mt-4 text-body">
               Elige entre tours cuidadosamente diseñados o crea tu propia experiencia personalizada.
@@ -335,7 +334,8 @@ const EsIndex = () => {
         <div className="container-section">
           <div className="grid lg:grid-cols-2 gap-16 items-center">
             <div>
-              <p className="text-label text-accent mb-3">Tu Guía</p>
+              <p className="text-label text-accent mb-4">Tu Guía</p>
+              <div className="w-10 h-px bg-accent mb-6" />
               <h2 className="heading-section text-foreground">
                 Conoce a Manabu — Tu Guía Oficial en Tokio
               </h2>
@@ -367,43 +367,38 @@ const EsIndex = () => {
       {/* How to Book */}
       <section className="py-20 md:py-28 bg-secondary/30">
         <div className="container-section">
-          <div className="text-center max-w-2xl mx-auto mb-12">
-            <p className="text-label text-accent mb-3">Reserva Fácil</p>
+          <div className="text-center max-w-2xl mx-auto mb-14">
+            <p className="text-label text-accent mb-4">Reserva Fácil</p>
+            <div className="w-10 h-px bg-accent mx-auto mb-6" />
             <h2 className="heading-section text-foreground">Cómo Reservar</h2>
           </div>
 
           <div className="grid md:grid-cols-3 gap-12">
             <div className="text-center">
-              <div className="w-16 h-16 rounded-full bg-accent text-white flex items-center justify-center mx-auto mb-6 text-2xl font-serif font-semibold">
-                1
-              </div>
+              <MapPin className="w-8 h-8 text-accent mx-auto mb-5" strokeWidth={1.2} />
               <h3 className="text-xl font-medium text-foreground mb-3">
-                Elige tu tour
+                Elige tu experiencia
               </h3>
-              <p className="text-muted-foreground leading-relaxed">
-                Explora nuestros tours o solicita un itinerario personalizado.
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Explora nuestros tours o cuéntame tu día ideal en Tokio.
               </p>
             </div>
             <div className="text-center">
-              <div className="w-16 h-16 rounded-full bg-accent text-white flex items-center justify-center mx-auto mb-6 text-2xl font-serif font-semibold">
-                2
-              </div>
+              <Heart className="w-8 h-8 text-accent mx-auto mb-5" strokeWidth={1.2} />
               <h3 className="text-xl font-medium text-foreground mb-3">
-                Cuéntame tus intereses
+                Comparte lo que te apasiona
               </h3>
-              <p className="text-muted-foreground leading-relaxed">
-                Gastronomía, historia, fotografía, cultura pop — lo adaptamos todo.
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Historia, gastronomía, callejones ocultos — creo la ruta a tu medida.
               </p>
             </div>
             <div className="text-center">
-              <div className="w-16 h-16 rounded-full bg-accent text-white flex items-center justify-center mx-auto mb-6 text-2xl font-serif font-semibold">
-                3
-              </div>
+              <User className="w-8 h-8 text-accent mx-auto mb-5" strokeWidth={1.2} />
               <h3 className="text-xl font-medium text-foreground mb-3">
-                Explora Tokio
+                Recorremos Tokio juntos
               </h3>
-              <p className="text-muted-foreground leading-relaxed">
-                Nos encontramos y descubrimos Tokio a tu ritmo. Sin aglomeraciones, sin prisas.
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Sin guiones. Sin multitudes. Solo tú, tu guía y la ciudad.
               </p>
             </div>
           </div>
@@ -444,7 +439,8 @@ const EsIndex = () => {
       <section className="py-20 md:py-28">
         <div className="container-section">
           <div className="text-center max-w-2xl mx-auto mb-12">
-            <p className="text-label text-accent mb-3">Opiniones</p>
+            <p className="text-label text-accent mb-4">Opiniones</p>
+            <div className="w-10 h-px bg-accent mx-auto mb-6" />
             <h2 className="heading-section text-foreground">Lo Que Dicen los Viajeros</h2>
           </div>
 


### PR DESCRIPTION
## Summary
This PR refactors the visual design of section headers and the "How It Works" step indicators across the Index and Spanish translation pages. The changes modernize the UI by replacing numbered circular badges with icon-based indicators and adding decorative accent lines to section headers.

## Key Changes

- **Section Header Enhancement**: Added decorative horizontal accent lines (`w-10 h-px bg-accent`) below section labels ("Explore Tokyo", "Your Guide", "Simple Booking", "Guest Reviews") with adjusted spacing for better visual hierarchy
  
- **"How It Works" Step Redesign**: 
  - Replaced numbered circular badges (1, 2, 3) with semantic icons (MapPin, Heart, User)
  - Updated step titles to be more action-oriented ("Choose Your Experience", "Share What Excites You", "Walk Tokyo Together")
  - Condensed step descriptions to be more concise and impactful
  - Reduced text size from default to `text-sm` for better visual balance
  
- **Trust Signals Simplification**: Removed the circular background container (`w-14 h-14 rounded-full bg-accent/10`) from trust signal icons, displaying them directly with adjusted stroke width for consistency

- **Spacing Adjustments**: 
  - Increased section header bottom margin from `mb-3` to `mb-4` for better breathing room
  - Adjusted "How It Works" container margin from `mb-12` to `mb-14`
  - Updated step icon bottom margin from `mb-6` to `mb-5`

## Implementation Details

- Applied changes consistently across both English (`src/pages/Index.tsx`) and Spanish (`src/pages/es/EsIndex.tsx`) versions
- Added new icon imports (MapPin, Heart, User) from lucide-react
- Maintained responsive design and existing layout structure
- All changes are purely visual/UX improvements with no functional modifications

https://claude.ai/code/session_01BqNLvszNAvn4oaVmoyq54F