### PR TITLE
Add three new landmark images to Index page gallery

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -18,6 +18,9 @@ import tourUeno from "@/assets/tour-ueno.jpg";
 import guidePortrait from "@/assets/About_page_Manabu_team_photo.webp";
 import imperialPalace from "@/assets/imperial-palace.jpg";
 import hamarikyu from "@/assets/hamarikyu.jpg";
+import asakusaTemple from "@/assets/asakusa-temple.jpg";
+import tsukijiMarket from "@/assets/tsukiji-market.jpg";
+import shibuyaStreet from "@/assets/shibuya-street.jpg";
 
 const tours = [
   {
@@ -241,6 +244,29 @@ const Index = () => {
                 That's why guests from over 30 countries have called this the best
                 tour of the trip — not just of Tokyo, but of their entire journey.
               </p>
+            </div>
+            <div className="mt-10 grid grid-cols-3 gap-3 md:gap-4">
+              <div className="aspect-[4/3] rounded-lg overflow-hidden">
+                <img
+                  src={asakusaTemple}
+                  alt="Senso-ji Temple with Tokyo Skytree"
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <div className="aspect-[4/3] rounded-lg overflow-hidden">
+                <img
+                  src={tsukijiMarket}
+                  alt="Tsukiji fish market"
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <div className="aspect-[4/3] rounded-lg overflow-hidden">
+                <img
+                  src={shibuyaStreet}
+                  alt="Shibuya streets at night"
+                  className="w-full h-full object-cover"
+                />
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Added three new landmark images to the Index page to enhance the visual content showcasing Tokyo's iconic destinations.

## Key Changes
- Imported three new image assets:
  - `asakusa-temple.jpg` - Senso-ji Temple with Tokyo Skytree
  - `tsukiji-market.jpg` - Tsukiji fish market
  - `shibuya-street.jpg` - Shibuya streets at night
- Added a new 3-column responsive image gallery grid below the existing tour description content
- Implemented responsive design with `grid-cols-3` layout and `md:gap-4` spacing adjustments
- Used consistent styling with `aspect-[4/3]` ratio, rounded corners, and object-cover for proper image scaling

## Implementation Details
- Images are displayed in a responsive grid that maintains a 4:3 aspect ratio
- Gallery is positioned after the tour description text with `mt-10` margin spacing
- Each image includes descriptive alt text for accessibility
- Layout uses Tailwind CSS utilities for responsive behavior across different screen sizes

https://claude.ai/code/session_015ANz6eQ61JPoaM3EYvxQnz