### PR TITLE
Enhance Tokyo Food Tour SEO and add vegetarian tour content

### DIFF
--- a/src/pages/tours/TokyoFoodTour.tsx
+++ b/src/pages/tours/TokyoFoodTour.tsx
@@ -149,8 +149,8 @@ const TokyoFoodTour = () => {
   return (
     <Layout>
       <SEO
-        title="Tokyo Food Tour | Private Guided Food Experience | Tanuki Tabi Travel"
-        description="Taste Tokyo's best food with a local licensed guide. From Tsukiji street food to hidden ramen shops, customize your private food tour experience."
+        title="Tokyo Food Tour | Best Private Local Food Experience | Tanuki Tabi"
+        description="Join a private Tokyo food tour with a licensed local guide. Explore Tsukiji Market, hidden ramen shops, and izakaya. Fully customizable for vegetarian, vegan, halal, and gluten-free diets."
         canonicalPath="/tours/tokyo-food-tour"
       />
 
@@ -299,6 +299,23 @@ const TokyoFoodTour = () => {
                 </p>
               </div>
             ))}
+          </div>
+
+          {/* Vegetarian Food Tour at Tsukiji */}
+          <div className="mt-12 max-w-3xl mx-auto text-center">
+            <h3 className="heading-card text-foreground mb-3">
+              Vegetarian Food Tour at Tsukiji Market
+            </h3>
+            <p className="text-body">
+              Tsukiji Outer Market is not just about seafood. Our vegetarian food
+              tour at Tsukiji features freshly grilled vegetables, tamagoyaki
+              (Japanese egg omelet), pickled seasonal produce, miso-based soups,
+              and handmade mochi sweets. Your guide will create a custom menu
+              focused entirely on plant-based and vegetarian options, navigating
+              the stalls in Japanese to confirm every ingredient. Whether you
+              follow a strict vegetarian diet or simply prefer lighter fare,
+              Tsukiji has far more to offer than most visitors ever discover.
+            </p>
           </div>
         </div>
       </section>
@@ -495,7 +512,7 @@ const TokyoFoodTour = () => {
             "@type": "TouristTrip",
             "name": "Tokyo Private Food Tour",
             "description":
-              "Private guided food tour of Tokyo with a licensed guide",
+              "Private guided food tour of Tokyo with a licensed local guide. Explore Tsukiji Market, hidden ramen shops, izakaya, and more. Fully customizable for vegetarian, vegan, halal, and gluten-free diets.",
             "touristType": "Food enthusiasts",
             "provider": {
               "@type": "Organization",
@@ -506,6 +523,61 @@ const TokyoFoodTour = () => {
               "@type": "Offer",
               "priceCurrency": "JPY",
               "availability": "https://schema.org/InStock",
+            },
+          }),
+        }}
+      />
+
+      {/* Product + Offer Schema for rich search results */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Product",
+            "name": "Tokyo Private Food Tour",
+            "description":
+              "A fully customizable private food tour in Tokyo led by a licensed local guide. Visit Tsukiji Market, hidden ramen shops, izakaya alleys, and more. Accommodates vegetarian, vegan, halal, and gluten-free diets.",
+            "brand": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "offers": {
+              "@type": "Offer",
+              "url": "https://tanuki-tabi-travel.com/tours/tokyo-food-tour",
+              "priceCurrency": "JPY",
+              "price": "15000",
+              "availability": "https://schema.org/InStock",
+              "validFrom": "2026-01-01",
+            },
+            "areaServed": {
+              "@type": "City",
+              "name": "Tokyo",
+              "addressCountry": "JP",
+            },
+          }),
+        }}
+      />
+
+      {/* TouristAttraction Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "TouristAttraction",
+            "name": "Tokyo Private Food Tour by Tanuki Tabi Travel",
+            "description":
+              "Explore Tokyo's best local food spots with a private licensed guide. From Tsukiji Market street food to ramen, izakaya, and depachika — fully customizable and dietary-friendly.",
+            "touristType": ["Food Tourism", "Culinary Experience"],
+            "url": "https://tanuki-tabi-travel.com/tours/tokyo-food-tour",
+            "isAccessibleForFree": false,
+            "availableLanguage": ["en", "ja"],
+            "address": {
+              "@type": "PostalAddress",
+              "addressLocality": "Tokyo",
+              "addressCountry": "JP",
             },
           }),
         }}


### PR DESCRIPTION
## Summary
This PR improves the SEO performance and content richness of the Tokyo Food Tour page by updating meta tags, adding a dedicated vegetarian food tour section, and implementing additional structured data schemas for better search engine visibility.

## Key Changes
- **Updated SEO meta tags**: Refined page title and description to be more concise and keyword-focused, emphasizing "private local food experience" and dietary accommodations (vegetarian, vegan, halal, gluten-free)
- **Added vegetarian food tour section**: New content block highlighting Tsukiji Market's vegetarian options, including grilled vegetables, tamagoyaki, pickled produce, miso soups, and mochi sweets
- **Enhanced structured data**: 
  - Updated existing TouristTrip schema description with dietary customization details
  - Added Product + Offer schema for rich search results with pricing and availability information
  - Added TouristAttraction schema to improve local search visibility and provide additional context about the tour experience
- **Improved schema descriptions**: All schema descriptions now mention dietary accommodations and specific attractions (Tsukiji Market, ramen shops, izakaya)

## Implementation Details
- The new vegetarian section maintains consistent styling with existing content blocks using `heading-card` and `text-body` classes
- All three schema blocks use proper JSON-LD formatting with `dangerouslySetInnerHTML`
- Product schema includes pricing (15000 JPY) and availability metadata for e-commerce integration
- TouristAttraction schema specifies available languages (English and Japanese) and accessibility information

https://claude.ai/code/session_01NyH56kqvxpUEqGLUYQ5Sr9