### PR TITLE
feat: add vegetarian food tour blog article and other updates

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -37,7 +37,9 @@ import TokyoItinerary5Days from "./pages/blog/TokyoItinerary5Days";
 import TokyoOnABudget from "./pages/blog/TokyoOnABudget";
 import TsukijiMarketGuide from "./pages/blog/TsukijiMarketGuide";
 import YanakaWalkingRoute from "./pages/blog/YanakaWalkingRoute";
+import YanakaWalkingTourGuide from "./pages/blog/YanakaWalkingTourGuide";
 import YokohamaDayTrip from "./pages/blog/YokohamaDayTrip";
+import VegetarianFoodTourTokyo from "./pages/blog/VegetarianFoodTourTokyo";
 import NotFound from "./pages/NotFound";
 import EsIndex from "./pages/es/EsIndex";
 import EsAsakusa from "./pages/es/tours/EsAsakusa";
@@ -125,7 +127,9 @@ const AppRoutes = () => (
         <Route path="/blog/tokyo-on-a-budget" element={<TokyoOnABudget />} />
         <Route path="/blog/tsukiji-market-guide" element={<TsukijiMarketGuide />} />
         <Route path="/blog/yanaka-tokyo-walking-route" element={<YanakaWalkingRoute />} />
+        <Route path="/blog/yanaka-walking-tour-guide" element={<YanakaWalkingTourGuide />} />
         <Route path="/blog/yokohama-day-trip-from-tokyo" element={<YokohamaDayTrip />} />
+        <Route path="/blog/vegetarian-food-tour-tokyo" element={<VegetarianFoodTourTokyo />} />
         {/* Spanish Pages */}
         <Route path="/es" element={<EsIndex />} />
         <Route path="/es/tours" element={<EsTours />} />

--- a/src/pages/blog/BlogIndex.tsx
+++ b/src/pages/blog/BlogIndex.tsx
@@ -119,6 +119,16 @@ const blogPosts: BlogPost[] = [
     image: "/images/tours/asakusa-backstreet-local.jpg",
   },
   {
+    slug: "yanaka-walking-tour-guide",
+    title: "Yanaka Walking Tour: Tokyo's Best-Kept Secret Neighborhood",
+    description:
+      "Yanaka is old Tokyo at its finest — temples, shotengai, and no crowds. A local guide shares the best walking route through this hidden gem.",
+    date: "March 8, 2026",
+    author: "Manabu, Licensed Tour Guide",
+    category: "Tokyo Area Guides",
+    image: "/images/tours/asakusa-backstreet-local.jpg",
+  },
+  {
     slug: "yanaka-tokyo-walking-route",
     title: "Yanaka Tokyo: A Guide's 3-Hour Walking Route",
     description:

--- a/src/pages/blog/NikkoDayTrip.tsx
+++ b/src/pages/blog/NikkoDayTrip.tsx
@@ -7,223 +7,304 @@ const NikkoDayTrip = () => {
   return (
     <Layout>
       <SEO
-        title="Nikko Day Trip from Tokyo: 2026 Guide | Tanuki Tabi"
-        description="Nikko is 2 hours from Tokyo and one of Japan's most ornate shrine complexes. A licensed guide explains how to get there, what to see, and how to plan."
+        title="Nikko Day Trip from Tokyo: Complete Guide (2025) | Tanuki Tabi"
+        description="Planning a Nikko day trip from Tokyo? A licensed guide covers trains, top sights, and why a private guided tour makes all the difference."
         canonicalPath="/blog/nikko-day-trip-from-tokyo"
       />
 
       {/* Hero Image */}
       <section className="relative h-[40vh] md:h-[50vh] min-h-[300px]">
         <img
-          src="/images/blog/nikko-toshogu-hero.jpg"
-          alt="Toshogu Shrine entrance through the stone torii gate in Nikko"
+          src="/images/candidates/nikko/PXL_20240718_040319956.MP.jpg"
+          alt="The ornate Yomeimon Gate at Nikko Tosho-gu Shrine surrounded by towering cedar trees"
           className="w-full h-full object-cover"
           loading="eager"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent" />
       </section>
 
+      {/* Article Header */}
       <section className="pt-16 pb-12 bg-secondary/30">
         <div className="container-section">
           <div className="max-w-3xl">
-            <Link to="/blog" className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6">
-              <ArrowLeft className="w-4 h-4" />Back to Blog
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
             </Link>
             <p className="text-label text-accent mb-3">Day Trip Guides</p>
             <h1 className="heading-display text-foreground">
-              Nikko Day Trip from Tokyo: The Complete 2026 Guide
+              Nikko Day Trip from Tokyo: Complete Guide
             </h1>
             <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
-              <span className="flex items-center gap-2"><User className="w-4 h-4" />Manabu, Licensed Tour Guide</span>
-              <span className="flex items-center gap-2"><Calendar className="w-4 h-4" />March 7, 2026</span>
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                March 8, 2026
+              </span>
             </div>
-            <p className="mt-4 text-sm text-muted-foreground italic">
-              Written by Manabu, a National Government Licensed Guide Interpreter (全国通訳案内士) who has guided over a hundred Nikko day trips from Tokyo.
-            </p>
           </div>
         </div>
       </section>
 
+      {/* Article Content */}
       <section className="py-16">
         <div className="container-section">
           <article className="max-w-3xl mx-auto prose-custom">
-            <p className="text-lg text-muted-foreground leading-relaxed mb-4">
-              Nikko is one of those rare places in Japan where nature and human ambition collide at full volume. Two hours north of Tokyo, tucked into the mountains of Tochigi Prefecture, sits one of the most lavishly decorated shrine complexes on earth, and most of the cedar forest around it has been standing since the 1600s. A Nikko day trip from Tokyo is entirely doable, deeply rewarding, and consistently one of the top experiences my clients rave about after their Japan trip ends.
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-8">
+              Nikko is one of those places that takes visitors by surprise. People come expecting a temple and a waterfall, and they leave speechless. Two hours north of Tokyo, hidden in the mountains of Tochigi Prefecture, sits one of the most extravagantly decorated shrine complexes on earth, a place where every surface is covered in gold leaf and thousands of hand-carved figures tell stories that are four centuries old. I have been leading guided tours to Nikko for years now, and it remains the day trip my clients talk about most when they write to me after returning home. There is something about the combination of extreme human artistry and raw mountain nature that stays with you in a way that other destinations simply do not.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-8">
-              But Nikko requires a bit more planning than hopping on a train to Kamakura. The distances are longer, the layout is spread out, and the historical layers run deep. Here's everything I tell my clients before we go.
+              But a Nikko day trip from Tokyo requires more thought than most excursions. The travel time is longer, the layout is spread across a mountainous area, and the historical layers run far deeper than what any signboard can convey. After leading well over a hundred trips to Nikko, I have learned exactly what makes the difference between a rushed, confusing visit and a deeply rewarding one. This guide is everything I know, distilled into the advice I give every client before we board the train.
             </p>
 
+            {/* Section 1: How to Get to Nikko */}
             <h2 className="heading-section text-foreground mt-12 mb-6">
-              Why Nikko Exists (The Short Version)
+              How to Get to Nikko from Tokyo (Train Options & Cost)
             </h2>
+            <figure className="my-8">
+              <img
+                src="/images/candidates/train/PXL_20240726_023308396.jpg"
+                alt="Train heading toward Nikko through the Japanese countryside"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                The journey north from Tokyo takes you through increasingly rural scenery as the mountains draw closer
+              </figcaption>
+            </figure>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              In 1616, Tokugawa Ieyasu, the shogun who unified Japan after more than a century of civil war, died at the age of 73. He had already chosen his burial site: a sacred mountain area in Nikko that had been a center of mountain worship for over 800 years. His grandson, Tokugawa Iemitsu, then spent two years and an estimated 1.5 million workers transforming the site into the Tosho-gu shrine complex we see today.
+              Getting to Nikko is straightforward once you know which train to take, but there are two completely different routes and choosing the wrong one can cost you both money and time. The route I recommend to almost everyone is the Tobu Nikko Line, which departs from Tobu Asakusa Station in central Tokyo. The limited express trains on this line, branded as "Spacia X" or the older "Spacia Kinu," run direct to Tobu-Nikko Station without requiring any transfers. The ride takes approximately one hour and fifty minutes, and a one-way ticket costs around 2,800 yen for a reserved seat on the limited express. If you are willing to ride the regular rapid train instead of the limited express, you can get there for about 1,400 yen, though the journey takes closer to two hours and twenty minutes with a transfer at Shimo-Imaichi.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              The result was deliberately, almost aggressively impressive. While most Japanese shrines and temples follow a principle of restrained beauty (think bare wood, clean lines, quiet spaces), Tosho-gu went the opposite direction. Every surface is covered in gold leaf, lacquer, and intricate carvings. There are over 5,000 individual carvings on the buildings, many painted in vivid colors that have been restored to their original intensity.
+              The second route uses the JR network. You take the Tohoku Shinkansen from Tokyo Station or Ueno Station to Utsunomiya, which takes roughly fifty minutes, and then transfer to the JR Nikko Line for another forty-five minutes. The total travel time is similar to the Tobu limited express, but the cost is significantly higher at around 5,500 yen one way. The only reason to choose this route is if you already hold a Japan Rail Pass, which covers the entire fare. If you do not have a JR Pass, the Tobu line from Asakusa is the obvious choice. It is cheaper, it is more direct, and the Asakusa departure point puts you right in one of Tokyo's most interesting neighborhoods if you want to grab breakfast before you go.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              I often compare Tosho-gu to Versailles for my clients. Both were built not primarily for worship or living, but as statements of absolute power. Louis XIV wanted visiting nobles to feel small when they walked through Versailles. Tokugawa Iemitsu wanted feudal lords (daimyo), who were forced to make pilgrimages to Nikko, to understand exactly who was in charge. The shrine's extravagance was the message: the Tokugawa dynasty controls enough wealth, labor, and artisan talent to build this, and you don't.
-            </p>
-            <p className="text-muted-foreground leading-relaxed mb-4">
-              Understanding this context transforms a Nikko day trip from Tokyo from "looking at a fancy shrine" into witnessing one of history's great political power plays frozen in wood and gold.
+              Whichever route you choose, I always tell my clients to aim for the earliest reasonable departure, ideally arriving in Nikko by 9:00 or 9:30 in the morning. Tosho-gu opens at 9:00 AM from April through October and at 9:00 AM the rest of the year as well, and the first hour before the large group tours arrive is when you can actually stand in front of the Yomeimon Gate and absorb its detail without being pushed along by a crowd. From Tobu-Nikko Station, it is about a twenty-five minute walk to the shrine area, or a short bus ride. I personally prefer walking because the approach takes you across the beautiful Shinkyo Bridge and through the towering cedar forest, which is the perfect way to decompress after the train and mentally arrive in Nikko before the sightseeing begins.
             </p>
 
+            {/* Section 2: Top Sights */}
             <h2 className="heading-section text-foreground mt-12 mb-6">
-              How to Get from Tokyo to Nikko
+              Top Sights in Nikko (Tosho-gu, Kegon Falls, Shinkyo Bridge)
             </h2>
+            <figure className="my-8">
+              <img
+                src="/images/candidates/nikko/PXL_20240718_040819618.jpg"
+                alt="Intricate carvings and gold leaf decoration at Nikko Tosho-gu Shrine"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                Every surface at Tosho-gu is alive with carvings, gold leaf, and centuries of craftsmanship
+              </figcaption>
+            </figure>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              There are two main routes, and the one you choose depends on whether you have a JR Pass:
+              <strong className="text-foreground">Tosho-gu Shrine</strong> is the reason Nikko exists as a destination, and it deserves the longest portion of your visit. This is the mausoleum of Tokugawa Ieyasu, the shogun who unified Japan after more than a century of civil war, and his grandson poured the resources of an entire nation into making it the most impressive religious site in the country. There are over 5,000 individual carvings spread across the buildings, many of them painted in vivid reds, greens, blues, and golds that have been meticulously restored over the centuries. The famous "see no evil, speak no evil, hear no evil" monkeys are here, carved above the sacred horse stable, and each panel in the sequence tells a chapter in the story of human life from birth to parenthood. The Yomeimon Gate alone contains more than 500 carvings and is considered one of the finest examples of architectural decoration in all of Japan. I have stood in front of it hundreds of times and I still notice details I missed before. Without a guide to point them out and explain the stories behind them, most visitors glance at the gate for thirty seconds and move on. With context, you could spend twenty minutes on the Yomeimon alone and it would not feel like enough.
             </p>
-            <ul className="space-y-4 mb-8">
-              <li className="text-muted-foreground leading-relaxed">
-                <strong className="text-foreground">Tobu Railway from Asakusa Station (recommended):</strong> The Tobu Nikko Line runs direct limited express trains (called "Spacia" or "Revaty") from Asakusa to Tobu-Nikko Station. The ride takes about 1 hour 50 minutes and costs around ¥2,800 one way. This is the fastest and cheapest option for most travelers. The train is comfortable and the route passes through increasingly rural scenery as you leave Tokyo behind. If you're planning a Nikko day trip from Tokyo on a budget, this is your best bet.
-              </li>
-              <li className="text-muted-foreground leading-relaxed">
-                <strong className="text-foreground">JR Shinkansen + local line:</strong> Take the Tohoku Shinkansen from Tokyo or Ueno Station to Utsunomiya (about 50 minutes), then transfer to the JR Nikko Line for another 45 minutes. Total time is roughly the same as Tobu, but the cost is significantly higher, around ¥5,500 one way. The advantage? It's fully covered by the Japan Rail Pass. If you have a JR Pass, this route costs you nothing extra. If you don't, take the Tobu line instead.
-              </li>
-            </ul>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              Either way, I recommend leaving Tokyo by 8:00 AM. Nikko's shrines open at 9:00 AM, and the earlier you arrive, the fewer crowds you'll deal with, especially at Tosho-gu, which gets packed by late morning.
+              Do not skip the climb to Ieyasu's actual tomb. A stone stairway behind the main hall leads up through ancient cedar forest to a surprisingly simple bronze pagoda that holds his remains. After all the gold and overwhelming decoration below, the quiet simplicity of his grave is deeply striking. It was intentional. Even in death, the Tokugawa understood contrast as a design tool, and the effect on visitors four hundred years later is exactly what they planned. I always tell my clients that the tomb is where Nikko shifts from spectacle to something genuinely moving. The forest up there is cool, silent, and thick with moss, and standing beside the grave of the man who shaped modern Japan while surrounded by trees that were already old when he was alive is an experience that no photograph can capture.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Shinkyo Bridge</strong> is the first major landmark you encounter when approaching the shrine area on foot, and it is worth more than a passing glance. This sacred vermilion bridge spans the Daiya River gorge and has been here in some form since the eighth century, though the current structure dates to 1636. According to legend, the Buddhist monk Shodo Shonin was blocked by the river on his journey to reach the sacred mountains, and two serpents appeared to form a bridge for him to cross. The bridge is photogenic in any season, but in autumn when the maple trees along the riverbank turn crimson and the water runs clear over green rocks beneath the red lacquer, it is genuinely one of the most beautiful single views in all of Japan. You can walk across the bridge for a 300-yen fee, which is worth doing for the view upstream toward the mountains, but the best photographs are actually taken from the road bridge next to it, which is free.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Kegon Falls</strong> sits about thirty minutes by bus from central Nikko, up a dramatic series of switchback roads that climb to the shores of Lake Chuzenji at 1,269 meters above sea level. The waterfall drops ninety-seven meters in a single breathtaking plunge from the lake's outlet, and it is ranked among the three most famous waterfalls in Japan. There is an elevator carved into the rock (570 yen) that takes you down to an observation platform at the base, and I consider it essential. From the top viewing area you see a postcard; from the base you feel the spray on your face and hear the thunderous volume of water crashing into the pool below. In autumn, the cliffs surrounding the falls turn brilliant shades of orange and gold. In winter, the peripheral streams freeze into spectacular ice columns while the main cascade keeps flowing. In any season, Kegon Falls is one of those sights that photographs do not do justice. You need to stand there, feel the mist, and hear it.
             </p>
 
+            {/* Section 3: How Much Time */}
             <h2 className="heading-section text-foreground mt-12 mb-6">
-              What to See: Tosho-gu, the Waterfall, the Cedar Avenue
+              How Much Time Do You Need in Nikko?
             </h2>
-
-            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">Tosho-gu Shrine</h3>
+            <figure className="my-8">
+              <img
+                src="/images/candidates/nikko/PXL_20240719_021128437.jpg"
+                alt="Ancient cedar trees lining the path through Nikko's shrine complex"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                The centuries-old cedar forest surrounding Nikko's shrines deserves unhurried exploration
+              </figcaption>
+            </figure>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              This is the main event, and it deserves at least 90 minutes. The complex is a UNESCO World Heritage Site containing dozens of buildings, each one covered in elaborate carvings that tell stories from Chinese classics, Buddhist teachings, and Shinto mythology. The famous "see no evil, speak no evil, hear no evil" monkeys are here, carved above the sacred horse stable. The Yomeimon Gate alone has over 500 carvings and is considered one of Japan's finest architectural achievements.
+              This is the question I hear most from clients planning a Nikko day trip from Tokyo, and my answer depends entirely on what you want to see. If you are focused solely on Tosho-gu and the surrounding shrine area, including nearby Futarasan Shrine and Taiyuin Mausoleum, you can comfortably explore them in about three hours. Add the walk from the station through the cedar avenue and across Shinkyo Bridge, and you are looking at roughly four hours from arrival to departure. That means you could leave Tokyo at 8:00 AM and be back in the city by 3:00 PM. It is a compressed visit, but if time is genuinely tight, you will still see Nikko's most important attraction.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              The climb to Ieyasu's actual tomb is easy to miss but shouldn't be. A stone stairway behind the main hall leads up through the forest to a surprisingly simple bronze pagoda that holds his remains. After all the gold and color below, the quiet simplicity of his grave is striking, and intentional. Even in death, the Tokugawa understood contrast as a design tool.
+              However, I almost always recommend a full day. The version of a Nikko day trip from Tokyo that I lead most often follows this rhythm: arrive by 9:30, spend the morning at Tosho-gu and the surrounding shrines with a detailed walking tour, break for a yuba (tofu skin) lunch at one of the traditional restaurants in town, then take the bus up the Irohazaka switchback road to Lake Chuzenji and Kegon Falls in the afternoon. The bus ride itself is part of the experience, climbing through forty-eight hairpin turns carved into the mountainside, each one named after a character from the Japanese syllabary. You spend an hour or so at the waterfall and lakeside, then ride the bus back down and catch an evening train to Tokyo. You are back in the city by 7:00 PM, tired in the best possible way, having seen mountain nature, a world-class waterfall, and the most elaborately decorated shrine in Japan all in a single day.
             </p>
-
-            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">Kegon Falls</h3>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              About 30 minutes by bus from central Nikko, Kegon Falls drops 97 meters from Lake Chuzenji in a single dramatic plunge. It's one of Japan's three most famous waterfalls, and in autumn, the surrounding cliffs turn brilliant shades of orange and red. There's an elevator (¥570) that takes you down to an observation platform at the base of the falls, and it's absolutely worth the cost. In winter, the falls partially freeze into spectacular ice columns.
+              For those with more flexible schedules, spending a night in Nikko opens up possibilities that a day trip simply cannot offer. Kinugawa Onsen, about thirty minutes from central Nikko by train, has excellent traditional Japanese inns with outdoor hot spring baths overlooking the river gorge. Soaking in a rotenburo (outdoor bath) after a full day of walking through shrines and waterfalls is one of the most restorative experiences Japan has to offer. An overnight stay also lets you visit Tosho-gu in the late afternoon when the light hits the gold leaf at a low angle and the crowds have thinned, which is when the shrine looks most alive. If your itinerary allows even one extra night, Nikko rewards that generosity many times over.
             </p>
 
-            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">The Cedar Avenue (Nikko Suginamiki)</h3>
-            <p className="text-muted-foreground leading-relaxed mb-4">
-              In 1625, a feudal lord named Matsudaira Masatsuna planted cedar trees along the approach roads to Nikko as an offering to Tosho-gu. Four hundred years later, approximately 12,000 of those trees are still standing along 37 kilometers of road, making it the longest tree-lined avenue in the world (verified by Guinness). Some of these cedars are over 30 meters tall and several meters in diameter. Driving or walking through them feels like entering a living cathedral. You'll pass through portions of the avenue on the bus to Kegon Falls, but if time allows, walking a section on foot is one of my favorite parts of any Nikko day trip from Tokyo.
-            </p>
-
+            {/* Section 4: Seasons */}
             <h2 className="heading-section text-foreground mt-12 mb-6">
-              How Long Do You Actually Need?
+              Nikko in Each Season: When to Go
             </h2>
+            <figure className="my-8">
+              <img
+                src="/images/candidates/autumn/PXL_20241125_034511698.jpg"
+                alt="Brilliant autumn foliage surrounding Nikko's mountain landscape"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                Nikko's autumn colors, particularly around Lake Chuzenji and Kegon Falls, are among the finest in Japan
+              </figcaption>
+            </figure>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              This is the question I get most from clients planning a Nikko day trip from Tokyo. Here's my honest breakdown:
+              Nikko is a destination that changes its entire personality with the seasons, and each one offers something genuinely different. Unlike many Tokyo day trips where the season is mostly a matter of comfort, in Nikko the landscape transformation is so dramatic that visitors who come in October and return in April sometimes do not recognize the same place. Understanding what each season brings will help you decide when to plan your Nikko day trip from Tokyo, and honestly, there is no bad answer.
             </p>
-            <ul className="space-y-4 mb-8">
-              <li className="text-muted-foreground leading-relaxed">
-                <strong className="text-foreground">Half day (minimum):</strong> If you focus solely on Tosho-gu and the surrounding shrine area, you can leave Tokyo at 8 AM and be back by 3 PM. You'll see the main attraction but miss the natural scenery that makes Nikko special. I only recommend this if you're truly short on time.
-              </li>
-              <li className="text-muted-foreground leading-relaxed">
-                <strong className="text-foreground">Full day (recommended):</strong> Leave Tokyo at 8 AM, visit Tosho-gu in the morning, take the bus up to Lake Chuzenji and Kegon Falls after lunch, and return to Tokyo by 6–7 PM. This is what I do with most clients and it covers Nikko's highlights without rushing. A full-day Nikko day trip from Tokyo is one of the most satisfying excursions you can do.
-              </li>
-              <li className="text-muted-foreground leading-relaxed">
-                <strong className="text-foreground">Overnight (luxury option):</strong> Stay at one of Nikko's traditional ryokan inns with onsen (hot spring baths). Kinugawa Onsen, about 30 minutes from central Nikko, has excellent options. This lets you explore at a leisurely pace, catch sunset over the mountains, and soak in outdoor hot springs after a full day of walking. If your schedule allows it, this is the version of Nikko I wish every visitor could experience.
-              </li>
-            </ul>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Autumn (mid-October to early November)</strong> is peak season, and for very good reason. The mountains surrounding Nikko erupt in color, starting at the higher elevations around Lake Chuzenji in early October and gradually descending to the shrine area by late October and early November. The contrast of crimson and gold maple leaves against the dark cedar forest and the vermilion of Shinkyo Bridge is something out of a painting. Kegon Falls framed by autumn foliage is one of the most photographed scenes in Japan. The trade-off is that everyone knows this, so expect crowds and longer bus waits on weekends. If you can visit on a weekday during this period, you get the color without the congestion. I consider late October the single best time for a Nikko day trip from Tokyo, and I schedule more tours during these weeks than at any other time of year.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Spring (late April to May)</strong> brings fresh green foliage and mild temperatures that make for ideal walking conditions. Cherry blossoms arrive in Nikko about two to three weeks after Tokyo because of the higher elevation, so if you missed the sakura in the city, you may catch them here. The shrine grounds are lush, the cedar forest feels alive, and the waterfalls run strong from snowmelt. Spring is also quieter than autumn, which means shorter lines at Tosho-gu and more elbow room on the buses. For travelers who value a relaxed pace over peak visual drama, spring is my personal recommendation.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Summer (June through August)</strong> is warmer, but Nikko's mountain elevation keeps it noticeably cooler than Tokyo, which is why Japanese families have been escaping here during the summer months for generations. Lake Chuzenji at 1,269 meters feels like a different climate entirely, and hiking trails around the lake and through the surrounding forests are at their most accessible. Humidity is higher in June during the rainy season, but July and August offer long days and green scenery as far as the eye can see. Just bring water and sun protection for the walk between sights.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              <strong className="text-foreground">Winter (December through February)</strong> is Nikko at its quietest and most atmospheric. Snow dusts the shrine roofs and the cedar branches, turning Tosho-gu into something from a woodblock print. The frozen streams around Kegon Falls create dramatic ice formations that attract photographers from across Japan. Visitor numbers drop sharply, which means you might have entire sections of the shrine to yourself. The cold can be serious, especially up at Lake Chuzenji where temperatures drop well below freezing, so dress in heavy layers. But for those who do not mind bundling up, winter Nikko offers an intimacy and a visual purity that no other season can match.
+            </p>
 
+            {/* Section 5: Self-Guided vs Private Guided Tour */}
             <h2 className="heading-section text-foreground mt-12 mb-6">
-              Nikko vs. Kamakura vs. Kawagoe: Which Day Trip?
+              Self-Guided vs Private Guided Tour: Which is Better?
             </h2>
+            <figure className="my-8">
+              <img
+                src="/images/candidates/nikko/PXL_20240719_040905028.jpg"
+                alt="A guide explaining the history and symbolism of carvings at Tosho-gu Shrine"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                Understanding the stories behind each carving transforms Tosho-gu from a beautiful building into a living narrative
+              </figcaption>
+            </figure>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              I get asked this constantly, so here's my honest comparison:
+              You can absolutely do a Nikko day trip from Tokyo on your own. The train connections are straightforward, Tosho-gu has some English signage, and there are English audio guides available for rent at the entrance. If you are an experienced Japan traveler who is comfortable navigating bus schedules in Japanese and is happy to read about the history beforehand, a self-guided visit can work. I have met plenty of independent travelers in Nikko who had a wonderful time exploring at their own pace, and I would never suggest that you need a guide to enjoy the place.
             </p>
-            <ul className="space-y-4 mb-8">
-              <li className="text-muted-foreground leading-relaxed">
-                <strong className="text-foreground">Nikko</strong> is the most visually dramatic. The shrine architecture is unlike anything else in Japan, and the mountain scenery adds a dimension you won't get near Tokyo. It's also the farthest (2 hours each way) and requires more planning. Best for travelers who want to see something truly unique and don't mind a longer travel day.
-              </li>
-              <li className="text-muted-foreground leading-relaxed">
-                <strong className="text-foreground">Kamakura</strong> is the most versatile: temples, hiking, a giant Buddha, beach views, and good food, all within an hour of Tokyo. It's the easiest to do independently. Best for active travelers and first-time visitors to Japan. See my full{" "}
-                <Link to="/blog/kamakura-day-trip-from-tokyo" className="text-accent hover:underline">Kamakura day trip guide</Link>.
-              </li>
-              <li className="text-muted-foreground leading-relaxed">
-                <strong className="text-foreground">Kawagoe</strong> is the most intimate: a small Edo-period merchant town with a preserved warehouse district, candy shops, and a bell tower that's been ringing since the 1600s. Only 30 minutes from Ikebukuro. Best for travelers who've already seen temples and want a quieter, more local experience. Read my{" "}
-                <Link to="/blog/kawagoe-day-trip-from-tokyo" className="text-accent hover:underline">Kawagoe day trip guide</Link>{" "}for details.
-              </li>
-            </ul>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              If you can only pick one and you've never been to Japan, I usually suggest Kamakura for its balance of access and variety. But if ornate architecture and natural beauty are your priorities, Nikko wins hands down.
+              That said, I believe Nikko is the single day trip from Tokyo where having a guide makes the most dramatic difference. Here is why. Tosho-gu contains over 5,000 carvings, and each one tells a story drawn from Chinese classics, Buddhist parables, Shinto mythology, or political messaging from the Tokugawa shogunate. The English signage at the shrine gives you names and dates, but it does not explain why a sleeping cat is carved above the entrance to Ieyasu's tomb (it represents peace, because when the cat sleeps, the mice can play freely, symbolizing the end of war). It does not explain why one pillar on the Yomeimon Gate was deliberately installed upside down (to invite imperfection, because in Japanese philosophy, a completed thing begins to decay, so an intentional flaw keeps the structure "alive"). These are the kinds of details that turn a Nikko visit from impressive to unforgettable, and they require a guide who knows the stories and can read the visual language of the shrine as fluently as reading a book.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Beyond the storytelling, a private guide handles the logistics that can consume your energy on an independent trip. I manage the train timing, navigate the sometimes confusing bus system to Kegon Falls and Lake Chuzenji, know which restaurants serve authentic yuba rather than tourist-oriented versions, and can adjust the itinerary in real time based on weather, crowds, and your energy level. On my guided Nikko tours, I also take clients to spots that most visitors walk right past: a small Shinto shrine hidden behind Tosho-gu where almost no one goes, a viewpoint above Shinkyo Bridge that offers the best angle for photographs, a particular stretch of the cedar avenue where the trees are thickest and the light filters through in a way that feels almost sacred. These are not secrets exactly, but they are the kind of local knowledge that accumulates over years of working in a place, and they are impossible to find in a guidebook.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The efficiency difference is also significant. On a self-guided visit, I frequently see travelers standing at bus stops confused about which bus goes where, or spending twenty minutes trying to figure out the shrine's ticket system, or missing the path to Ieyasu's tomb entirely because the entrance is not obvious. A guided Nikko day trip from Tokyo eliminates all of that friction. Every minute of your day goes toward actually experiencing Nikko rather than figuring out Nikko, and when you are working with a limited day-trip window, that efficiency is the difference between seeing two things and seeing five.
             </p>
 
-            {/* CTA */}
+            {/* CTA Section */}
             <div className="bg-secondary/50 rounded-lg p-8 mt-12">
               <h2 className="text-2xl font-medium text-foreground mb-4">
-                Want a guided Nikko day trip?
+                Book a Private Nikko Day Trip
               </h2>
               <p className="text-muted-foreground leading-relaxed mb-6">
-                I offer full-day guided tours to Nikko that cover Tosho-gu's hidden details, navigate the bus routes to Kegon Falls, and include the historical context that makes every carving meaningful. Browse my tours or contact me to plan your trip.
+                I wrote this guide to help you plan a better visit, but nothing replaces having someone beside you who can read every carving, navigate every bus, and find the hidden corners that make Nikko extraordinary. On my private Nikko day trips, I handle everything from train tickets to restaurant reservations, so you can focus entirely on the experience. We move at your pace, linger where you want to linger, and skip what does not interest you. Whether it is your first time in Japan or your tenth, a guided day in Nikko is the trip people remember most.
               </p>
               <div className="flex flex-col sm:flex-row gap-4">
-                <Link to="/tours" className="btn-accent">View All Tours</Link>
-                <Link to="/contact" className="btn-outline">Contact Me</Link>
-              </div>
-            </div>
-
-            {/* FAQ */}
-            <div className="mt-16">
-              <h2 className="heading-section text-foreground mb-8">Frequently Asked Questions</h2>
-              <div className="space-y-8">
-                <div>
-                  <h3 className="text-lg font-medium text-foreground mb-2">How long does a Nikko day trip from Tokyo take?</h3>
-                  <p className="text-muted-foreground leading-relaxed">
-                    Plan for 10–11 hours total if you want to see both the shrines and Kegon Falls. The train is about 2 hours each way, leaving 6–7 hours for sightseeing. Leaving Tokyo by 8 AM and returning by 6–7 PM is a comfortable schedule. A half-day visit focused only on Tosho-gu can have you back by 3 PM.
-                  </p>
-                </div>
-                <div>
-                  <h3 className="text-lg font-medium text-foreground mb-2">Is the JR Pass worth it just for Nikko?</h3>
-                  <p className="text-muted-foreground leading-relaxed">
-                    No. A JR Pass costs significantly more than the Nikko round trip alone. The JR route to Nikko costs about ¥5,500 each way, while the Tobu line (not covered by JR Pass) costs only ¥2,800. Only use the JR route if you already have a pass for other travel. If Nikko is your only day trip, take the Tobu line from Asakusa.
-                  </p>
-                </div>
-                <div>
-                  <h3 className="text-lg font-medium text-foreground mb-2">What's the best season to visit Nikko?</h3>
-                  <p className="text-muted-foreground leading-relaxed">
-                    Autumn (mid-October to early November) is peak season. The fall foliage around Lake Chuzenji and Kegon Falls is spectacular. Spring and early summer are also excellent with fewer crowds. Winter is beautiful but cold, and some roads to the lake may be affected by snow. Summer can be warm but is still cooler than Tokyo thanks to the mountain elevation.
-                  </p>
-                </div>
-                <div>
-                  <h3 className="text-lg font-medium text-foreground mb-2">Can I visit Nikko without a guide?</h3>
-                  <p className="text-muted-foreground leading-relaxed">
-                    Yes, Nikko is doable independently. The train connections are straightforward and Tosho-gu has some English signage. However, the bus system to Kegon Falls and Lake Chuzenji can be confusing, and the 5,000+ carvings at Tosho-gu are much more meaningful with someone who can explain the stories behind them. A guide turns a sightseeing trip into a history lesson you'll actually remember.
-                  </p>
-                </div>
-                <div>
-                  <h3 className="text-lg font-medium text-foreground mb-2">What should I eat in Nikko?</h3>
-                  <p className="text-muted-foreground leading-relaxed">
-                    Nikko is famous for yuba (tofu skin), which is served in various forms: in soup, as sashimi, wrapped around rice, or fried. It sounds simple but the local preparation is genuinely delicious. You'll find yuba restaurants throughout the town center, especially along the main road between the station and the shrines. Try it in a set meal (teishoku) for the full experience.
-                  </p>
-                </div>
+                <Link to="/tours/nikko-day-trip" className="btn-accent">
+                  View Nikko Day Trip Tour
+                </Link>
+                <Link to="/contact" className="btn-outline">
+                  Contact Me
+                </Link>
               </div>
             </div>
           </article>
         </div>
       </section>
 
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
-        "@context": "https://schema.org", "@type": "BlogPosting",
-        headline: "Nikko Day Trip from Tokyo: The Complete 2026 Guide",
-        description: "Nikko is 2 hours from Tokyo and one of Japan's most ornate shrine complexes. A licensed guide explains how to get there, what to see, and how to plan.",
-        author: { "@type": "Person", name: "Manabu", jobTitle: "National Government Licensed Guide Interpreter", url: "https://tanuki-tabi-travel.com/about" },
-        datePublished: "2026-03-07", dateModified: "2026-03-07",
-        publisher: { "@type": "Organization", name: "Tanuki Tabi Travel", url: "https://tanuki-tabi-travel.com" },
-        mainEntityOfPage: { "@type": "WebPage", "@id": "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo" }
-      })}} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
-        "@context": "https://schema.org", "@type": "FAQPage",
-        mainEntity: [
-          { "@type": "Question", name: "How long does a Nikko day trip from Tokyo take?", acceptedAnswer: { "@type": "Answer", text: "Plan for 10–11 hours total. The train is about 2 hours each way, leaving 6–7 hours for sightseeing. Leave by 8 AM, return by 6–7 PM." }},
-          { "@type": "Question", name: "Is the JR Pass worth it just for Nikko?", acceptedAnswer: { "@type": "Answer", text: "No. The Tobu line from Asakusa costs ¥2,800 each way and is faster. Only use the JR route if you already have a pass for other travel." }},
-          { "@type": "Question", name: "What's the best season to visit Nikko?", acceptedAnswer: { "@type": "Answer", text: "Autumn (mid-October to early November) for spectacular foliage. Spring and early summer for fewer crowds. Winter is cold but beautiful." }},
-          { "@type": "Question", name: "Can I visit Nikko without a guide?", acceptedAnswer: { "@type": "Answer", text: "Yes, but the bus system can be confusing and the 5,000+ carvings at Tosho-gu are much more meaningful with historical context from a guide." }},
-          { "@type": "Question", name: "What should I eat in Nikko?", acceptedAnswer: { "@type": "Answer", text: "Yuba (tofu skin) is Nikko's specialty, served in soup, as sashimi, or fried. Try it in a set meal at restaurants along the main road." }}
-        ]
-      })}} />
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Nikko Day Trip from Tokyo: Complete Guide",
+            "description": "Planning a Nikko day trip from Tokyo? A licensed guide covers trains, top sights, and why a private guided tour makes all the difference.",
+            "image": "https://tanuki-tabi-travel.com/images/candidates/nikko/PXL_20240718_040319956.MP.jpg",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+              "jobTitle": "National Government Licensed Guide Interpreter",
+              "url": "https://tanuki-tabi-travel.com/about",
+            },
+            "datePublished": "2026-03-08",
+            "dateModified": "2026-03-08",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo",
+            },
+          }),
+        }}
+      />
+
+      {/* FAQPage Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            "mainEntity": [
+              {
+                "@type": "Question",
+                "name": "How long does a Nikko day trip from Tokyo take?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Plan for 10 to 11 hours total if you want to see both the shrines and Kegon Falls. The train is about 2 hours each way, leaving 6 to 7 hours for sightseeing. Leaving Tokyo by 8 AM and returning by 7 PM is a comfortable schedule.",
+                },
+              },
+              {
+                "@type": "Question",
+                "name": "What is the cheapest way to get to Nikko from Tokyo?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "The Tobu Nikko Line from Asakusa Station is the cheapest option at around 1,400 yen one way for the regular rapid train, or 2,800 yen for the limited express with reserved seats. The JR Shinkansen route costs about 5,500 yen each way but is covered by the Japan Rail Pass.",
+                },
+              },
+              {
+                "@type": "Question",
+                "name": "What is the best season to visit Nikko?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Autumn from mid-October to early November offers spectacular foliage. Spring from late April to May has mild weather and fewer crowds. Winter brings snow-dusted shrines and frozen waterfalls. Summer is cooler than Tokyo thanks to the mountain elevation.",
+                },
+              },
+              {
+                "@type": "Question",
+                "name": "Do I need a guide for a Nikko day trip?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "You can visit independently, but Nikko is the day trip where a guide makes the biggest difference. Tosho-gu has over 5,000 carvings with stories that English signage does not explain. A guide also navigates the bus system to Kegon Falls and knows hidden spots most visitors miss.",
+                },
+              },
+              {
+                "@type": "Question",
+                "name": "Can I use the Japan Rail Pass to get to Nikko?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Yes, but only on the JR route via Utsunomiya. The more popular and cheaper Tobu Railway line from Asakusa is not covered by the JR Pass. If you do not already have a JR Pass, the Tobu line is the better option.",
+                },
+              },
+            ],
+          }),
+        }}
+      />
     </Layout>
   );
 };

--- a/src/pages/blog/Tokyo3DayItinerary.tsx
+++ b/src/pages/blog/Tokyo3DayItinerary.tsx
@@ -7,8 +7,8 @@ const Tokyo3DayItinerary = () => {
   return (
     <Layout>
       <SEO
-        title="Tokyo 3-Day Itinerary | A Local Guide's Recommendations | Tanuki Tabi Travel"
-        description="A Tokyo 3-day itinerary curated by a licensed local guide. Where to go, what to eat, and how to experience the city like an insider, from Asakusa to Shibuya."
+        title="Tokyo 3-Day Itinerary 2026 | First-Timer's Complete Guide"
+        description="Spend three days in Tokyo with this local guide's itinerary. What to do in Tokyo for 3 days, from Asakusa temples and Tsukiji food to Shibuya nightlife and day trips."
         canonicalPath="/blog/tokyo-3-day-itinerary"
       />
 
@@ -63,6 +63,9 @@ const Tokyo3DayItinerary = () => {
             <p className="text-muted-foreground leading-relaxed mb-8">
               I've organized the three days geographically to minimize transit time and maximize exploration. Each day covers a different side of Tokyo: traditional east, modern west, and then your choice of central Tokyo or a day trip. Here's what I recommend based on years of walking these streets with travelers from around the world.
             </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              <strong className="text-foreground">Quick overview:</strong> Day 1 takes you through east Tokyo's historic neighborhoods, from the ancient lanes of Asakusa to the nostalgic charm of Yanaka and the market energy of Ameyoko. Day 2 shifts west to Meiji Shrine's forest, Harajuku's youth culture, Shibuya Crossing's organized chaos, and Shinjuku's legendary nightlife. Day 3 is your choice: dive into central Tokyo's food markets and imperial gardens, or escape the city for a day trip to Kamakura, Hakone, or Nikko. Each day works as a standalone route, so you can rearrange them to suit your schedule.
+            </p>
 
             {/* Day 1 */}
             <h2 className="heading-section text-foreground mt-12 mb-6">
