### PR TITLE
Improve Shinjuku Guide SEO and section heading clarity

### DIFF
--- a/src/pages/blog/ShinjukuGuide.tsx
+++ b/src/pages/blog/ShinjukuGuide.tsx
@@ -7,8 +7,8 @@ const ShinjukuGuide = () => {
   return (
     <Layout>
       <SEO
-        title="Shinjuku Guide: What a Licensed Guide Shows Clients"
-        description="Shinjuku is Tokyo's most overwhelming neighborhood. A licensed guide who brings clients here weekly explains what's worth your time, and what to skip."
+        title="Shinjuku Guide: Best Things to Do | Local Expert Tips"
+        description="Plan your Shinjuku visit with insider tips from a licensed Tokyo guide. Explore Golden Gai, Omoide Yokocho, Gyoen Garden, and more hidden spots most tourists miss."
         canonicalPath="/blog/shinjuku-guide"
       />
 
@@ -509,7 +509,7 @@ const ShinjukuGuide = () => {
 
             {/* What I Show Clients */}
             <h2 className="heading-section text-foreground mt-12 mb-6">
-              What I Actually Show Clients in This Shinjuku Guide
+              Why Hire a Guide in Shinjuku: What I Actually Show Clients
             </h2>
             <p className="text-muted-foreground leading-relaxed mb-4">
               When I bring private tour clients to Shinjuku, I don't just show them the neon signs and say "here's the famous crossing." I show them why Shinjuku looks the way it does, and how it connects to the rest of Tokyo's story.


### PR DESCRIPTION
## Summary
Updated SEO metadata and content headings in the Shinjuku Guide page to better reflect the guide's value proposition and improve search engine visibility.

## Key Changes
- **SEO Title**: Changed from "Shinjuku Guide: What a Licensed Guide Shows Clients" to "Shinjuku Guide: Best Things to Do | Local Expert Tips" for better keyword targeting and clarity
- **SEO Description**: Expanded and refined to highlight specific attractions (Golden Gai, Omoide Yokocho, Gyoen Garden) and emphasize insider knowledge and hidden spots
- **Section Heading**: Updated "What I Actually Show Clients in This Shinjuku Guide" to "Why Hire a Guide in Shinjuku: What I Actually Show Clients" to better communicate the value of hiring a guide

## Implementation Details
These changes focus on improving discoverability and user engagement by:
- Using more action-oriented language ("Best Things to Do")
- Including specific landmark names in the meta description for better SEO matching
- Reframing the section heading to address a key user question ("Why hire a guide?") before explaining what's shown

https://claude.ai/code/session_01EP6JQijPRxwsDTzN9TN3yX