### PR TITLE
Standardize blog article image heights to 400px across all pages

### DIFF
--- a/src/pages/blog/AsakusaGuide.tsx
+++ b/src/pages/blog/AsakusaGuide.tsx
@@ -72,7 +72,7 @@ const AsakusaGuide = () => {
               <img
                 src="/images/blog/asakusa-sensoji-pagoda.jpg"
                 alt="Five-story pagoda at Senso-ji Temple Asakusa"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -136,7 +136,7 @@ const AsakusaGuide = () => {
               <img
                 src="/images/blog/asakusa-hidden-shrine.jpg"
                 alt="Asakusa Shrine - hidden gem next to Senso-ji"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -161,7 +161,7 @@ const AsakusaGuide = () => {
               <img
                 src="/images/blog/asakusa-hoppy-street.jpg"
                 alt="Hoppy Street Asakusa - local drinking alley at sunset"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -194,7 +194,7 @@ const AsakusaGuide = () => {
               <img
                 src="/images/blog/asakusa-street-food.jpg"
                 alt="Street food on Nakamise-dori - melon bread and sweet treats"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">

--- a/src/pages/blog/AsakusaGuideNew.tsx
+++ b/src/pages/blog/AsakusaGuideNew.tsx
@@ -72,7 +72,7 @@ const AsakusaGuideNew = () => {
               <img
                 src="/images/blog/asakusa-sensoji-pagoda.jpg"
                 alt="Empty Senso-ji Temple grounds at dawn in Asakusa"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -117,7 +117,7 @@ const AsakusaGuideNew = () => {
               <img
                 src="/images/blog/asakusa-hoppy-street.jpg"
                 alt="Hoppy Street in Asakusa with lanterns and local izakaya"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -149,7 +149,7 @@ const AsakusaGuideNew = () => {
               <img
                 src="/images/blog/asakusa-street-food.jpg"
                 alt="Traditional street food and senbei rice crackers in Asakusa"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">

--- a/src/pages/blog/DayTripComparison.tsx
+++ b/src/pages/blog/DayTripComparison.tsx
@@ -131,7 +131,7 @@ const DayTripComparison = () => {
               <img
                 src="/images/blog/kamakura-buddha-comparison.jpg"
                 alt="Great Buddha in Kamakura - popular day trip from Tokyo"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 The Great Buddha of Kamakura, one of Japan's most iconic landmarks
@@ -174,7 +174,7 @@ const DayTripComparison = () => {
               <img
                 src="/images/blog/hakone-fuji-comparison.jpg"
                 alt="Mt Fuji from Hakone - scenic day trip from Tokyo"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Mt. Fuji from Lake Ashi, Hakone's most sought-after view

--- a/src/pages/blog/JapanRailPass.tsx
+++ b/src/pages/blog/JapanRailPass.tsx
@@ -74,7 +74,7 @@ const JapanRailPass = () => {
                 src="/images/blog/shinkansen-n700-tokyo-station.jpg"
                 alt="N700 Series Shinkansen bullet train at a station platform in Japan"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 The N700 Series Shinkansen — the backbone of Japan's high-speed rail network covered by the JR Pass
@@ -111,7 +111,7 @@ const JapanRailPass = () => {
                 src="/images/blog/fushimi-inari-senbon-torii-kyoto.jpg"
                 alt="Thousands of vermillion torii gates forming a tunnel at Fushimi Inari Shrine in Kyoto"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 The iconic senbon torii at Fushimi Inari, Kyoto — one of the top reasons travelers take the Shinkansen from Tokyo
@@ -126,7 +126,7 @@ const JapanRailPass = () => {
                 src="/images/blog/kinkakuji-golden-pavilion-kyoto.jpg"
                 alt="Kinkaku-ji, the Golden Pavilion temple reflecting on a pond in Kyoto, Japan"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Kinkaku-ji (Golden Pavilion) in Kyoto — the classic route from Tokyo makes the JR Pass pay for itself
@@ -172,7 +172,7 @@ const JapanRailPass = () => {
                 src="/images/blog/jr-okachimachi-station-entrance.jpg"
                 alt="JR Okachimachi Station entrance in Tokyo showing the JR logo and ticket gates"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 A typical JR station in central Tokyo — IC cards work seamlessly at every gate

--- a/src/pages/blog/NikkoDayTrip.tsx
+++ b/src/pages/blog/NikkoDayTrip.tsx
@@ -72,7 +72,7 @@ const NikkoDayTrip = () => {
               <img
                 src="/images/candidates/train/PXL_20240726_023308396.jpg"
                 alt="Train heading toward Nikko through the Japanese countryside"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -97,7 +97,7 @@ const NikkoDayTrip = () => {
               <img
                 src="/images/candidates/nikko/PXL_20240718_040819618.jpg"
                 alt="Intricate carvings and gold leaf decoration at Nikko Tosho-gu Shrine"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -125,7 +125,7 @@ const NikkoDayTrip = () => {
               <img
                 src="/images/candidates/nikko/PXL_20240719_021128437.jpg"
                 alt="Ancient cedar trees lining the path through Nikko's shrine complex"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -150,7 +150,7 @@ const NikkoDayTrip = () => {
               <img
                 src="/images/candidates/autumn/PXL_20241125_034511698.jpg"
                 alt="Brilliant autumn foliage surrounding Nikko's mountain landscape"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -181,7 +181,7 @@ const NikkoDayTrip = () => {
               <img
                 src="/images/candidates/nikko/PXL_20240719_040905028.jpg"
                 alt="A guide explaining the history and symbolism of carvings at Tosho-gu Shrine"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">

--- a/src/pages/blog/OldTokyoShitamachi.tsx
+++ b/src/pages/blog/OldTokyoShitamachi.tsx
@@ -89,7 +89,7 @@ const OldTokyoShitamachi = () => {
                 src="/images/blog/asakusa-jizo-statues-red-bibs.jpg"
                 alt="Row of Jizo stone statues wearing red bibs at an Asakusa temple in old Tokyo"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Jizo statues with red bibs near a temple in Asakusa — each bib is a personal prayer, a quiet reminder of Shitamachi's spiritual roots
@@ -107,7 +107,7 @@ const OldTokyoShitamachi = () => {
                 src="/images/blog/yanaka-ginza-shotengai-entrance.jpg"
                 alt="Entrance gate to Yanaka Ginza shopping street with local shoppers in old Tokyo"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 The entrance to Yanaka Ginza — this slope lined with family-run shops feels more like a village than a part of Tokyo
@@ -123,7 +123,7 @@ const OldTokyoShitamachi = () => {
                 src="/images/blog/ningyocho-amazake-yokocho-tofu-shop.jpg"
                 alt="Traditional tofu and amazake shop in Ningyocho's Amazake Yokocho alley, Tokyo"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 A tofu shop on Amazake Yokocho in Ningyocho — these family-run stores have been here for generations
@@ -160,7 +160,7 @@ const OldTokyoShitamachi = () => {
                 src="/images/blog/yanaka-traditional-pottery-storefront.jpg"
                 alt="Traditional pottery and ceramics shop storefront in Yanaka with handmade bowls on display"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 A ceramics shop in Yanaka — the wooden storefront and handmade wares are exactly what Shitamachi looks like when you know where to look

--- a/src/pages/blog/ShibuyaHarajukuGuide.tsx
+++ b/src/pages/blog/ShibuyaHarajukuGuide.tsx
@@ -79,7 +79,7 @@ const ShibuyaHarajukuGuide = () => {
               <img
                 src="/images/blog/shibuya-crossing-guide.jpg"
                 alt="How to enjoy Shibuya Crossing - best viewing spots"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Shibuya Crossing from above. Up to 3,000 people cross each signal change
@@ -144,7 +144,7 @@ const ShibuyaHarajukuGuide = () => {
               <img
                 src="/images/blog/harajuku-cat-street.jpg"
                 alt="Cat Street Harajuku - the real fashion street"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Cat Street, Harajuku's real fashion street, away from the Takeshita crowds
@@ -168,7 +168,7 @@ const ShibuyaHarajukuGuide = () => {
               <img
                 src="/images/blog/meiji-shrine-forest.jpg"
                 alt="Forest path at Meiji Shrine - quiet escape near Harajuku"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 The forested approach to Meiji Shrine, a world away from Harajuku's crowds

--- a/src/pages/blog/ShinjukuGuide.tsx
+++ b/src/pages/blog/ShinjukuGuide.tsx
@@ -118,7 +118,7 @@ const ShinjukuGuide = () => {
               <img
                 src="/images/blog/shinjuku-golden-gai-bars.jpg"
                 alt="Golden Gai - intimate bar district in Shinjuku"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Golden Gai's narrow alleys are home to over 200 tiny bars
@@ -175,7 +175,7 @@ const ShinjukuGuide = () => {
               <img
                 src="/images/blog/shinjuku-omoide-yokocho.jpg"
                 alt="Omoide Yokocho Memory Lane - yakitori under the train tracks"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Omoide Yokocho: smoke, yakitori, and cold beer under the tracks
@@ -219,7 +219,7 @@ const ShinjukuGuide = () => {
               <img
                 src="/images/blog/shinjuku-gyoen-garden.jpg"
                 alt="Shinjuku Gyoen National Garden - peaceful escape in Tokyo"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Shinjuku Gyoen, a peaceful escape from the surrounding urban energy

--- a/src/pages/blog/TempleEtiquette.tsx
+++ b/src/pages/blog/TempleEtiquette.tsx
@@ -113,7 +113,7 @@ const TempleEtiquette = () => {
                 src="/images/blog/nikko-toshogu-stone-torii-gate.jpg"
                 alt="Visitors approaching through a stone torii gate at Nikko Toshogu shrine with ornate Yomeimon gate visible beyond"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Walking through the stone torii at Nikko Toshogu — notice how visitors naturally walk to the sides, leaving the center path clear
@@ -151,7 +151,7 @@ const TempleEtiquette = () => {
                 src="/images/blog/shrine-chozuya-dragon-purification.jpg"
                 alt="Dragon-shaped water spout at a chozuya purification fountain with bamboo ladles at a Japanese shrine"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 A chozuya with a dragon water spout — look for the bamboo ladles and follow the five-step purification sequence
@@ -210,7 +210,7 @@ const TempleEtiquette = () => {
                 src="/images/blog/nikko-ornate-temple-hall.jpg"
                 alt="Ornate Buddhist temple hall at Nikko with red pillars, gold trim, and stone lanterns"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 A richly decorated temple hall at Nikko — Buddhist temples tend to be more ornate and contemplative than Shinto shrines
@@ -255,7 +255,7 @@ const TempleEtiquette = () => {
                 src="/images/blog/kamakura-serene-temple-garden.jpg"
                 alt="Serene Japanese temple garden in Kamakura with traditional tea house and camellia flowers"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 A temple garden in Kamakura — these tranquil spaces invite quiet contemplation, not selfie sessions

--- a/src/pages/blog/TippingInJapan.tsx
+++ b/src/pages/blog/TippingInJapan.tsx
@@ -122,7 +122,7 @@ const TippingInJapan = () => {
                 src="/images/tours/night-tour-omoide-yokocho.jpg"
                 alt="Busy yakitori counter at Omoide Yokocho in Shinjuku with diners and cooks in a smoky atmosphere"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 A typical counter-style izakaya in Shinjuku — the intimacy between cook and customer is part of the experience, and tipping would disrupt that dynamic
@@ -145,7 +145,7 @@ const TippingInJapan = () => {
                 src="/images/blog/ryokan-nakai-kimono-greeting.jpg"
                 alt="A nakai-san in elegant kimono greeting guests at a traditional Japanese ryokan entrance"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 A nakai-san at a traditional ryokan — kokorozuke is the only context where a monetary gift is sometimes appropriate
@@ -184,7 +184,7 @@ const TippingInJapan = () => {
                 src="/images/blog/japanese-elegant-gift-wrapping.jpg"
                 alt="Elegantly wrapped Japanese gift boxes with blue ribbon bows, representing the art of gift-giving in Japan"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 In Japan, presentation matters as much as the gift itself — a small, beautifully wrapped souvenir speaks louder than cash

--- a/src/pages/blog/Tokyo3DayItinerary.tsx
+++ b/src/pages/blog/Tokyo3DayItinerary.tsx
@@ -100,7 +100,7 @@ const Tokyo3DayItinerary = () => {
               <img
                 src="/images/blog/asakusa-sensoji-pagoda.jpg"
                 alt="Senso-ji Temple pagoda in Asakusa, a highlight of any Tokyo 3-day itinerary"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
@@ -160,7 +160,7 @@ const Tokyo3DayItinerary = () => {
               <img
                 src="/images/blog/asakusa-street-food.jpg"
                 alt="Street food stalls near Asakusa and Ueno, part of Tokyo's vibrant food scene"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
@@ -208,7 +208,7 @@ const Tokyo3DayItinerary = () => {
               <img
                 src="/images/tours/harajuku-takeshita-street.jpg"
                 alt="Harajuku Takeshita Street, colorful and crowded with youth culture shops"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
@@ -251,7 +251,7 @@ const Tokyo3DayItinerary = () => {
               <img
                 src="/images/blog/shinjuku-omoide-yokocho.jpg"
                 alt="Omoide Yokocho in Shinjuku, narrow alley lined with yakitori stalls and lanterns"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
@@ -286,7 +286,7 @@ const Tokyo3DayItinerary = () => {
               <img
                 src="/images/blog/tsukiji-fresh-sushi.jpg"
                 alt="Fresh sushi breakfast at Tsukiji Outer Market in Tokyo"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">

--- a/src/pages/blog/TsukijiGuide.tsx
+++ b/src/pages/blog/TsukijiGuide.tsx
@@ -100,7 +100,7 @@ const TsukijiGuide = () => {
               <img
                 src="/images/blog/tsukiji-fresh-sushi.jpg"
                 alt="Fresh sushi at Tsukiji Market Tokyo"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Fresh sushi at Tsukiji. The fish arrives from wholesalers every morning
@@ -120,7 +120,7 @@ const TsukijiGuide = () => {
               <img
                 src="/images/blog/tsukiji-tamagoyaki.jpg"
                 alt="Tamagoyaki Japanese egg omelette at Tsukiji Market"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Tamagoyaki on a stick, Tsukiji's most iconic street food
@@ -180,7 +180,7 @@ const TsukijiGuide = () => {
               <img
                 src="/images/blog/ginza-shopping-street.jpg"
                 alt="Ginza luxury district - combine with Tsukiji for perfect day"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Ginza, just a short walk from Tsukiji, a completely different world

--- a/src/pages/blog/TsukijiMarketGuide.tsx
+++ b/src/pages/blog/TsukijiMarketGuide.tsx
@@ -99,7 +99,7 @@ const TsukijiMarketGuide = () => {
               <img
                 src="/images/blog/tsukiji-outer-market-lanes.jpg"
                 alt="Narrow lanes of Tsukiji outer market with food stalls"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 The outer market's narrow lanes, over 400 shops packed into a few walkable blocks
@@ -125,7 +125,7 @@ const TsukijiMarketGuide = () => {
                 src="/images/blog/tsukiji-tamagoyaki-on-stick.jpg"
                 alt="Golden tamagoyaki egg omelette on a stick at Tsukiji outer market"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Tsukiji's iconic tamagoyaki — golden, fluffy, and best eaten straight from the grill
@@ -147,7 +147,7 @@ const TsukijiMarketGuide = () => {
                 src="/images/blog/tsukiji-fresh-maguro-sashimi.jpg"
                 alt="Fresh sliced maguro tuna sashimi served at Tsukiji market"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Freshly sliced maguro at Tsukiji — sourced directly from the wholesalers that morning
@@ -172,7 +172,7 @@ const TsukijiMarketGuide = () => {
                 src="/images/blog/tsukiji-dried-goods-souvenirs.jpg"
                 alt="Tsukiji market stall displaying wasabi sesame seeds and specialty dried goods souvenirs"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Wasabi sesame, dried seasonings, and other Tsukiji-exclusive souvenirs that pack more flavor than any airport gift shop

--- a/src/pages/blog/VegetarianFoodTourTokyo.tsx
+++ b/src/pages/blog/VegetarianFoodTourTokyo.tsx
@@ -72,7 +72,7 @@ const VegetarianFoodTourTokyo = () => {
               <img
                 src="/images/blog/tokyo-street-snack.jpg"
                 alt="Traditional Japanese monaka ice cream, a popular plant-based street snack in Tokyo"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -97,7 +97,7 @@ const VegetarianFoodTourTokyo = () => {
               <img
                 src="/images/blog/vegetarian-temple-vegetables.jpg"
                 alt="Daikon radish offering at a Tokyo shrine, reflecting the connection between vegetables and Japanese culture"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -125,7 +125,7 @@ const VegetarianFoodTourTokyo = () => {
               <img
                 src="/images/blog/izakaya-dining-atmosphere.jpg"
                 alt="Intimate izakaya dining atmosphere in Tokyo, where private food tours include personalized service"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -150,7 +150,7 @@ const VegetarianFoodTourTokyo = () => {
               <img
                 src="/images/blog/yanaka-street-food-display.jpg"
                 alt="Traditional Japanese street food display with senbei rice crackers and mochi, all vegetarian-friendly"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">

--- a/src/pages/blog/YanakaWalkingTourGuide.tsx
+++ b/src/pages/blog/YanakaWalkingTourGuide.tsx
@@ -72,7 +72,7 @@ const YanakaWalkingTourGuide = () => {
               <img
                 src="/images/blog/yanaka-candy-shop-art.jpg"
                 alt="Traditional candy shop in Yanaka with colorful wall art"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -97,7 +97,7 @@ const YanakaWalkingTourGuide = () => {
               <img
                 src="/images/blog/yanaka-street-food-display.jpg"
                 alt="Traditional street food display in Yanaka with senbei and mochi"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -122,7 +122,7 @@ const YanakaWalkingTourGuide = () => {
               <img
                 src="/images/blog/yanaka-pottery-shop.jpg"
                 alt="Traditional pottery and ceramics shop in Yanaka"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -147,7 +147,7 @@ const YanakaWalkingTourGuide = () => {
               <img
                 src="/images/blog/yanaka-soba-restaurant.jpg"
                 alt="Traditional soba restaurant in Yanaka with green noren curtain at the entrance"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -172,7 +172,7 @@ const YanakaWalkingTourGuide = () => {
               <img
                 src="/images/candidates/train/PXL_20240726_023308396.jpg"
                 alt="JR train platform — Nippori Station on the Yamanote Line is the gateway to Yanaka"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">

--- a/src/pages/es/blog/EsComparativaExcursiones.tsx
+++ b/src/pages/es/blog/EsComparativaExcursiones.tsx
@@ -137,7 +137,7 @@ const EsComparativaExcursiones = () => {
               <img
                 src="/images/blog/kamakura-buddha-comparison.jpg"
                 alt="Gran Buda de Kamakura - excursión popular desde Tokio"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 El Gran Buda de Kamakura, uno de los monumentos más icónicos de Japón
@@ -180,7 +180,7 @@ const EsComparativaExcursiones = () => {
               <img
                 src="/images/blog/hakone-fuji-comparison.jpg"
                 alt="Monte Fuji desde Hakone - excursión escénica desde Tokio"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 El Monte Fuji desde el Lago Ashi, la vista más codiciada de Hakone

--- a/src/pages/es/blog/EsEtiquetaTemplos.tsx
+++ b/src/pages/es/blog/EsEtiquetaTemplos.tsx
@@ -119,7 +119,7 @@ const EsEtiquetaTemplos = () => {
                 src="/images/blog/nikko-toshogu-stone-torii-gate.jpg"
                 alt="Visitantes cruzando la puerta torii de piedra en el santuario Nikko Toshogu con la puerta Yomeimon al fondo"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Cruzando el torii de piedra en Nikko Toshogu — observa cómo los visitantes caminan naturalmente por los lados, dejando libre el camino central
@@ -157,7 +157,7 @@ const EsEtiquetaTemplos = () => {
                 src="/images/blog/shrine-chozuya-dragon-purification.jpg"
                 alt="Fuente de purificación chozuya con caño en forma de dragón y cucharones de bambú en un santuario japonés"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Un chozuya con caño de dragón — busca los cucharones de bambú y sigue los cinco pasos de purificación
@@ -216,7 +216,7 @@ const EsEtiquetaTemplos = () => {
                 src="/images/blog/nikko-ornate-temple-hall.jpg"
                 alt="Salón de templo budista ornamentado en Nikko con pilares rojos, detalles dorados y linternas de piedra"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Un salón de templo ricamente decorado en Nikko — los templos budistas suelen ser más ornamentados y contemplativos que los santuarios sintoístas
@@ -261,7 +261,7 @@ const EsEtiquetaTemplos = () => {
                 src="/images/blog/kamakura-serene-temple-garden.jpg"
                 alt="Jardín sereno de templo japonés en Kamakura con casa de té tradicional y flores de camelia"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Un jardín de templo en Kamakura — estos espacios tranquilos invitan a la contemplación silenciosa, no a las sesiones de selfies

--- a/src/pages/es/blog/EsGuiaAsakusa.tsx
+++ b/src/pages/es/blog/EsGuiaAsakusa.tsx
@@ -78,7 +78,7 @@ const EsGuiaAsakusa = () => {
               <img
                 src="/images/blog/asakusa-sensoji-pagoda.jpg"
                 alt="Pagoda de cinco pisos en el Templo Senso-ji de Asakusa"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -142,7 +142,7 @@ const EsGuiaAsakusa = () => {
               <img
                 src="/images/blog/asakusa-hidden-shrine.jpg"
                 alt="Santuario de Asakusa - joya oculta junto al Senso-ji"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -167,7 +167,7 @@ const EsGuiaAsakusa = () => {
               <img
                 src="/images/blog/asakusa-hoppy-street.jpg"
                 alt="Calle Hoppy en Asakusa - callejón de bares locales al atardecer"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">
@@ -200,7 +200,7 @@ const EsGuiaAsakusa = () => {
               <img
                 src="/images/blog/asakusa-street-food.jpg"
                 alt="Comida callejera en Nakamise-dori - pan de melón y dulces"
-                className="w-full rounded-lg shadow-md"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
                 loading="lazy"
               />
               <figcaption className="mt-3 text-sm text-muted-foreground text-center">

--- a/src/pages/es/blog/EsGuiaShibuyaHarajuku.tsx
+++ b/src/pages/es/blog/EsGuiaShibuyaHarajuku.tsx
@@ -85,7 +85,7 @@ const EsGuiaShibuyaHarajuku = () => {
               <img
                 src="/images/blog/shibuya-crossing-guide.jpg"
                 alt="Cómo disfrutar del Cruce de Shibuya - mejores puntos de observación"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 El Cruce de Shibuya desde arriba. Hasta 3.000 personas cruzan en cada cambio de semáforo
@@ -150,7 +150,7 @@ const EsGuiaShibuyaHarajuku = () => {
               <img
                 src="/images/blog/harajuku-cat-street.jpg"
                 alt="Cat Street en Harajuku - la verdadera calle de la moda"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Cat Street, la verdadera calle de la moda de Harajuku, lejos de las multitudes de Takeshita
@@ -174,7 +174,7 @@ const EsGuiaShibuyaHarajuku = () => {
               <img
                 src="/images/blog/meiji-shrine-forest.jpg"
                 alt="Camino boscoso en el Santuario Meiji - escape tranquilo cerca de Harajuku"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 El camino arbolado hacia el Santuario Meiji, un mundo aparte de las multitudes de Harajuku

--- a/src/pages/es/blog/EsGuiaShinjuku.tsx
+++ b/src/pages/es/blog/EsGuiaShinjuku.tsx
@@ -91,7 +91,7 @@ const EsGuiaShinjuku = () => {
               <img
                 src="/images/blog/shinjuku-golden-gai-bars.jpg"
                 alt="Golden Gai - distrito de bares íntimos en Shinjuku"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Los estrechos callejones de Golden Gai albergan más de 200 diminutos bares
@@ -119,7 +119,7 @@ const EsGuiaShinjuku = () => {
               <img
                 src="/images/blog/shinjuku-omoide-yokocho.jpg"
                 alt="Omoide Yokocho Memory Lane - yakitori bajo las vías del tren"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Omoide Yokocho: humo, yakitori y cerveza fría bajo las vías
@@ -144,7 +144,7 @@ const EsGuiaShinjuku = () => {
               <img
                 src="/images/blog/shinjuku-gyoen-garden.jpg"
                 alt="Jardín Nacional Shinjuku Gyoen - un escape tranquilo en Tokio"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Shinjuku Gyoen, un escape tranquilo de la energía urbana circundante

--- a/src/pages/es/blog/EsGuiaTsukiji.tsx
+++ b/src/pages/es/blog/EsGuiaTsukiji.tsx
@@ -106,7 +106,7 @@ const EsGuiaTsukiji = () => {
               <img
                 src="/images/blog/tsukiji-fresh-sushi.jpg"
                 alt="Sushi fresco en el mercado de Tsukiji en Tokio"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Sushi fresco en Tsukiji. El pescado llega de los mayoristas cada mañana
@@ -126,7 +126,7 @@ const EsGuiaTsukiji = () => {
               <img
                 src="/images/blog/tsukiji-tamagoyaki.jpg"
                 alt="Tamagoyaki, tortilla japonesa de huevo en el mercado de Tsukiji"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Tamagoyaki en palito, la comida callejera más icónica de Tsukiji
@@ -186,7 +186,7 @@ const EsGuiaTsukiji = () => {
               <img
                 src="/images/blog/ginza-shopping-street.jpg"
                 alt="Distrito de lujo de Ginza - combínalo con Tsukiji para un día perfecto"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Ginza, a pocos pasos de Tsukiji, un mundo completamente diferente

--- a/src/pages/es/blog/EsJapanRailPass.tsx
+++ b/src/pages/es/blog/EsJapanRailPass.tsx
@@ -91,7 +91,7 @@ const EsJapanRailPass = () => {
                 src="/images/blog/shinkansen-n700-tokyo-station.jpg"
                 alt="Tren bala Shinkansen Serie N700 en un andén de estación en Japón"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 El Shinkansen Serie N700 — la columna vertebral de la red de alta velocidad japonesa cubierta por el JR Pass
@@ -160,7 +160,7 @@ const EsJapanRailPass = () => {
                 src="/images/blog/fushimi-inari-senbon-torii-kyoto.jpg"
                 alt="Miles de puertas torii bermellón formando un túnel en el santuario Fushimi Inari de Kioto"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Los icónicos senbon torii de Fushimi Inari, Kioto — una de las razones principales por las que los viajeros toman el Shinkansen desde Tokio
@@ -178,7 +178,7 @@ const EsJapanRailPass = () => {
                 src="/images/blog/kinkakuji-golden-pavilion-kyoto.jpg"
                 alt="Kinkaku-ji, el Pabellón Dorado reflejándose en un estanque en Kioto, Japón"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Kinkaku-ji (Pabellón Dorado) en Kioto — la ruta clásica desde Tokio hace que el JR Pass se amortice solo
@@ -286,7 +286,7 @@ const EsJapanRailPass = () => {
                 src="/images/blog/jr-okachimachi-station-entrance.jpg"
                 alt="Entrada de la estación JR Okachimachi en Tokio mostrando el logotipo de JR y las puertas de acceso"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Una estación JR típica en el centro de Tokio — las tarjetas IC funcionan en todas las puertas

--- a/src/pages/es/blog/EsMercadoTsukijiTokio.tsx
+++ b/src/pages/es/blog/EsMercadoTsukijiTokio.tsx
@@ -148,7 +148,7 @@ const EsMercadoTsukijiTokio = () => {
                 src="/images/blog/tsukiji-fresh-maguro-sashimi.jpg"
                 alt="Sashimi de atún maguro recién cortado servido en el mercado de Tsukiji"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Maguro recién cortado en Tsukiji — comprado directamente a los mayoristas esa misma mañana
@@ -166,7 +166,7 @@ const EsMercadoTsukijiTokio = () => {
                 src="/images/blog/tsukiji-tamagoyaki-on-stick.jpg"
                 alt="Tamagoyaki dorado en palito en el mercado exterior de Tsukiji"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 El icónico tamagoyaki de Tsukiji — dorado, esponjoso y mejor recién salido de la plancha
@@ -184,7 +184,7 @@ const EsMercadoTsukijiTokio = () => {
                 src="/images/blog/tsukiji-dried-goods-souvenirs.jpg"
                 alt="Puesto del mercado de Tsukiji con sésamo de wasabi y productos secos especiales como recuerdo"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Sésamo de wasabi, condimentos secos y otros recuerdos exclusivos de Tsukiji con más sabor que cualquier tienda de aeropuerto

--- a/src/pages/es/blog/EsPropinasenJapon.tsx
+++ b/src/pages/es/blog/EsPropinasenJapon.tsx
@@ -153,7 +153,7 @@ const EsPropinasenJapon = () => {
                 src="/images/blog/ryokan-nakai-kimono-greeting.jpg"
                 alt="Una nakai-san en elegante kimono recibiendo a los huéspedes en la entrada de un ryokan tradicional japonés"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Una nakai-san en un ryokan tradicional — el kokorozuke es el único contexto donde un regalo monetario puede ser apropiado
@@ -171,7 +171,7 @@ const EsPropinasenJapon = () => {
                 src="/images/tours/night-tour-omoide-yokocho.jpg"
                 alt="Mostrador animado de yakitori en Omoide Yokocho en Shinjuku con comensales y cocineros en ambiente ahumado"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Una izakaya típica de mostrador en Shinjuku — la intimidad entre cocinero y cliente forma parte de la experiencia, y la propina rompería esa dinámica
@@ -210,7 +210,7 @@ const EsPropinasenJapon = () => {
                 src="/images/blog/japanese-elegant-gift-wrapping.jpg"
                 alt="Cajas de regalo japonesas elegantemente envueltas con lazos de cinta azul, representando el arte del regalo en Japón"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 En Japón, la presentación importa tanto como el regalo — un pequeño obsequio bellamente envuelto dice más que el dinero

--- a/src/pages/es/blog/EsShitamachiTokio.tsx
+++ b/src/pages/es/blog/EsShitamachiTokio.tsx
@@ -122,7 +122,7 @@ const EsShitamachiTokio = () => {
                 src="/images/blog/asakusa-jizo-statues-red-bibs.jpg"
                 alt="Fila de estatuas Jizo de piedra con baberos rojos en un templo de Asakusa en el antiguo Tokio"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Estatuas Jizo con baberos rojos cerca de un templo en Asakusa — cada babero es una oración personal, un recordatorio silencioso de las raíces espirituales del shitamachi
@@ -143,7 +143,7 @@ const EsShitamachiTokio = () => {
                 src="/images/blog/yanaka-ginza-shotengai-entrance.jpg"
                 alt="Puerta de entrada a la calle comercial Yanaka Ginza con compradores locales en el antiguo Tokio"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 La entrada a Yanaka Ginza — esta cuesta con tiendas familiares se siente más como un pueblo que como parte de Tokio
@@ -180,7 +180,7 @@ const EsShitamachiTokio = () => {
                 src="/images/blog/ningyocho-amazake-yokocho-tofu-shop.jpg"
                 alt="Tienda tradicional de tofu y amazake en el callejón Amazake Yokocho de Ningyocho, Tokio"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Una tienda de tofu en Amazake Yokocho, Ningyocho — estos negocios familiares llevan generaciones en el mismo lugar
@@ -212,7 +212,7 @@ const EsShitamachiTokio = () => {
                 src="/images/blog/yanaka-traditional-pottery-storefront.jpg"
                 alt="Fachada de tienda tradicional de cerámica en Yanaka con cuencos artesanales expuestos"
                 loading="lazy"
-                className="w-full rounded-lg"
+                className="w-full h-[400px] object-cover rounded-lg shadow-md"
               />
               <figcaption className="mt-2 text-sm text-muted-foreground text-center">
                 Una tienda de cerámica en Yanaka — la fachada de madera y las piezas artesanales son exactamente lo que descubres en el shitamachi cuando sabes dónde mirar


### PR DESCRIPTION
Apply fixed h-[400px] with object-cover to all in-article images (89 occurrences
across 25 files) for consistent visual presentation. Also unified shadow-md
styling on images that were missing it.

https://claude.ai/code/session_01NoMFHRqcAH9m7RVGczm27V