### PR TITLE
Replace hardcoded image paths with imported asset in Contact pages

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -3,6 +3,7 @@ import { Mail, MapPin, Send, Check } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { useToast } from "@/hooks/use-toast";
+import guidePortrait from "@/assets/About_page_Manabu_team_photo.webp";
 
 const Contact = () => {
   const { toast } = useToast();
@@ -107,7 +108,7 @@ const Contact = () => {
         <div className="container-section">
           <div className="flex items-center gap-4 max-w-2xl">
             <img
-              src="/images/tour-photos/group-photo.webp"
+              src={guidePortrait}
               alt="Manabu, your licensed Tokyo tour guide"
               className="w-14 h-14 rounded-full object-cover border-2 border-accent shrink-0"
             />

--- a/src/pages/es/EsContact.tsx
+++ b/src/pages/es/EsContact.tsx
@@ -4,6 +4,7 @@ import { Mail, MapPin, Send, Check } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { useToast } from "@/hooks/use-toast";
+import guidePortrait from "@/assets/About_page_Manabu_team_photo.webp";
 
 const EsContact = () => {
   const { toast } = useToast();
@@ -105,7 +106,7 @@ const EsContact = () => {
         <div className="container-section">
           <div className="flex items-center gap-4 max-w-2xl">
             <img
-              src="/images/tour-photos/group-photo.webp"
+              src={guidePortrait}
               alt="Manabu, tu guía turístico con licencia en Tokio"
               className="w-14 h-14 rounded-full object-cover border-2 border-accent shrink-0"
               loading="lazy"


### PR DESCRIPTION
## Summary
Updated Contact and Spanish Contact pages to use imported asset references instead of hardcoded public image paths for the guide portrait image.

## Key Changes
- Imported `guidePortrait` asset from `@/assets/About_page_Manabu_team_photo.webp` in both `Contact.tsx` and `EsContact.tsx`
- Replaced hardcoded `/images/tour-photos/group-photo.webp` path with the imported `guidePortrait` variable in both files
- Applied change to the guide profile image displayed in the contact form section

## Implementation Details
This change improves asset management by:
- Using explicit imports for better build-time asset tracking and optimization
- Enabling webpack/bundler to properly handle asset versioning and hashing
- Reducing reliance on public directory paths, making assets more maintainable
- Ensuring consistent asset references across the application

https://claude.ai/code/session_01PG5T6ySHSrSnbsuDwB8if1