@@ -92,6 +95,18 @@ const Tokyo3DayItinerary = () => {
               </Link>{" "}
               covers everything from temple rituals to the best street food stalls.
             </p>
+
+            <figure className="my-8">
+              <img
+                src="/images/blog/asakusa-sensoji-pagoda.jpg"
+                alt="Senso-ji Temple pagoda in Asakusa, a highlight of any Tokyo 3-day itinerary"
+                className="w-full rounded-lg"
+                loading="lazy"
+              />
+              <figcaption className="mt-2 text-sm text-muted-foreground text-center">
+                Senso-ji's five-story pagoda. Arrive before 9 AM for the most peaceful experience
+              </figcaption>
+            </figure>
 
             <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
               Late Morning: Walk to Tokyo Skytree via Sumida Park
@@ -133,6 +148,25 @@ const Tokyo3DayItinerary = () => {
             <p className="text-muted-foreground leading-relaxed mb-4">
               End your first day at Ameyoko, the lively market street near Ueno Station. Originally a post-war black market, it's now a bustling strip of food stalls, seafood vendors, and discount shops. Great for street food: try the fresh seafood bowls, grilled meats on sticks, or chocolate-covered strawberries. The energy here is infectious and it's a perfect way to end your first day.
             </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you're feeling adventurous, follow the side alleys that branch off the main market street. You'll find tiny izakaya (Japanese pubs) where office workers unwind after a long day, cheap and cheerful standing-bar spots, and some of the best value yakitori in the city. The area around the train tracks is especially atmospheric once the sun goes down and the lanterns come on. For visitors who love exploring food culture firsthand, our{" "}
+              <Link to="/tours/tokyo-food-tour" className="text-accent hover:underline">
+                Tokyo Food Tour
+              </Link>{" "}
+              covers markets and backstreet eateries that visitors rarely find on their own.
+            </p>
+
+            <figure className="my-8">
+              <img
+                src="/images/blog/asakusa-street-food.jpg"
+                alt="Street food stalls near Asakusa and Ueno, part of Tokyo's vibrant food scene"
+                className="w-full rounded-lg"
+                loading="lazy"
+              />
+              <figcaption className="mt-2 text-sm text-muted-foreground text-center">
+                Street food stalls in east Tokyo. Graze your way through grilled skewers, fresh seafood, and seasonal snacks
+              </figcaption>
+            </figure>
 
             {/* Day 2 */}
             <h2 className="heading-section text-foreground mt-16 mb-6">
@@ -170,6 +204,18 @@ const Tokyo3DayItinerary = () => {
               covers this area in depth, from hidden vintage shops to the stories behind Omotesando's architectural masterpieces.
             </p>
 
+            <figure className="my-8">
+              <img
+                src="/images/tours/harajuku-takeshita-street.jpg"
+                alt="Harajuku Takeshita Street, colorful and crowded with youth culture shops"
+                className="w-full rounded-lg"
+                loading="lazy"
+              />
+              <figcaption className="mt-2 text-sm text-muted-foreground text-center">
+                Takeshita Street in Harajuku. The shift from Meiji Shrine's calm forest to this sensory overload takes about 30 seconds
+              </figcaption>
+            </figure>
+
             <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
               Lunch: Shibuya Area
             </h3>
@@ -184,7 +230,7 @@ const Tokyo3DayItinerary = () => {
               No Tokyo visit is complete without experiencing Shibuya Crossing, the world's busiest pedestrian intersection, where up to 3,000 people cross at once. Cross it yourself, then head to the Shibuya Sky observation deck or the Starbucks above the crossing for the best overhead views. Visit the Hachiko statue (the famous loyal dog) and explore Center-gai for a taste of Tokyo's vibrant street culture.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              If you have energy left, walk through the quieter neighborhoods behind the main streets. Tomigaya and Kamiyamacho are local favorites with excellent cafes, independent bookshops, and small restaurants that most tourists never discover.
+              If you have energy left, walk through the quieter neighborhoods behind the main streets. Tomigaya and Kamiyamacho are local favorites with excellent cafes, independent bookshops, and small restaurants that most tourists never discover. Tomigaya in particular has become one of Tokyo's most interesting food neighborhoods, with tiny ramen shops, natural wine bars, and pastry cafes that draw locals from across the city. It's a 10-minute walk from the Shibuya scramble, but it feels like a completely different world.
             </p>
 
             <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
@@ -198,8 +244,20 @@ const Tokyo3DayItinerary = () => {
               for more details on Golden Gai etiquette and the best food spots.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              For dinner, try Omoide Yokocho ("Memory Lane"), a narrow alley of yakitori (grilled chicken) stalls that has been serving workers since the 1940s. It's smoky, crowded, and absolutely authentic. Vegetarians should note that options are limited here, but nearby Shinjuku has restaurants for every dietary need.
+              For dinner, try Omoide Yokocho ("Memory Lane"), a narrow alley of yakitori (grilled chicken) stalls that has been serving workers since the 1940s. It's smoky, crowded, and absolutely authentic. Grab a seat at a counter, order a few skewers and a beer, and watch the grill masters work their magic inches from your plate. The most popular stalls are the ones doing simple things perfectly: chicken thigh with salt, tsukune (chicken meatball) with egg yolk, and negima (chicken and leek). Vegetarians should note that options are limited here, but nearby Shinjuku has restaurants for every dietary need.
             </p>
+
+            <figure className="my-8">
+              <img
+                src="/images/blog/shinjuku-omoide-yokocho.jpg"
+                alt="Omoide Yokocho in Shinjuku, narrow alley lined with yakitori stalls and lanterns"
+                className="w-full rounded-lg"
+                loading="lazy"
+              />
+              <figcaption className="mt-2 text-sm text-muted-foreground text-center">
+                Omoide Yokocho at night. This narrow alley of yakitori stalls has been a Shinjuku landmark since the 1940s
+              </figcaption>
+            </figure>
 
             {/* Day 3 */}
             <h2 className="heading-section text-foreground mt-16 mb-6">
@@ -223,8 +281,21 @@ const Tokyo3DayItinerary = () => {
               </Link>{" "}
               will help you navigate the best stalls and explain what you're eating.
             </p>
+
+            <figure className="my-8">
+              <img
+                src="/images/blog/tsukiji-fresh-sushi.jpg"
+                alt="Fresh sushi breakfast at Tsukiji Outer Market in Tokyo"
+                className="w-full rounded-lg"
+                loading="lazy"
+              />
+              <figcaption className="mt-2 text-sm text-muted-foreground text-center">
+                Sushi for breakfast at Tsukiji. The freshest fish you'll find anywhere in Tokyo
+              </figcaption>
+            </figure>
+
             <p className="text-muted-foreground leading-relaxed mb-4">
-              <strong className="text-foreground">Afternoon: Imperial Palace East Gardens.</strong> A peaceful contrast to the morning's market energy. These free-entry gardens were once the innermost circle of Edo Castle, the seat of Tokugawa shogunate power for over 250 years. The stone walls, moats, and garden design tell the story of samurai-era Japan. Walk through to the Marunouchi business district to see Tokyo's modern skyline framed by ancient castle walls.
+              <strong className="text-foreground">Afternoon: Imperial Palace East Gardens.</strong> A peaceful contrast to the morning's market energy. These free-entry gardens were once the innermost circle of Edo Castle, the seat of Tokugawa shogunate power for over 250 years. The stone walls, moats, and garden design tell the story of samurai-era Japan. The Ninomaru Garden is particularly beautiful, with a traditional Japanese landscape garden that changes dramatically with the seasons. In spring, you'll find plum and cherry blossoms. In summer, irises and hydrangeas. Autumn brings fiery maples, and winter reveals the elegant bare structure of the pruned pine trees. Walk through to the Marunouchi business district to see Tokyo's modern skyline framed by ancient castle walls.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
               Explore the area in depth with our{" "}
@@ -260,7 +331,7 @@ const Tokyo3DayItinerary = () => {
                 <Link to="/tours/nikko-day-trip" className="text-accent hover:underline font-medium">
                   Nikko
                 </Link>{" "}
-                UNESCO World Heritage Toshogu Shrine, dramatic waterfalls, and mountain lake scenery. Further from Tokyo (2 hours) but less crowded and deeply rewarding for history enthusiasts. October-November is spectacular for autumn foliage.
+                UNESCO World Heritage Toshogu Shrine, dramatic waterfalls, and mountain lake scenery. Further from Tokyo (2 hours) but less crowded and deeply rewarding for history enthusiasts. The ornate carvings at Toshogu are unlike anything else in Japan, and the surrounding cedar forest adds a sense of grandeur you won't find in the city. October-November is spectacular for autumn foliage, and the Irohazaka winding road to Lake Chuzenji is one of the country's most scenic drives.
               </li>
             </ul>
             <p className="text-muted-foreground leading-relaxed mb-4">
@@ -307,6 +378,16 @@ const Tokyo3DayItinerary = () => {
             </p>
 
             <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
+              Food & Dining
+            </h3>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tokyo has more Michelin-starred restaurants than any other city in the world, but some of the best meals you'll have cost under ¥1,000. Convenience stores (konbini) in Japan are genuinely good: onigiri, egg sandwiches, and fresh bento boxes make excellent budget meals. For sit-down dining, lunch sets (called "ranchi") are the best value, often half the price of the same restaurant's dinner menu with nearly identical food.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              A few practical notes: most restaurants display plastic food models or photo menus outside, so you can see what you're ordering before you sit down. Many smaller restaurants use ticket vending machines at the entrance. Just insert coins or bills, press the button for what you want, and hand the ticket to the chef. It's faster and simpler than it sounds. Tipping is not practiced in Japan, at restaurants or anywhere else. The price on the menu is the price you pay, and excellent service is simply the standard.
+            </p>
+
+            <h3 className="text-xl font-medium text-foreground mt-8 mb-4">
               Temple & Shrine Etiquette
             </h3>
             <p className="text-muted-foreground leading-relaxed mb-4">
@@ -348,8 +429,8 @@ const Tokyo3DayItinerary = () => {
           __html: JSON.stringify({
             "@context": "https://schema.org",
             "@type": "BlogPosting",
-            "headline": "The Perfect 3-Day Tokyo Itinerary: From a Local Guide",
-            "description": "Plan the perfect 3 days in Tokyo with insider tips from a licensed local guide.",
+            "headline": "Tokyo 3-Day Itinerary 2026: First-Timer's Complete Guide",
+            "description": "Spend three days in Tokyo with a local guide's itinerary. What to do in Tokyo for 3 days, from Asakusa temples and Tsukiji food to Shibuya nightlife and day trips.",
             "author": {
               "@type": "Person",
               "name": "Manabu",

--- a/src/pages/blog/VegetarianFoodTourTokyo.tsx
+++ b/src/pages/blog/VegetarianFoodTourTokyo.tsx
@@ -1,0 +1,222 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const VegetarianFoodTourTokyo = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Vegetarian Food Tour Tokyo: A Complete Guide for Dietary Restrictions | Tanuki Tabi"
+        description="Worried about dietary restrictions in Tokyo? A licensed private guide shares the best vegetarian-friendly food spots and how to customize your tour."
+        canonicalPath="/blog/vegetarian-food-tour-tokyo"
+      />
+
+      {/* Hero Image */}
+      <section className="relative h-[40vh] md:h-[50vh] min-h-[300px]">
+        <img
+          src="/images/candidates/tsukiji/Photos-3-001/PXL_20240927_000302980.jpg"
+          alt="Fresh vegetables and produce at a Tokyo market stall"
+          className="w-full h-full object-cover"
+          loading="eager"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent" />
+      </section>
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Food & Culture</p>
+            <h1 className="heading-display text-foreground">
+              Vegetarian Food Tour Tokyo: A Complete Guide for Dietary Restrictions
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                March 8, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-8">
+              One of the most common concerns I hear from guests before they book a food tour with me is about dietary restrictions. "I'm vegetarian, is that going to be a problem in Tokyo?" or "My partner is vegan and we're worried there won't be anything for them to eat." I completely understand the anxiety. Japan has a reputation as a meat-and-fish-heavy food culture, and when you look at the typical tourist food recommendations, everything seems to revolve around sushi, ramen with pork broth, and grilled yakitori skewers. But after leading hundreds of food-focused tours across Tokyo over the years, I can tell you with absolute confidence that vegetarian and vegan travelers can eat extraordinarily well here. You just need to know where to look, what to ask for, and how to communicate your needs clearly.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              This guide is everything I have learned from years of customizing tours for guests with dietary restrictions. Whether you are fully vegan, lacto-ovo vegetarian, pescatarian, gluten-free, or dealing with specific allergies, Tokyo has more to offer than you might expect. The key is preparation, and that is exactly what this article is designed to give you.
+            </p>
+
+            {/* Section 1: Can You Do a Food Tour as a Vegetarian? */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Can You Do a Food Tour in Tokyo as a Vegetarian?
+            </h2>
+            <figure className="my-8">
+              <img
+                src="/images/candidates/asakusa/Photos-3-001/PXL_20241130_073346158.jpg"
+                alt="Traditional Japanese food stalls along a busy Tokyo street"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                Tokyo's food scene offers far more plant-based options than most visitors expect
+              </figcaption>
+            </figure>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The short answer is yes, absolutely. The longer answer is that it requires a bit more planning than a standard food tour, but the result can be just as rich and satisfying, sometimes even more so, because it forces you to explore corners of Japanese cuisine that most tourists never discover. When I lead a vegetarian food tour, I am not simply removing the meat and fish from a standard itinerary and hoping for the best. I am building an entirely different experience around the incredible depth of plant-based cooking that has existed in Japan for centuries.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Japan has a long tradition of Buddhist vegetarian cuisine called shojin ryori. This is the food that monks in Zen temples have been eating for over 700 years, and it is one of the most refined and intentional forms of plant-based cooking anywhere in the world. Shojin ryori treats vegetables, tofu, and seasonal ingredients with the same reverence that a sushi master gives to a piece of tuna. Every dish is designed to highlight the natural flavor, texture, and color of its ingredients, with no garlic, no onion, and no excess seasoning to mask the pure taste of the food. When I take vegetarian guests to a proper shojin ryori restaurant, they are often stunned by the complexity and beauty of what arrives at the table. A single meal might include eight or ten small dishes: sesame tofu with a ginger glaze, grilled maitake mushrooms with a miso dengaku sauce, pickled mountain vegetables, deep-fried yuba (tofu skin) that shatters like the lightest tempura, and a bowl of fragrant rice cooked with chestnuts or sweet potato depending on the season.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Beyond shojin ryori, Japan's everyday food culture is full of naturally vegetarian dishes that many visitors overlook. Inari sushi, those sweet tofu-skin pouches stuffed with vinegared rice, are completely plant-based. Vegetable tempura, when fried in a vegetable-oil batter and served with a salt dip instead of the standard dashi-based tentsuyu sauce, is vegan. Onigiri rice balls come in fillings like pickled plum (umeboshi), kelp (kombu), and seasoned rice, all of which are meat-free. Even at a typical convenience store, which might seem like an unlikely source of good vegetarian food, I can walk guests through the options and help them identify which onigiri, sandwiches, and snacks are safe to eat. The challenge is not a lack of options. The challenge is that ingredients like dashi, a stock made from bonito fish flakes, hide in places you would not expect. That is where having a guide who speaks the language and knows the cuisine inside out makes all the difference.
+            </p>
+
+            {/* Section 2: Best Areas for Vegetarian-Friendly Food */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Best Areas for Vegetarian-Friendly Food (Asakusa, Tsukiji, Shinjuku)
+            </h2>
+            <figure className="my-8">
+              <img
+                src="/images/candidates/tsukiji/Photos-3-001/PXL_20250302_072511103.jpg"
+                alt="Tsukiji Outer Market with vendors selling fresh produce and prepared food"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                Tsukiji Outer Market, home to surprising vegetarian finds alongside the famous seafood
+              </figcaption>
+            </figure>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              When I design a vegetarian food tour, I typically build the route around three neighborhoods that each offer something different. Asakusa, Tsukiji, and Shinjuku are my go-to areas, and each one brings a distinct flavor to the experience. The beauty of a private tour is that I can adjust the route on the day based on what my guests are craving, how much they want to walk, and which specific restrictions they are working with.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Asakusa is where I often start, especially for guests who want to combine food with cultural immersion. The streets around Senso-ji Temple are full of traditional snack shops, and many of them are naturally vegetarian. Freshly grilled senbei rice crackers brushed with soy sauce, ningyo-yaki cakes filled with sweet red bean paste, and kibi-dango millet dumplings coated in soybean powder are all plant-based and have been sold here for generations. I like to walk guests through the backstreets behind the temple where the tourist crowds thin out and the neighborhood teahouses come into view. There is a particular matcha cafe tucked into a quiet side street where they serve thick, whisked matcha alongside seasonal wagashi sweets. The wagashi are handmade, entirely plant-based, and almost too beautiful to eat. Almost. For guests who want a more substantial meal in Asakusa, there are excellent soba noodle shops that will prepare dishes with a kombu-based broth instead of the standard katsuobushi dashi if you ask properly, and I always make sure to communicate the request clearly so there are no misunderstandings.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Tsukiji Outer Market surprises vegetarian guests every time I bring them. Yes, Tsukiji is famous for seafood, but the market is much more diverse than its reputation suggests. There are stalls selling tamagoyaki (the sweet Japanese egg omelet, suitable for lacto-ovo vegetarians), shops specializing in pickled vegetables and tsukemono that go back decades, vendors with fresh fruit on sticks, and stands serving piping-hot age-dashi tofu. One of my favorite stops is a small family-run shop that makes fresh soy milk and yuba right on the premises. You can watch them lift the delicate tofu skin from the surface of the simmering soy milk, and then eat it moments later with just a touch of soy sauce and wasabi. It is one of those simple, perfect bites that stays with people long after the tour is over. For vegan guests, I know which tamagoyaki shops to skip and which pickle vendors use no fish-based seasonings in their recipes, details that are nearly impossible to figure out on your own without speaking Japanese.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Shinjuku offers a completely different energy, and I tend to save it for the later part of the tour when guests are ready for a sit-down meal. The area around Shinjuku Station has an enormous concentration of restaurants, and within that sprawl are some genuinely excellent vegetarian and vegan-dedicated establishments. There are izakaya-style restaurants that serve entirely plant-based menus with creative dishes like miso-glazed eggplant, avocado tempura rolls, and mushroom hot pots that would satisfy even the most committed carnivore. Shinjuku is also home to several Indian and Nepali restaurants that serve reliably vegetarian curries and naan, which can be a welcome change of pace for guests who have been eating Japanese food for several days and want something familiar. I have also found a remarkable little teishoku-ya, a set-meal restaurant, near the west exit that does a rotating vegetable-focused lunch set with six or seven small plates of seasonal dishes, a bowl of rice, and miso soup made from a kelp-and-mushroom stock. It is the kind of place you would walk right past without a second glance if you did not know it was there.
+            </p>
+
+            {/* Section 3: What to Expect on a Private Vegetarian Food Tour */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              What to Expect on a Private Vegetarian Food Tour
+            </h2>
+            <figure className="my-8">
+              <img
+                src="/images/candidates/shinjuku/Photos-3-001/PXL_20241124_085630263.jpg"
+                alt="Atmospheric backstreet restaurant alley in Shinjuku at dusk"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                The intimate backstreet dining alleys of Shinjuku, where hidden gems await
+              </figcaption>
+            </figure>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Every vegetarian food tour I lead is different because every guest is different. Before the tour, I always ask detailed questions about your specific dietary restrictions. Are you lacto-ovo vegetarian, or strictly vegan? Do you avoid dashi made from bonito flakes? Are there allergies I need to know about, such as soy, wheat, or nuts? Do you have any restrictions related to gluten? This conversation is essential because "vegetarian" means different things to different people, and in Japan the distinctions matter enormously. A dish that seems vegetarian on the surface might contain dashi, mirin with trace amounts of fish-derived ingredients, or a sauce that was thickened with animal-based gelatin. I need to know exactly where your boundaries are so I can navigate the food landscape on your behalf with complete confidence.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              On the day of the tour, I handle all communication with restaurant staff and food vendors. This is where the value of a private guide becomes most obvious. I speak directly with the chef or the shop owner in Japanese, explaining your dietary needs in precise terms that leave no room for ambiguity. I do not simply say "no meat" because in Japan that phrase alone does not exclude fish, fish stock, or animal-derived seasonings. Instead, I specify exactly which ingredients to avoid: no meat, no fish, no shellfish, no bonito dashi, no animal-derived gelatin, and whatever else applies to your specific situation. The reaction from restaurant staff when they hear the request explained clearly in their own language is always positive. Japanese hospitality, omotenashi, means that once a chef understands your needs, they will go out of their way to accommodate you. I have watched chefs prepare entirely custom dishes for my vegetarian guests, creating off-menu items simply because they wanted to offer the best possible experience. That kind of personalized care does not happen when you are pointing at a translation card and hoping for the best.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              A typical tour lasts around four to five hours and includes five to seven food stops, depending on portion sizes and your appetite. We move at a comfortable pace, and I weave in cultural context throughout: why tofu holds such an important place in Japanese cuisine, how seasonal awareness (shun) dictates what appears on menus, why Buddhist dietary principles shaped an entire culinary tradition, and what makes Japanese pickles some of the most complex fermented foods in the world. I also cover practical survival skills so you can eat confidently on your own after the tour ends. By the time we say goodbye, you will know how to read key kanji on menus, which convenience store items are safe, and which chain restaurants have reliable vegetarian options. Guests who are gluten-free get additional guidance, because soy sauce contains wheat, and I show them where to find tamari (wheat-free soy sauce) and which dishes to approach with caution.
+            </p>
+
+            {/* Section 4: How to Communicate Dietary Restrictions */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              How to Communicate Dietary Restrictions in Japan
+            </h2>
+            <figure className="my-8">
+              <img
+                src="/images/candidates/asakusa/Photos-3-001/PXL_20241030_072249070.jpg"
+                alt="Close-up of traditional Japanese food preparation in a Tokyo kitchen"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                Clear communication with staff is the key to eating safely with dietary restrictions in Japan
+              </figcaption>
+            </figure>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Even if you are not joining a guided tour, knowing how to communicate your dietary restrictions in Japanese will dramatically improve your experience in Tokyo. English-language allergy cards and translation apps have gotten better over the years, but nothing replaces speaking a few key phrases yourself. The effort shows respect, and Japanese restaurant staff respond to it with genuine warmth and extra care.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The most important phrase for vegetarians is "Watashi wa bejitarian desu" (私はベジタリアンです), which simply means "I am a vegetarian." However, this phrase alone is not always enough because the concept of vegetarianism is still not universally understood in Japan the same way it is in Western countries. Many Japanese people hear "vegetarian" and think it means you avoid meat but still eat fish, because fish is often categorized separately from "meat" (niku) in Japanese culinary thinking. To be more precise, follow up with "Niku to sakana wa taberaremasen" (肉と魚は食べられません), meaning "I cannot eat meat or fish." For vegan guests, I recommend saying "Niku, sakana, tamago, nyuseihin wa taberaremasen" (肉、魚、卵、乳製品は食べられません), which covers meat, fish, eggs, and dairy products. If dashi is a concern, and it should be for strict vegetarians, say "Katsuo dashi mo dame desu" (かつおだしもだめです), meaning "Bonito fish stock is also not okay." For guests with gluten concerns, "Komugi arerugi ga arimasu" (小麦アレルギーがあります) tells the staff you have a wheat allergy, which Japanese restaurants take very seriously because allergy communication is well-established in the food service industry here.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              I also recommend writing these phrases down on a card or saving them on your phone to show restaurant staff. A written note in Japanese is often more effective than a spoken phrase, especially in a noisy restaurant or when dealing with staff who may be nervous about understanding foreign-accented Japanese. On my tours, I prepare a custom dietary restriction card for each guest that I write out in natural, polite Japanese. This card explains your specific needs in clear terms and includes a note that says "Thank you very much for your help" (ご協力ありがとうございます), which always gets a smile. Several of my past guests have told me that this card alone was worth the price of the tour because they used it every single day for the rest of their trip. The reality is that Japan is an incredibly accommodating country once people understand what you need. The barrier is almost never unwillingness, it is communication. Bridge that gap and you will eat beautifully.
+            </p>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="text-2xl font-medium text-foreground mb-4">
+                Book a Custom Vegetarian Food Tour
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                I wrote this guide to show you that vegetarian and vegan travelers can absolutely thrive in Tokyo, but reading about it and tasting it are two very different things. On a private food tour with me, every stop is handpicked for your specific dietary needs, every conversation with restaurant staff is handled in fluent Japanese, and every dish comes with the cultural story behind it. Whether you are strictly vegan, gluten-free, or somewhere in between, I will build a tour that lets you experience Tokyo's food culture without a single moment of worry. Come hungry and leave amazed.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/tours" className="btn-accent">
+                  Browse Tours
+                </Link>
+                <Link to="/contact" className="btn-outline">
+                  Contact Us
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Vegetarian Food Tour Tokyo: A Complete Guide for Dietary Restrictions",
+            "description": "Worried about dietary restrictions in Tokyo? A licensed private guide shares the best vegetarian-friendly food spots and how to customize your tour.",
+            "image": "https://tanuki-tabi-travel.com/images/candidates/tsukiji/Photos-3-001/PXL_20240927_000302980.jpg",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+            },
+            "datePublished": "2026-03-08",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/vegetarian-food-tour-tokyo",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default VegetarianFoodTourTokyo;

--- a/src/pages/blog/YanakaWalkingTourGuide.tsx
+++ b/src/pages/blog/YanakaWalkingTourGuide.tsx
@@ -1,0 +1,247 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import { SEO } from "@/components/SEO";
+
+const YanakaWalkingTourGuide = () => {
+  return (
+    <Layout>
+      <SEO
+        title="Yanaka Walking Tour: Tokyo's Best-Kept Secret Neighborhood | Tanuki Tabi Travel"
+        description="Yanaka is old Tokyo at its finest — temples, shotengai, and no crowds. A local guide shares the best walking route through this hidden gem."
+        canonicalPath="/blog/yanaka-walking-tour-guide"
+      />
+
+      {/* Hero Image */}
+      <section className="relative h-[40vh] md:h-[50vh] min-h-[300px]">
+        <img
+          src="/images/tours/asakusa-backstreet-local.jpg"
+          alt="Quiet traditional backstreet in old Tokyo — the atmosphere of Yanaka's hidden lanes"
+          className="w-full h-full object-cover"
+          loading="eager"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent" />
+      </section>
+
+      {/* Article Header */}
+      <section className="pt-16 pb-12 bg-secondary/30">
+        <div className="container-section">
+          <div className="max-w-3xl">
+            <Link
+              to="/blog"
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to Blog
+            </Link>
+            <p className="text-label text-accent mb-3">Tokyo Area Guides</p>
+            <h1 className="heading-display text-foreground">
+              Yanaka Walking Tour: Tokyo's Hidden Neighborhood
+            </h1>
+            <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
+              <span className="flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Manabu, Licensed Tour Guide
+              </span>
+              <span className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" />
+                March 8, 2026
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Article Content */}
+      <section className="py-16">
+        <div className="container-section">
+          <article className="max-w-3xl mx-auto prose-custom">
+            {/* Introduction */}
+            <p className="text-lg text-muted-foreground leading-relaxed mb-8">
+              Most visitors to Tokyo never hear the name Yanaka. It does not appear on the standard sightseeing lists, the hop-on hop-off bus routes do not stop here, and the big travel agencies have never figured out how to package it into a half-day itinerary. That is precisely what makes it one of the most rewarding neighborhoods in the entire city. Yanaka is old Tokyo, the real thing, not a reconstruction or a theme park version but an actual living neighborhood where wooden houses lean against one another on narrow lanes, where temple bells mark the hours, and where a shopping street that has been feeding the community for generations still does exactly that every single day.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              After leading private tours through Yanaka for years, I can tell you that this neighborhood consistently produces the strongest reactions from my guests. People who have already spent days exploring Shibuya, Shinjuku, and Asakusa arrive in Yanaka and suddenly feel like they have discovered a completely different country. The pace slows down. The noise drops. The crowds vanish. And Tokyo reveals a side of itself that most travelers never get to see. This guide is my attempt to put everything I know about walking Yanaka into one place, so that whether you visit on your own or with a guide, you will experience the neighborhood at its absolute best.
+            </p>
+
+            {/* Why Yanaka Feels Different */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Why Yanaka Feels Different from the Rest of Tokyo
+            </h2>
+            <figure className="my-8">
+              <img
+                src="/images/tours/senso-ji-temple-tokyo.jpg"
+                alt="Traditional temple architecture in Tokyo — Yanaka is home to over 70 Buddhist temples"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                Temple grounds in old Tokyo. Yanaka holds the highest concentration of Buddhist temples in the city
+              </figcaption>
+            </figure>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              To understand why Yanaka feels so different, you need to understand what happened to the rest of Tokyo. The city has been devastated twice in the last century. The Great Kanto Earthquake of 1923 and the fires that followed it destroyed vast swaths of the eastern lowlands. Then in March 1945, American firebombing raids reduced sixteen square miles of the Shitamachi flatlands to ash in a single night, killing over 100,000 people in what remains the most destructive air raid in human history. After the war, rapid modernization and aggressive urban development erased most of whatever the fires had spared. The Tokyo you see today, all glass towers and concrete apartment blocks and elevated highways, is essentially a city that has been rebuilt from scratch two or three times over.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Yanaka survived all of it. The neighborhood sits on slightly elevated ground west of the traditional Shitamachi lowlands, and its position near the open expanse of Ueno Park created a natural firebreak that shielded it from the spreading flames of both 1923 and 1945. But geographic luck alone does not explain why Yanaka still looks the way it does. What truly preserved this neighborhood was its people. When postwar developers arrived with plans for apartment towers and wide boulevards, Yanaka's residents, many of them temple priests, small-business owners, and families who had lived here for generations, refused to sell. The community associations pushed back against rezoning. The temples would not budge. And so, while the rest of Tokyo transformed itself into a gleaming modern metropolis, Yanaka simply stayed the same.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              What this means for you as a visitor is extraordinary. Walking through Yanaka today is the closest you can come to experiencing what Tokyo felt like before the earthquakes, the bombs, and the construction cranes changed everything. The streets are narrow and winding. The buildings are low, made of dark-stained wood and clay tile. More than seventy Buddhist temples are clustered within a few blocks, their moss-covered stone gardens and incense-scented halls open to anyone who wanders in. Cats sleep on warm stone walls. An elderly shopkeeper arranges pickles in wooden barrels the same way her grandmother did. This is the Shitamachi spirit, the culture of Tokyo's old downtown, preserved in amber. I point all of this out on my tours because once you understand the history, every weathered wooden facade and hand-painted shop sign becomes a small miracle of survival.
+            </p>
+
+            {/* Walking Tour Route */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Yanaka Walking Tour Route (2 to 3 Hours)
+            </h2>
+            <figure className="my-8">
+              <img
+                src=""
+                alt="Tree-lined path through Yanaka Cemetery, one of Tokyo's most peaceful walks"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                The main avenue of Yanaka Cemetery, lined with cherry trees and a world away from central Tokyo
+              </figcaption>
+            </figure>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The route I use on my private tours has been refined over hundreds of walks through this neighborhood. It follows a roughly north-to-south line from Nippori Station to Nezu Station, covering about three kilometers at a gentle pace that leaves plenty of time for stopping, exploring, eating, and photographing. You never backtrack, and the terrain is almost entirely flat despite Yanaka's hillside position. I typically allow two and a half to three hours, though guests who love photography or want to linger at the temples sometimes stretch it to four.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The walk begins at the west exit of Nippori Station on the JR Yamanote Line. The moment you step outside, the atmosphere changes. There are no department stores, no electronic billboards, no rush-hour crowds even at rush hour. You are in a residential neighborhood that happens to be ten minutes from the center of one of the world's largest cities. A two-minute walk south brings you to the entrance of Yanaka Cemetery, a vast, tree-lined space that functions more like a public park than a graveyard. Locals walk their dogs here, families spread blankets under the cherry trees in spring, and the wide central avenue, flanked by towering old trees, is one of the most beautiful walks in Tokyo during sakura season.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              From the cemetery, you move south through what I call the temple district, a dense cluster of streets where more than seventy Buddhist temples sit within a few blocks. Each one is small and quiet, typically maintained by a single priest and their family, and most are open for you to walk through without any fee or reservation. The route then descends toward the Yuyake Dandan, a flight of stone steps famous for its sunset views over the neighborhood rooftops. At the bottom of the stairs begins Yanaka Ginza, the shopping street that serves as the neighborhood's beating heart. After grazing your way through the food stalls and shops, the final stretch threads through residential backstreets toward Nezu, passing wooden houses with potted-plant gardens, artisan workshops, and community notice boards advertising local festivals. The walk ends at Nezu Station on the Chiyoda Line, though I always make a detour to Nezu Shrine, one of Tokyo's oldest and most beautiful Shinto shrines, with its tunnel of vermillion torii gates and an azalea garden that explodes with color every April.
+            </p>
+
+            {/* Top Spots */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Top Spots Not to Miss in Yanaka
+            </h2>
+            <figure className="my-8">
+              <img
+                src="/images/tours/kamakura-hasedera-temple.jpg"
+                alt="Serene temple garden — similar tranquility awaits at Yanaka's seventy-plus Buddhist temples"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                Temple gardens like this one define the peaceful character of Yanaka's backstreets
+              </figcaption>
+            </figure>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Yanaka Cemetery is far more than a graveyard. It is a sprawling green space that holds over 7,000 graves, including that of Tokugawa Yoshinobu, the fifteenth and last shogun of Japan. I always pause at his resting place to tell the story of how this one man voluntarily surrendered power in 1868, ending 260 years of military rule by the Tokugawa clan and launching Japan into the modern era. He retired to a quiet life of photography and painting, eventually being buried here in a neighborhood that, fittingly, still feels like the era he left behind. The cemetery's main path is also one of Tokyo's finest cherry blossom spots, far less crowded than the famous viewing areas at Ueno Park or along the Meguro River. If you visit in late March or early April, make this your first stop.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Among the temples, a few stand out. Tenno-ji is home to a large seated bronze Buddha that predates many of the surrounding buildings and sits in a quiet garden where time seems to stop. Kyoo-ji has a stunning painted ceiling featuring a dragon that appears to follow you with its eyes as you move beneath it. Joko-ji is tiny and easy to miss entirely, but its miniature garden is one of the most peaceful spaces I have found in all of Tokyo. I never try to visit every temple on a tour. Instead, I choose three or four based on what each guest finds most interesting, whether that is Buddhist art, architecture, garden design, or simply finding the quietest possible spot in a city of fourteen million people.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The Yuyake Dandan staircase deserves special mention. The name translates roughly to "sunset steps," and they earn it. On clear evenings, the view from the top of the stairs looks out over the low rooftops of Yanaka toward the western sky, and the sunset fills the lane with golden light. Even if you do not time your visit for sunset, the stairs are the gateway between the quiet temple district above and the lively energy of Yanaka Ginza below, and descending them always feels like crossing a threshold into a different world. At the route's southern end, Nezu Shrine is the perfect closing act. Its grounds are ancient, its architecture is exquisitely maintained, and the corridor of red torii gates winding up the hillside behind the main hall offers one of the most photogenic scenes in the city.
+            </p>
+
+            {/* Food & Drinks */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Best Food and Drinks in Yanaka Ginza Shopping Street
+            </h2>
+            <figure className="my-8">
+              <img
+                src="/images/blog/asakusa-street-food.jpg"
+                alt="Traditional Japanese street food — Yanaka Ginza offers a similar old-fashioned snacking experience"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                Street food culture thrives in Tokyo's traditional shopping streets like Yanaka Ginza
+              </figcaption>
+            </figure>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Yanaka Ginza is a 170-meter shopping street that runs from the base of the Yuyake Dandan stairs south through the heart of the neighborhood. Unlike the tourist-oriented shopping streets you find in Asakusa or Harajuku, Yanaka Ginza is a genuine local shotengai, a traditional neighborhood commercial strip where residents come to buy their daily groceries, pick up household supplies, and chat with shopkeepers they have known for decades. The result is a street where the food is made for people who eat here every day, not for people who will never come back. Quality is high, prices are low, and everything is designed to be eaten while walking.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              The croquettes are the street's most famous snack, and for good reason. Several butchers along Yanaka Ginza sell hand-formed menchi katsu, deep-fried ground meat croquettes with a shattering crispy shell and a juicy, savory interior. They cost about 200 yen each and are fried to order, handed to you wrapped in a small sheet of paper while still almost too hot to hold. I usually grab one from the shop right at the base of the Yuyake Dandan steps, where the line moves quickly and the product is consistently excellent. Nearby, you will find yakitori stalls sending clouds of charcoal smoke into the air, grilling chicken skewers that make for perfect walking food. There are also traditional sweet shops selling dorayaki, the red-bean-paste-filled pancakes that are a Japanese comfort food staple, and taiyaki, the fish-shaped cakes with fillings of sweet bean paste, custard cream, or seasonal flavors.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              For something more substantial, step off the main strip and into the backstreets, where you will find small kissaten, old-fashioned Japanese coffee shops with dark wood interiors, classical music playing softly, and hand-dripped coffee served in porcelain cups. These places feel like stepping into the 1960s and they are exactly the kind of hidden gem that rewards walking slowly and looking carefully. Yanaka Beer Hall, located just off the main Ginza street in a beautifully renovated old building, serves local craft beer and makes an excellent stop on a warm afternoon. For a proper sit-down meal, the neighborhood has several small soba restaurants tucked into quiet side streets, serving handmade buckwheat noodles in simple, elegant settings. On my tours, I always build in at least forty-five minutes for eating on Yanaka Ginza, because the food here is not just fuel for the walk. It is part of the experience.
+            </p>
+
+            {/* Getting There */}
+            <h2 className="heading-section text-foreground mt-12 mb-6">
+              Getting to Yanaka from Central Tokyo
+            </h2>
+            <figure className="my-8">
+              <img
+                src="/images/candidates/train/PXL_20240726_023308396.jpg"
+                alt="JR train platform — Nippori Station on the Yamanote Line is the gateway to Yanaka"
+                className="w-full rounded-lg shadow-md"
+                loading="lazy"
+              />
+              <figcaption className="mt-3 text-sm text-muted-foreground text-center">
+                Getting to Yanaka is simple thanks to the JR Yamanote Line, which stops at Nippori Station
+              </figcaption>
+            </figure>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Reaching Yanaka is remarkably easy, which makes its off-the-beaten-path character all the more surprising. The starting point of the walking route is Nippori Station on the JR Yamanote Line, Tokyo's main loop line that connects virtually every major neighborhood in the city. From Tokyo Station, the ride is about twelve minutes. From Shinjuku, it is roughly twenty minutes. From Shibuya, allow about twenty-five minutes. If you are staying anywhere along the Yamanote Line, which covers most of central Tokyo, you can reach Nippori with a single train and no transfers. The station is also served by the Keisei Skyliner from Narita Airport, so if you are arriving from overseas and want to start your Tokyo experience with something genuinely local rather than the overwhelming sensory assault of Shinjuku or Shibuya, Yanaka is an outstanding first stop.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              At Nippori Station, use the west exit. This puts you on the quiet, residential side of the station, facing directly toward Yanaka Cemetery and the start of the walking route. The east exit leads to a different neighborhood entirely, so make sure you head west. If you are ending the walk at Nezu Station, as I recommend, you will exit via the Tokyo Metro Chiyoda Line, which connects you directly to Omotesando, Meiji-jingumae (for Harajuku), and other points in central and western Tokyo. This makes it easy to continue your day after the walk. A morning spent in Yanaka pairs beautifully with an afternoon at the Ueno museums, which are just one stop south on the Yamanote Line, or with a trip across to Asakusa, which is a short ride away via the Tsukuba Express from Shin-Okachimachi. Many of my guests combine Yanaka with our{" "}
+              <Link to="/tours/asakusa" className="text-accent hover:underline">
+                Asakusa Walking Tour
+              </Link>{" "}
+              for a full day of traditional Tokyo.
+            </p>
+
+            {/* CTA */}
+            <div className="bg-secondary/50 rounded-lg p-8 mt-12">
+              <h2 className="text-2xl font-medium text-foreground mb-4">
+                Explore Yanaka with a Private Guide
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                Reading about Yanaka is one thing. Walking it with someone who knows every backstreet, every hidden temple garden, and every shopkeeper by name is something else entirely. My private Yanaka walking tour covers this entire route and goes deeper into the history, the architecture, and the local stories that you simply cannot get from a guidebook or a blog post. I adjust the pace and focus based on what interests you most, handle all the navigation and logistics, and make sure you taste the best food the neighborhood has to offer. If you are looking for a private tour in Yanaka that goes beyond the surface, this is it.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link to="/tours/yanaka" className="btn-accent">
+                  Yanaka Walking Tour
+                </Link>
+                <Link to="/contact" className="btn-outline">
+                  Contact Us
+                </Link>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      {/* BlogPosting Schema */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "headline": "Yanaka Walking Tour: Tokyo's Hidden Neighborhood",
+            "description": "Yanaka is old Tokyo at its finest — temples, shotengai, and no crowds. A local guide shares the best walking route through this hidden gem.",
+            "image": "https://tanuki-tabi-travel.com/images/tours/asakusa-backstreet-local.jpg",
+            "author": {
+              "@type": "Person",
+              "name": "Manabu",
+              "jobTitle": "National Government Licensed Guide Interpreter",
+              "url": "https://tanuki-tabi-travel.com/about",
+            },
+            "datePublished": "2026-03-08",
+            "publisher": {
+              "@type": "Organization",
+              "name": "Tanuki Tabi Travel",
+              "url": "https://tanuki-tabi-travel.com",
+            },
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": "https://tanuki-tabi-travel.com/blog/yanaka-walking-tour-guide",
+            },
+          }),
+        }}
+      />
+    </Layout>
+  );
+};
+
+export default YanakaWalkingTourGuide;

--- a/src/pages/es/EsAbout.tsx
+++ b/src/pages/es/EsAbout.tsx
@@ -17,7 +17,7 @@ const credentials = [
   {
     icon: Shield,
     title: "Guía con Licencia del Gobierno",
-    description: "Intérprete-guía con licencia nacional del gobierno japonés (全国通訳案内士) — la certificación profesional más alta para guías en Japón, que requiere amplio conocimiento de historia, cultura, geografía y dominio del idioma.",
+    description: "Intérprete-guía con licencia nacional del gobierno japonés (全国通訳案内士), la certificación profesional más alta para guías en Japón, que requiere amplio conocimiento de historia, cultura, geografía y dominio del idioma.",
   },
   {
     icon: Globe,
@@ -55,7 +55,7 @@ const whyChooseGuide = [
   {
     icon: Utensils,
     title: "Asistencia Completa",
-    description: "Desde reservas en restaurantes y navegación del tren hasta consejos de etiqueta cultural — tu guía se encarga de los detalles para que tú disfrutes del viaje.",
+    description: "Desde reservas en restaurantes y navegación del tren hasta consejos de etiqueta cultural, tu guía se encarga de los detalles para que tú disfrutes del viaje.",
   },
 ];
 
@@ -65,7 +65,7 @@ const allReviews = [
     author: "Couple visiting Tokyo",
   },
   {
-    text: "Manabu's tour was one of the best I've been on — he is professional, kind, very knowledgeable and an awesome story-teller. His route is well-planned and offers fun experiences. You can tell he is a full-time tour guide because of the effort he puts in.",
+    text: "Manabu's tour was one of the best I've been on. He is professional, kind, very knowledgeable and an awesome story-teller. His route is well-planned and offers fun experiences. You can tell he is a full-time tour guide because of the effort he puts in.",
     author: "Solo traveler",
   },
   {
@@ -98,7 +98,7 @@ const EsAbout = () => {
   return (
     <Layout>
       <SEO
-        title="Conoce a Manabu — Tu Guía Privado en Tokio | Tanuki Tabi Travel"
+        title="Conoce a Manabu, Tu Guía Privado en Tokio | Tanuki Tabi Travel"
         description="Manabu es un guía japonés nativo con licencia oficial del gobierno (全国通訳案内士), 500+ tours y valoración de 4.86★. Nacido en Kanazawa, criado en Kioto, ahora en Tokio."
         canonicalPath="/es/about"
         hreflang={[
@@ -121,7 +121,7 @@ const EsAbout = () => {
                 Soy Manabu, intérprete-guía con licencia nacional del gobierno japonés (全国通訳案内士) con base en Tokio. Esta es una certificación nacional emitida por el gobierno japonés, que requiere amplios conocimientos de historia, cultura, geografía y dominio del inglés y español. Solo los guías certificados están legalmente reconocidos como guías turísticos profesionales en Japón.
               </p>
               <p className="mt-4 text-muted-foreground leading-relaxed">
-                Nacido en Kanazawa, criado en Kioto y ahora viviendo en Tokio — aporto una perspectiva única de las regiones culturalmente más ricas de Japón. Con más de 500 tours completados y una valoración media de 4.86 estrellas, mi pasión es compartir las historias de Japón con viajeros de todo el mundo.
+                Nacido en Kanazawa, criado en Kioto y ahora viviendo en Tokio, aporto una perspectiva única de las regiones culturalmente más ricas de Japón. Con más de 500 tours completados y una valoración media de 4.86 estrellas, mi pasión es compartir las historias de Japón con viajeros de todo el mundo.
               </p>
 
               <div className="mt-8 grid grid-cols-2 sm:grid-cols-4 gap-6">
@@ -157,16 +157,16 @@ const EsAbout = () => {
             </h2>
             <div className="mt-8 text-muted-foreground leading-relaxed space-y-4 text-left">
               <p>
-                Mi filosofía como guía se basa en un principio: <strong className="text-foreground">cada viajero es diferente</strong>. En los primeros 30 minutos de cada tour, presto mucha atención a lo que te emociona — ya sea la arquitectura, la comida callejera, las curiosidades históricas o la fotografía — y adapto la ruta en tiempo real.
+                Mi filosofía como guía se basa en un principio: <strong className="text-foreground">cada viajero es diferente</strong>. En los primeros 30 minutos de cada tour, presto mucha atención a lo que te emociona, ya sea la arquitectura, la comida callejera, las curiosidades históricas o la fotografía, y adapto la ruta en tiempo real.
               </p>
               <p>
                 No doy monólogos con guión. Mis tours son conversaciones. Comparto historias y contexto cultural, pero también quiero escuchar tus preguntas, tus observaciones y lo que te sorprende de Japón. Ese intercambio es lo que hace la experiencia memorable.
               </p>
               <p>
-                Mis años en el mundo empresarial me dieron la oportunidad de viajar y trabajar con personas de diversos orígenes. Me di cuenta de que los visitantes a Japón a menudo perdían el contexto y el significado detrás de lo que veían — el "por qué" que hace las experiencias verdaderamente significativas.
+                Mis años en el mundo empresarial me dieron la oportunidad de viajar y trabajar con personas de diversos orígenes. Me di cuenta de que los visitantes a Japón a menudo perdían el contexto y el significado detrás de lo que veían, el "por qué" que hace las experiencias verdaderamente significativas.
               </p>
               <p className="font-medium text-foreground">
-                Hoy, nada me da más alegría que ver el momento de comprensión en los ojos de un visitante — cuando un templo deja de ser solo piedras viejas y se convierte en una conexión viva con siglos de creencia y artesanía.
+                Hoy, nada me da más alegría que ver el momento de comprensión en los ojos de un visitante, cuando un templo deja de ser solo piedras viejas y se convierte en una conexión viva con siglos de creencia y artesanía.
               </p>
             </div>
           </div>
@@ -315,7 +315,7 @@ const EsAbout = () => {
                 </p>
                 <footer>
                   <cite className="not-italic font-medium text-foreground text-sm">
-                    — {review.author}
+                    - {review.author}
                   </cite>
                 </footer>
               </blockquote>

--- a/src/pages/es/EsFaq.tsx
+++ b/src/pages/es/EsFaq.tsx
@@ -29,7 +29,7 @@ const faqCategories: FAQCategory[] = [
       },
       {
         question: "¿Con cuánta antelación debo reservar?",
-        answer: "Recomendamos reservar al menos 1-2 semanas antes, especialmente durante las temporadas altas (marzo-mayo para los cerezos en flor, octubre-noviembre para el otoño). Las reservas de último momento a veces son posibles — ¡solo pregunta!",
+        answer: "Recomendamos reservar al menos 1-2 semanas antes, especialmente durante las temporadas altas (marzo-mayo para los cerezos en flor, octubre-noviembre para el otoño). Las reservas de último momento a veces son posibles. ¡Solo pregunta!",
       },
       {
         question: "¿Cuál es la política de cancelación?",
@@ -37,7 +37,7 @@ const faqCategories: FAQCategory[] = [
       },
       {
         question: "¿Puedo reservar para una sola persona?",
-        answer: "¡Sí! Los viajeros individuales son muy bienvenidos. El precio puede variar respecto a las tarifas de grupo — contáctanos para un presupuesto.",
+        answer: "¡Sí! Los viajeros individuales son muy bienvenidos. El precio puede variar respecto a las tarifas de grupo, así que contáctanos para un presupuesto.",
       },
     ],
   },
@@ -50,11 +50,11 @@ const faqCategories: FAQCategory[] = [
       },
       {
         question: "¿Son privados sus tours?",
-        answer: "Sí, todos nuestros tours son 100% privados. Solo estás tú y tu grupo con tu guía — sin desconocidos, sin horarios fijos. Tú marcas el ritmo.",
+        answer: "Sí, todos nuestros tours son 100% privados. Solo estás tú y tu grupo con tu guía: sin desconocidos, sin horarios fijos. Tú marcas el ritmo.",
       },
       {
         question: "¿Qué pasa si llueve?",
-        answer: "Los tours se realizan con lluvia o sol — Tokio tiene muchas zonas cubiertas, paradas interiores y pasajes subterráneos. Tu guía adaptará la ruta según el clima. Solo cancelamos por alertas meteorológicas graves (tifones, etc.), en cuyo caso recibirás un reembolso completo o podrás reprogramar.",
+        answer: "Los tours se realizan con lluvia o sol. Tokio tiene muchas zonas cubiertas, paradas interiores y pasajes subterráneos. Tu guía adaptará la ruta según el clima. Solo cancelamos por alertas meteorológicas graves (tifones, etc.), en cuyo caso recibirás un reembolso completo o podrás reprogramar.",
       },
       {
         question: "¿Pueden acomodar restricciones alimentarias?",
@@ -66,7 +66,7 @@ const faqCategories: FAQCategory[] = [
       },
       {
         question: "¿Pueden acomodar usuarios de silla de ruedas?",
-        answer: "Hacemos todo lo posible para que los tours sean accesibles. Por favor, avísanos con antelación y planificaremos una ruta que evite escaleras y use entradas accesibles. Algunos sitios históricos tienen accesibilidad limitada — tu guía planificará en consecuencia.",
+        answer: "Hacemos todo lo posible para que los tours sean accesibles. Por favor, avísanos con antelación y planificaremos una ruta que evite escaleras y use entradas accesibles. Algunos sitios históricos tienen accesibilidad limitada, pero tu guía planificará en consecuencia.",
       },
     ],
   },
@@ -83,7 +83,7 @@ const faqCategories: FAQCategory[] = [
       },
       {
         question: "¿Puedo combinar una excursión con un tour por Tokio?",
-        answer: "¡Sí! Muchos huéspedes reservan un tour a pie por Tokio un día y una excursión otro. Ofrecemos paquetes de varios días — contáctanos para más detalles.",
+        answer: "¡Sí! Muchos huéspedes reservan un tour a pie por Tokio un día y una excursión otro. Ofrecemos paquetes de varios días. Contáctanos para más detalles.",
       },
     ],
   },
@@ -119,7 +119,7 @@ const EsFaq = () => {
     <Layout>
       <SEO
         title="Preguntas Frecuentes sobre Tours en Tokio en Español | Tanuki Tabi Travel"
-        description="Respuestas a las preguntas más frecuentes sobre los tours privados en Tokio con Tanuki Tabi Travel — reservas, precios, cancelaciones y qué esperar del tour."
+        description="Respuestas a las preguntas más frecuentes sobre los tours privados en Tokio con Tanuki Tabi Travel: reservas, precios, cancelaciones y qué esperar del tour."
         canonicalPath="/es/faq"
         hreflang={[
           { lang: "en", path: "/faq" },

--- a/src/pages/es/EsIndex.tsx
+++ b/src/pages/es/EsIndex.tsx
@@ -125,7 +125,7 @@ const trustSignals = [
   {
     icon: Users,
     title: "Tour 100% Privado",
-    description: "El tour es exclusivamente para ti. Sin extraños, sin horarios rígidos — solo tu grupo y tu guía.",
+    description: "El tour es exclusivamente para ti. Sin extraños, sin horarios rígidos. Solo tu grupo y tu guía.",
   },
 ];
 
@@ -136,7 +136,7 @@ const testimonials = [
     rating: 5,
   },
   {
-    text: "Manabu's tour was one of the best I've been on — he is professional, kind, very knowledgeable and an awesome story-teller. His route is well-planned and offers fun experiences. You can tell he is a full-time tour guide because of the effort he puts in.",
+    text: "Manabu's tour was one of the best I've been on. He is professional, kind, very knowledgeable and an awesome story-teller. His route is well-planned and offers fun experiences. You can tell he is a full-time tour guide because of the effort he puts in.",
     author: "Solo traveler",
     rating: 5,
   },
@@ -175,7 +175,7 @@ const EsIndex = () => {
         <div className="relative container-section py-20">
           <div className="max-w-2xl">
             <h1 className="heading-display text-white animate-fade-in-up" style={{ animationDelay: "0.2s" }}>
-              Tokyo con Manabu —{" "}
+              Tokyo con Manabu:{" "}
               <span className="text-accent">Tu Guía Local Certificado</span>
             </h1>
             <p className="mt-6 text-lg text-white/90 leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.3s" }}>
@@ -184,7 +184,7 @@ const EsIndex = () => {
             <p className="mt-3 text-base text-white/70 leading-relaxed animate-fade-in-up" style={{ animationDelay: "0.35s" }}>
               Cada tour comienza con una pregunta simple: ¿Qué es lo que más te
               emociona de Tokio? A partir de ahí, el recorrido es tuyo. No sigo un
-              guión — sigo tu curiosidad.
+              guión, sigo tu curiosidad.
             </p>
 
             <div className="mt-8 flex flex-col sm:flex-row gap-4 animate-fade-in-up" style={{ animationDelay: "0.4s" }}>
@@ -231,14 +231,14 @@ const EsIndex = () => {
                 La mayoría de los guías siguen una ruta fija. Yo no.
               </p>
               <p>
-                En los primeros 30 minutos, te pregunto qué te importa — la comida,
+                En los primeros 30 minutos, te pregunto qué te importa: la comida,
                 la historia, los rincones escondidos, las oportunidades para fotos.
                 Luego me adapto sobre la marcha. Si quieres quedarte más tiempo en un
                 templo, nos quedamos. Si prefieres adelantarte al almuerzo, lo hacemos.
               </p>
               <p>
                 Por eso, viajeros de más de 30 países han dicho que este fue el mejor
-                tour del viaje — no solo de Tokio, sino de todo su recorrido.
+                tour del viaje, no solo de Tokio, sino de todo su recorrido.
               </p>
             </div>
           </div>
@@ -255,7 +255,7 @@ const EsIndex = () => {
                 La mayoría de los guías en español en Tokio son hispanohablantes que aprendieron japonés. Manabu es al revés: japonés nativo que habla español.
               </p>
               <p>
-                Eso marca la diferencia. Conoce Tokio desde dentro — su historia, sus costumbres, los lugares donde come la gente local — y te lo cuenta directamente en español, sin filtros de traducción ni malentendidos culturales.
+                Eso marca la diferencia. Conoce Tokio desde dentro, su historia, sus costumbres, los lugares donde come la gente local, y te lo cuenta directamente en español, sin filtros de traducción ni malentendidos culturales.
               </p>
             </div>
           </div>
@@ -337,13 +337,13 @@ const EsIndex = () => {
               <p className="text-label text-accent mb-4">Tu Guía</p>
               <div className="w-10 h-px bg-accent mb-6" />
               <h2 className="heading-section text-foreground">
-                Conoce a Manabu — Tu Guía Oficial en Tokio
+                Conoce a Manabu, Tu Guía Oficial en Tokio
               </h2>
               <p className="mt-4 text-body">
-                Soy Manabu, intérprete-guía con licencia nacional del gobierno japonés (全国通訳案内士), con más de 500 tours completados y una valoración media de 4.86 estrellas. Nacido en Kanazawa, criado en Kioto y ahora viviendo en Tokio — conozco Japón desde dentro y en profundidad.
+                Soy Manabu, intérprete-guía con licencia nacional del gobierno japonés (全国通訳案内士), con más de 500 tours completados y una valoración media de 4.86 estrellas. Nacido en Kanazawa, criado en Kioto y ahora viviendo en Tokio. Conozco Japón desde dentro y en profundidad.
               </p>
               <p className="mt-4 text-body">
-                Mi forma de guiar es simple: en los primeros 30 minutos aprendo qué es lo que más te emociona, y adapto el tour en tiempo real. No es una clase magistral — es una conversación.
+                Mi forma de guiar es simple: en los primeros 30 minutos aprendo qué es lo que más te emociona, y adapto el tour en tiempo real. No es una clase magistral, es una conversación.
               </p>
               <Link to="/es/about" className="btn-outline mt-8 inline-flex">
                 Más Información
@@ -389,7 +389,7 @@ const EsIndex = () => {
                 Comparte lo que te apasiona
               </h3>
               <p className="text-sm text-muted-foreground leading-relaxed">
-                Historia, gastronomía, callejones ocultos — creo la ruta a tu medida.
+                Historia, gastronomía, callejones ocultos... creo la ruta a tu medida.
               </p>
             </div>
             <div className="text-center">
@@ -463,7 +463,7 @@ const EsIndex = () => {
                 </p>
                 <footer className="pt-4 border-t border-border">
                   <cite className="not-italic font-medium text-foreground text-sm">
-                    — {testimonial.author}
+                    - {testimonial.author}
                   </cite>
                 </footer>
               </blockquote>


### PR DESCRIPTION
Add new blog post "Vegetarian Food Tour Tokyo: A Complete Guide for Dietary Restrictions" with 5 H2 sections covering vegetarian dining in Asakusa, Tsukiji, and Shinjuku, Japanese phrase guide, and CTA. Also includes Yanaka walking tour guide, Nikko/Tokyo itinerary revisions, BlogIndex update, and Spanish page refinements.