### PR TITLE
Add FAQ sections to tour pages and enhance blog content

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -78,6 +78,13 @@
   to = "/404.html"
   status = 404
 
+# Blog article consolidation: licensed guide article → hiring guide article
+[[redirects]]
+  from = "/blog/licensed-tour-guide-japan"
+  to = "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo"
+  status = 301
+  force = true
+
 # Remove trailing slashes: /path/ → /path (301 redirect)
 [[redirects]]
   from = "/:splat/"

--- a/src/components/blog/InlineCTA.tsx
+++ b/src/components/blog/InlineCTA.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+
+interface InlineCTAProps {
+  /** Short contextual message relating to the article topic */
+  message?: string;
+  /** Link text for the CTA */
+  linkText?: string;
+  /** Target path */
+  href?: string;
+}
+
+export const InlineCTA = ({
+  message = "Want to experience this with a local guide?",
+  linkText = "Learn more & book →",
+  href = "/contact",
+}: InlineCTAProps) => (
+  <aside className="bg-accent/10 border-l-4 border-accent rounded-r-lg px-6 py-5 my-10">
+    <p className="text-foreground leading-relaxed">
+      <strong>{message}</strong>{" "}
+      Our private Tokyo tours bring these stories to life.{" "}
+      <Link to={href} className="text-accent hover:underline font-medium">
+        {linkText}
+      </Link>
+    </p>
+  </aside>
+);

--- a/src/pages/TourDetail.tsx
+++ b/src/pages/TourDetail.tsx
@@ -538,6 +538,48 @@ const tourData = {
   },
 };
 
+const tourFAQs: Record<string, { question: string; answer: string }[]> = {
+  "tsukiji-ginza": [
+    { question: "What time should I book the Tsukiji & Ginza tour?", answer: "The morning session starting at 9:00 AM is strongly recommended. Tsukiji Outer Market is at its freshest and liveliest early in the morning, with most stalls closing by 2:00 PM." },
+    { question: "Is Tsukiji Outer Market still open?", answer: "Yes! Only the inner wholesale market moved to Toyosu in 2018. The outer market with 460+ shops, restaurants, and food stalls remains fully open." },
+    { question: "What dietary restrictions can you accommodate?", answer: "We can accommodate most dietary restrictions including vegetarian, pescatarian, halal, and common allergies. Let us know when booking and we'll plan the food stops accordingly." },
+    { question: "How many people can join the tour?", answer: "Our private tours accommodate 1-6 people per group. The per-group pricing means larger groups get better value per person." },
+  ],
+  "nikko-day-trip": [
+    { question: "How do we get to Nikko from Tokyo?", answer: "We take the JR Tohoku Shinkansen to Utsunomiya, then transfer to the JR Nikko Line. Total journey is about 2 hours. Your guide handles all navigation and tickets." },
+    { question: "Is the Nikko day trip suitable for children?", answer: "Yes, though there are some stairs and uphill walking at Toshogu Shrine. Children usually love the ornate carvings (especially the sleeping cat and three monkeys) and the waterfall." },
+    { question: "What is the best season to visit Nikko?", answer: "October to November offers spectacular autumn foliage. May brings lush spring greenery. Summer is cooler than Tokyo, making it a pleasant escape. Winter has fewer crowds but some facilities may be closed." },
+    { question: "What does the tour cost not include?", answer: "Train fares (approx. ¥5,000-8,000 round trip), Toshogu Shrine admission (¥1,600), lunch, Kegon Falls elevator (¥570, optional), and local bus fares are not included in the guide fee." },
+  ],
+  "kamakura-day-trip": [
+    { question: "How far is Kamakura from Tokyo?", answer: "Kamakura is about 1 hour from Tokyo by train. We typically take the JR Yokosuka Line from Tokyo Station directly to Kamakura Station." },
+    { question: "Can we customize the Kamakura itinerary?", answer: "Absolutely. Kamakura has over 65 temples and shrines. Your guide will tailor the route to your interests — whether that's history, hiking trails, zen gardens, or beach views." },
+    { question: "Is Kamakura worth visiting with kids?", answer: "Yes! Children love the Great Buddha (you can go inside the statue), the beach, and the street food on Komachi-dori. The walking is mostly flat and manageable." },
+    { question: "What should I wear to Kamakura?", answer: "Comfortable walking shoes are essential. Some temple grounds have gravel paths and stairs. Dress modestly for temple visits (shoulders and knees covered). Bring a hat and sunscreen in summer." },
+  ],
+  "hakone-day-trip": [
+    { question: "Will I see Mt. Fuji from Hakone?", answer: "Mt. Fuji visibility depends on weather. Clearest views are typically October through February. Your guide monitors conditions and adjusts the itinerary to maximize your chances." },
+    { question: "What is the Hakone Free Pass?", answer: "The Hakone Free Pass (approx. ¥6,100) covers round-trip train from Shinjuku plus unlimited rides on ropeway, cruise ship, cable car, and buses within Hakone. It's not included in the guide fee but highly recommended." },
+    { question: "Can we visit an onsen (hot spring) during the tour?", answer: "Yes! We can include a public foot bath (free) or a day-use onsen facility. Let your guide know your preference when booking." },
+    { question: "Is the Hakone day trip too long for elderly travelers?", answer: "The tour is mostly transport-based with short walks, so it's manageable for most fitness levels. We can adjust the pace and skip more strenuous segments if needed." },
+  ],
+  asakusa: [
+    { question: "How long is the Asakusa walking tour?", answer: "The tour is approximately 3 hours. We cover Senso-ji Temple, Nakamise Street, hidden backstreets, and Sumida River views at a comfortable pace." },
+    { question: "Is the Asakusa tour suitable for young children?", answer: "Yes! The route is flat and pram-friendly. Children enjoy the colorful temple, the fortune-telling (omikuji), and the street food on Nakamise." },
+    { question: "What's the best time of day for the Asakusa tour?", answer: "Morning (10:00 AM start) is ideal for fewer crowds and better photos. The afternoon session works well too, especially for catching the evening illumination of Senso-ji." },
+  ],
+  "shibuya-harajuku": [
+    { question: "Will we see the Shibuya Crossing from above?", answer: "Yes! Your guide will take you to the best observation points for watching and photographing the famous scramble crossing from above." },
+    { question: "Is this tour suitable for teenagers?", answer: "Absolutely — this is one of our most popular tours for families with teens. Harajuku's fashion scene, crepe shops, and pop culture make it a highlight." },
+    { question: "Do we visit Meiji Shrine on this tour?", answer: "Yes. Meiji Shrine is a peaceful contrast to busy Harajuku and a highlight of the tour. We walk through the forested approach and explain the Shinto rituals." },
+  ],
+  custom: [
+    { question: "How do I tell you what I want to see?", answer: "After booking, we'll exchange messages about your interests, pace, food preferences, and any specific places you want to visit. Your guide then designs a custom itinerary." },
+    { question: "What's the minimum booking time for a custom tour?", answer: "The minimum is 3 hours. Most guests book 4-6 hours for a half-day experience or 7-8 hours for a full day." },
+    { question: "Can you combine multiple neighborhoods?", answer: "Yes! A custom tour can cover 2-3 areas depending on the duration. Your guide plans efficient routes using Tokyo's excellent train network." },
+  ],
+};
+
 const relatedTours: Record<string, string[]> = {
   asakusa: ["yanaka", "tsukiji-ginza", "kamakura-day-trip"],
   yanaka: ["asakusa", "imperial-palace", "nikko-day-trip"],
@@ -612,6 +654,7 @@ const TourDetail = () => {
   }, [emblaApi, onSelect]);
 
   const related = relatedTours[id as string] || [];
+  const faqs = tourFAQs[id as string] || [];
 
   useEffect(() => {
     if (seo) {
@@ -912,6 +955,23 @@ const TourDetail = () => {
         </div>
       </section>
 
+      {/* FAQ Section */}
+      {faqs.length > 0 && (
+        <section className="py-16 bg-secondary/30">
+          <div className="container-section">
+            <h2 className="heading-section text-foreground mb-8 text-center">Frequently Asked Questions</h2>
+            <div className="max-w-3xl mx-auto space-y-6">
+              {faqs.map((faq, index) => (
+                <div key={index} className="bg-card border border-border rounded-lg p-6">
+                  <h3 className="text-lg font-medium text-foreground mb-2">{faq.question}</h3>
+                  <p className="text-muted-foreground leading-relaxed">{faq.answer}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
       {/* Day Trip CTA */}
       {"whyGuide" in tour && (
         <section className="py-16 bg-primary text-primary-foreground">
@@ -996,6 +1056,27 @@ const TourDetail = () => {
                 "name": "Tanuki Tabi Travel",
                 "url": "https://tanuki-tabi-travel.com",
               },
+            }),
+          }}
+        />
+      )}
+
+      {/* FAQ Schema */}
+      {faqs.length > 0 && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "FAQPage",
+              "mainEntity": faqs.map((faq) => ({
+                "@type": "Question",
+                "name": faq.question,
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": faq.answer,
+                },
+              })),
             }),
           }}
         />

--- a/src/pages/blog/AsakusaGuideNew.tsx
+++ b/src/pages/blog/AsakusaGuideNew.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { RelatedTourCards } from "@/components/blog/RelatedTourCards";
+import { InlineCTA } from "@/components/blog/InlineCTA";
 
 const AsakusaGuideNew = () => {
   return (
@@ -114,6 +115,8 @@ const AsakusaGuideNew = () => {
             <p className="text-muted-foreground leading-relaxed mb-4">
               <strong className="text-foreground">The Fortune Slips (Omikuji).</strong> Drawing a fortune at Senso-ji is practically mandatory, and the experience is straightforward: drop a 100-yen coin in the box, shake the metal cylinder until a numbered stick falls out, then find the corresponding drawer and take your paper fortune. Here is what makes Senso-ji's fortunes unique: roughly 30% of them are "bad luck" (kyo), which is far higher than most temples in Japan. This is not a mistake or a tourist gimmick. This is how traditional fortune distribution was always calculated. Most other temples have quietly adjusted their ratios over the years to keep visitors happy, but Senso-ji maintains the authentic proportions. If you get a bad fortune, the tradition is to fold it and tie it to the metal rack near the fortune stand. You are literally leaving the bad luck at the temple rather than carrying it with you. If you get a good fortune, keep it in your wallet.
             </p>
+
+            <InlineCTA message="Want to discover the stories behind Asakusa's temples?" href="/tours/asakusa" />
 
             {/* Section 3: Beyond the Temple */}
             <h2 className="heading-section text-foreground mt-12 mb-6">

--- a/src/pages/blog/BlogIndex.tsx
+++ b/src/pages/blog/BlogIndex.tsx
@@ -292,16 +292,6 @@ const blogPosts: BlogPost[] = [
     category: "Helpful Guides",
     image: "/images/tour-photos/group-photo.webp",
   },
-  {
-    slug: "licensed-tour-guide-japan",
-    title: "What Is a Licensed Tour Guide in Japan?",
-    description:
-      "Japan has a national licensing exam for tour guides. Here's what separates a licensed guide from an unlicensed one, and why it matters for your trip.",
-    date: "March 7, 2026",
-    author: "Manabu, Licensed Tour Guide",
-    category: "Helpful Guides",
-    image: "/images/tour-photos/tour-photo-1.webp",
-  },
 ];
 
 const categories = [

--- a/src/pages/blog/IsItWorthHiringGuide.tsx
+++ b/src/pages/blog/IsItWorthHiringGuide.tsx
@@ -222,11 +222,7 @@ const IsItWorthHiringGuide = () => {
               The National Government Licensed Guide Interpreter (全国通訳案内士) is Japan's only nationally recognized professional guide certification. It requires passing extensive exams covering Japanese history, geography, culture, politics, and English proficiency. Only about 20% of test-takers pass.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              This means your guide has verified deep knowledge, not just memorized scripts, but genuine understanding of Japanese culture and history that allows them to answer unexpected questions and provide context that goes beyond the standard tourist narrative. You can ask about anything, and you'll get a thoughtful, informed answer. I've written a detailed explanation of{" "}
-                <Link to="/blog/licensed-tour-guide-japan" className="text-accent hover:underline">
-                  what the licensed tour guide system in Japan actually means
-                </Link>
-                {" "}if you want to understand the certification process and why it matters.
+              This means your guide has verified deep knowledge, not just memorized scripts, but genuine understanding of Japanese culture and history that allows them to answer unexpected questions and provide context that goes beyond the standard tourist narrative. You can ask about anything, and you'll get a thoughtful, informed answer.
             </p>
 
             {/* How Much Does It Cost */}

--- a/src/pages/blog/JapanRailPass.tsx
+++ b/src/pages/blog/JapanRailPass.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { RelatedTourCards } from "@/components/blog/RelatedTourCards";
+import { InlineCTA } from "@/components/blog/InlineCTA";
 
 const JapanRailPass = () => {
   return (
@@ -106,7 +107,7 @@ const JapanRailPass = () => {
               <li className="text-muted-foreground leading-relaxed"><strong className="text-foreground">Tokyo → Kamakura (JR):</strong> ¥940</li>
             </ul>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              Remember: the JR Pass covers the Hikari and Kodama Shinkansen but NOT the Nozomi or Mizuho (the fastest trains on the Tokaido/Sanyo line). The Hikari gets you to Kyoto in 2 hours 20 minutes vs. the Nozomi's 2 hours 15 minutes, barely any difference.
+              Remember: the JR Pass covers the Hikari and Kodama Shinkansen. For the Nozomi or Mizuho (the fastest trains), you'll need to purchase a supplementary ticket (about ¥4,960 for Tokyo–Kyoto). In practice, the Hikari gets you to Kyoto in about 2 hours 20 minutes vs. the Nozomi's 2 hours 15 minutes — barely any difference, so most travelers simply take the Hikari.
             </p>
 
             <h2 className="heading-section text-foreground mt-12 mb-6">
@@ -153,12 +154,15 @@ const JapanRailPass = () => {
               Any itinerary with three or more Shinkansen legs plus local JR rides will almost certainly exceed ¥50,000. If you're doing the "Golden Route" with side trips, the 7-day pass pays for itself. <strong className="text-foreground">Verdict: definitely worth it.</strong>
             </p>
 
+            <InlineCTA message="Need help planning your Japan logistics?" href="/contact" />
+
             <h2 className="heading-section text-foreground mt-12 mb-6">
               When the JR Pass Is NOT Worth It
             </h2>
             <ul className="space-y-4 mb-8">
               <li className="text-muted-foreground leading-relaxed">
-                <strong className="text-foreground">Tokyo-only trips:</strong> If you're staying in Tokyo for your entire visit, the JR Pass makes no sense. Tokyo's subway and metro systems (which the JR Pass doesn't cover) do most of the heavy lifting. Your daily JR usage in Tokyo might be ¥500–1,000.
+                <strong className="text-foreground">Tokyo-only trips:</strong> If you're staying in Tokyo for your entire visit, the JR Pass makes no sense. Tokyo's subway and metro systems (which the JR Pass doesn't cover) do most of the heavy lifting. Your daily JR usage in Tokyo might be ¥500–1,000. Instead, invest your budget in experiences like a{" "}
+                <Link to="/tours/tokyo-food-tour" className="text-accent hover:underline">private food tour</Link> to discover local culinary gems beyond the guidebooks.
               </li>
               <li className="text-muted-foreground leading-relaxed">
                 <strong className="text-foreground">Simple Tokyo → Kyoto → Tokyo round trip:</strong> Total Shinkansen cost: ¥27,700. The pass costs ¥50,000. You'd need ¥22,300 in additional JR rides to break even, which is unlikely unless you're doing multiple day trips.
@@ -167,7 +171,9 @@ const JapanRailPass = () => {
                 <strong className="text-foreground">Short stays (3–4 days):</strong> Even with a 7-day pass, if you're only traveling for half the window, you won't use enough rides to justify the cost. Individual tickets are almost always cheaper for short trips.
               </li>
               <li className="text-muted-foreground leading-relaxed">
-                <strong className="text-foreground">Itineraries using non-JR trains:</strong> Many popular routes use non-JR operators: the Odakyu Line to Hakone, the Tobu Line to Nikko, the Kintetsu Line in the Kansai region. The JR Pass doesn't cover these. If your itinerary relies heavily on private railways, the pass loses value.
+                <strong className="text-foreground">Itineraries using non-JR trains:</strong> Many popular routes use non-JR operators: the Odakyu Line to Hakone, the Tobu Line to Nikko, the Kintetsu Line in the Kansai region. The JR Pass doesn't cover these. If your itinerary relies heavily on private railways, the pass loses value. For day trips like{" "}
+                <Link to="/tours/nikko-day-trip" className="text-accent hover:underline">Nikko</Link>, where transport logistics can be complex, a{" "}
+                <Link to="/tours/nikko-day-trip" className="text-accent hover:underline">guided day trip</Link> handles all the transfers and lets you focus on the experience.
               </li>
             </ul>
 
@@ -213,6 +219,27 @@ const JapanRailPass = () => {
               guides, which cover transportation logistics in detail.
             </p>
 
+            {/* Related Tours */}
+            <div className="mt-16 border-t pt-12">
+              <h2 className="heading-section text-foreground mb-4">
+                Explore Tokyo With a Local Guide
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-6">
+                While the JR Pass gets you across Japan, the best Tokyo experiences happen on foot. Our private walking tours reveal the stories, flavors, and hidden corners that make Tokyo unforgettable.
+              </p>
+              <ul className="space-y-3 mb-8">
+                <li className="text-muted-foreground leading-relaxed">
+                  <Link to="/tours/tokyo-food-tour" className="text-accent hover:underline font-medium">Tokyo Food Tour</Link> — Tsukiji, Ginza & beyond
+                </li>
+                <li className="text-muted-foreground leading-relaxed">
+                  <Link to="/tours/nikko-day-trip" className="text-accent hover:underline font-medium">Nikko Day Trip</Link> — Shrines, nature & Edo history
+                </li>
+                <li className="text-muted-foreground leading-relaxed">
+                  <Link to="/tours/tsukiji-ginza" className="text-accent hover:underline font-medium">Tsukiji & Ginza Walk</Link> — Markets, culture & cuisine
+                </li>
+              </ul>
+            </div>
+
             {/* CTA */}
             <div className="bg-secondary/50 rounded-lg p-8 mt-12">
               <h2 className="text-2xl font-medium text-foreground mb-4">
@@ -234,13 +261,7 @@ const JapanRailPass = () => {
                 <div>
                   <h3 className="text-lg font-medium text-foreground mb-2">Where do I buy the Japan Rail Pass?</h3>
                   <p className="text-muted-foreground leading-relaxed">
-                    You can buy the JR Pass online through the official JR Pass website or authorized agents before arriving in Japan. You can also buy it at major JR stations in Japan (Tokyo, Osaka, Kyoto, airports), though it's slightly more convenient to arrange it before your trip. You'll need your passport for purchase and activation.
-                  </p>
-                </div>
-                <div>
-                  <h3 className="text-lg font-medium text-foreground mb-2">Can I buy the JR Pass in Japan?</h3>
-                  <p className="text-muted-foreground leading-relaxed">
-                    Yes. Since 2023, you can purchase the JR Pass at major JR stations and airports in Japan. The price is the same as buying online. You'll activate it at a JR ticket office by showing your passport and choosing your start date.
+                    Since October 2023, the nationwide JR Pass can only be purchased online through the official JR Pass website or authorized agents. After purchasing online, you pick it up at a designated JR ticket office counter by showing your passport and choosing your start date. Note that regional JR passes (JR East Pass, JR West Pass, etc.) can still be purchased at station counters.
                   </p>
                 </div>
                 <div>
@@ -252,7 +273,7 @@ const JapanRailPass = () => {
                 <div>
                   <h3 className="text-lg font-medium text-foreground mb-2">Does the JR Pass cover the Nozomi Shinkansen?</h3>
                   <p className="text-muted-foreground leading-relaxed">
-                    No. The JR Pass covers the Hikari and Kodama trains on the Tokaido/Sanyo Shinkansen, but not the Nozomi or Mizuho (the fastest services). In practice, the Hikari is only 5–10 minutes slower than the Nozomi on most routes, so this limitation is minor.
+                    Not by default. However, since October 2023, JR Pass holders can purchase a supplementary "Nozomi/Mizuho Ticket" to ride these fastest trains. The supplement costs approximately ¥4,960 for Tokyo–Kyoto. Without the supplement, use the Hikari, which is only about 5 minutes slower on the same route.
                   </p>
                 </div>
               </div>
@@ -261,7 +282,7 @@ const JapanRailPass = () => {
         </div>
       </section>
 
-      <RelatedTourCards tourIds={["custom","asakusa"]} />
+      <RelatedTourCards tourIds={["nikko-day-trip","tokyo-food-tour","tsukiji-ginza"]} showViewAll />
 
             <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
         "@context": "https://schema.org", "@type": "BlogPosting",
@@ -275,10 +296,9 @@ const JapanRailPass = () => {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
         "@context": "https://schema.org", "@type": "FAQPage",
         mainEntity: [
-          { "@type": "Question", name: "Where do I buy the Japan Rail Pass?", acceptedAnswer: { "@type": "Answer", text: "Online through the official JR Pass website or at major JR stations and airports in Japan. You need your passport." }},
-          { "@type": "Question", name: "Can I buy the JR Pass in Japan?", acceptedAnswer: { "@type": "Answer", text: "Yes, at major JR stations and airports since 2023. Same price as online." }},
+          { "@type": "Question", name: "Where do I buy the Japan Rail Pass?", acceptedAnswer: { "@type": "Answer", text: "Since October 2023, the nationwide JR Pass can only be purchased online through the official website or authorized agents. You pick it up at a JR ticket office with your passport." }},
           { "@type": "Question", name: "What's the difference between IC card and JR Pass?", acceptedAnswer: { "@type": "Answer", text: "IC cards are pay-per-ride cards for all transit. JR Pass is unlimited but only covers JR trains. Most travelers need both." }},
-          { "@type": "Question", name: "Does the JR Pass cover the Nozomi Shinkansen?", acceptedAnswer: { "@type": "Answer", text: "No. It covers Hikari and Kodama, which are only 5–10 minutes slower on most routes." }}
+          { "@type": "Question", name: "Does the JR Pass cover the Nozomi Shinkansen?", acceptedAnswer: { "@type": "Answer", text: "Not by default. Since October 2023, JR Pass holders can purchase a supplementary Nozomi/Mizuho Ticket (about ¥4,960 for Tokyo–Kyoto). Without the supplement, use the Hikari, which is only about 5 minutes slower." }}
         ]
       })}} />
     </Layout>

--- a/src/pages/blog/KamakuraDayTrip.tsx
+++ b/src/pages/blog/KamakuraDayTrip.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { RelatedTourCards } from "@/components/blog/RelatedTourCards";
+import { InlineCTA } from "@/components/blog/InlineCTA";
 
 const KamakuraDayTrip = () => {
   return (
@@ -88,6 +89,8 @@ const KamakuraDayTrip = () => {
                 <strong className="text-foreground">Enoden Railway (local):</strong> The charming local tram that runs from Kamakura Station to Enoshima along the coast. Not for getting TO Kamakura, but essential for getting around within the area. It passes through residential neighborhoods and runs right along the beach. A Kamakura day trip from Tokyo isn't complete without at least one Enoden ride.
               </li>
             </ul>
+
+            <InlineCTA message="Want a guided Kamakura day trip from Tokyo?" href="/tours/kamakura-day-trip" />
 
             <h2 className="heading-section text-foreground mt-12 mb-6">
               What to See: Great Buddha, Engaku-ji, the Hiking Trails

--- a/src/pages/blog/NikkoDayTrip.tsx
+++ b/src/pages/blog/NikkoDayTrip.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { RelatedTourCards } from "@/components/blog/RelatedTourCards";
+import { InlineCTA } from "@/components/blog/InlineCTA";
 
 const NikkoDayTrip = () => {
   return (
@@ -124,6 +125,8 @@ const NikkoDayTrip = () => {
             <p className="text-muted-foreground leading-relaxed mb-4">
               <strong className="text-foreground">Kegon Falls</strong> sits about thirty minutes by bus from central Nikko, up a dramatic series of switchback roads that climb to the shores of Lake Chuzenji at 1,269 meters above sea level. The waterfall drops ninety-seven meters in a single breathtaking plunge from the lake's outlet, and it is ranked among the three most famous waterfalls in Japan. There is an elevator carved into the rock (570 yen) that takes you down to an observation platform at the base, and I consider it essential. From the top viewing area you see a postcard; from the base you feel the spray on your face and hear the thunderous volume of water crashing into the pool below. In autumn, the cliffs surrounding the falls turn brilliant shades of orange and gold. In winter, the peripheral streams freeze into spectacular ice columns while the main cascade keeps flowing. In any season, Kegon Falls is one of those sights that photographs do not do justice. You need to stand there, feel the mist, and hear it.
             </p>
+
+            <InlineCTA message="Want a guided Nikko day trip with all logistics handled?" href="/tours/nikko-day-trip" />
 
             {/* Section 3: How Much Time */}
             <h2 className="heading-section text-foreground mt-12 mb-6">

--- a/src/pages/blog/ShibuyaHarajukuGuide.tsx
+++ b/src/pages/blog/ShibuyaHarajukuGuide.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { RelatedTourCards } from "@/components/blog/RelatedTourCards";
+import { InlineCTA } from "@/components/blog/InlineCTA";
 
 const ShibuyaHarajukuGuide = () => {
   return (
@@ -131,6 +132,8 @@ const ShibuyaHarajukuGuide = () => {
             <p className="text-muted-foreground leading-relaxed mb-4">
               Dogenzaka is the sloping street that leads up the hill from the crossing, and it has a reputation as Shibuya's love hotel district. That reputation is deserved (you'll see plenty of colorful facades with hourly rates), but Dogenzaka is also home to some of the best vintage and secondhand clothing shops in Tokyo. Stores like Ragtag, Flamingo, and dozens of smaller independent shops sell everything from designer labels at a fraction of retail to perfectly curated vintage Americana. If you're into fashion or thrifting, Dogenzaka is worth an afternoon of browsing. The love hotels, by the way, are a fascinating part of Japanese urban culture in their own right, and I'm happy to explain their history and social role on tour. It's more interesting than you might expect.
             </p>
+
+            <InlineCTA message="Want to explore Shibuya and Harajuku with a local guide?" href="/tours/shibuya-harajuku" />
 
             {/* Harajuku */}
             <h2 className="heading-section text-foreground mt-12 mb-6">

--- a/src/pages/blog/ShinjukuGuide.tsx
+++ b/src/pages/blog/ShinjukuGuide.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { RelatedTourCards } from "@/components/blog/RelatedTourCards";
+import { InlineCTA } from "@/components/blog/InlineCTA";
 
 const ShinjukuGuide = () => {
   return (
@@ -191,6 +192,8 @@ const ShinjukuGuide = () => {
                 Omoide Yokocho: smoke, yakitori, and cold beer under the tracks
               </figcaption>
             </figure>
+
+            <InlineCTA message="Want to discover Shinjuku's hidden side with a local?" href="/contact" />
 
             {/* Omoide Yokocho */}
             <h2 className="heading-section text-foreground mt-12 mb-6">

--- a/src/pages/blog/TempleEtiquette.tsx
+++ b/src/pages/blog/TempleEtiquette.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { RelatedTourCards } from "@/components/blog/RelatedTourCards";
+import { InlineCTA } from "@/components/blog/InlineCTA";
 
 const TempleEtiquette = () => {
   return (
@@ -205,6 +206,8 @@ const TempleEtiquette = () => {
             <p className="text-muted-foreground leading-relaxed mb-8">
               <strong className="text-foreground">Ema</strong> are small wooden plaques where you write a wish or prayer. Purchase one from the shrine office (usually ¥500-1,000), write your wish on the blank side (it's perfectly fine to write in English; the kami understand all languages), and hang it on the designated ema rack. You'll see hundreds of wishes hanging together, which in itself is a beautiful sight. Take a moment to read some. You'll find everything from exam prayers to health wishes to marriage hopes, giving you a touching window into what matters to people.
             </p>
+
+            <InlineCTA message="Want to learn temple etiquette from a local guide?" href="/contact" />
 
             {/* Temple Step-by-Step */}
             <h2 className="heading-section text-foreground mt-12 mb-6">

--- a/src/pages/blog/Tokyo3DayItinerary.tsx
+++ b/src/pages/blog/Tokyo3DayItinerary.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { RelatedTourCards } from "@/components/blog/RelatedTourCards";
+import { InlineCTA } from "@/components/blog/InlineCTA";
 
 const Tokyo3DayItinerary = () => {
   return (
@@ -175,6 +176,8 @@ const Tokyo3DayItinerary = () => {
                 Street food stalls in east Tokyo. Graze your way through grilled skewers, fresh seafood, and seasonal snacks
               </figcaption>
             </figure>
+
+            <InlineCTA message="Want a local guide to optimize your 3-day Tokyo itinerary?" href="/contact" />
 
             {/* Day 2 */}
             <h2 className="heading-section text-foreground mt-16 mb-6">

--- a/src/pages/blog/TokyoItinerary5Days.tsx
+++ b/src/pages/blog/TokyoItinerary5Days.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { RelatedTourCards } from "@/components/blog/RelatedTourCards";
+import { InlineCTA } from "@/components/blog/InlineCTA";
 
 const TokyoItinerary5Days = () => {
   return (
@@ -98,6 +99,8 @@ const TokyoItinerary5Days = () => {
               <p className="text-sm text-foreground font-medium mb-1">Guide's tip:</p>
               <p className="text-sm text-muted-foreground">Day 2 is about context. You're building an understanding of what old Tokyo looked like before the modernization you'll see on Days 3–5. Without this foundation, Shibuya and Shinjuku are just neon. With it, they become the contrast that makes Tokyo fascinating.</p>
             </div>
+
+            <InlineCTA message="Want a local guide to show you the real Tokyo?" href="/contact" />
 
             <h2 className="heading-section text-foreground mt-12 mb-6">
               Day 3: Modern Tokyo and What It Means

--- a/src/pages/blog/TsukijiMarketGuide.tsx
+++ b/src/pages/blog/TsukijiMarketGuide.tsx
@@ -3,13 +3,14 @@ import { ArrowLeft, Calendar, User } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
 import { SEO } from "@/components/SEO";
 import { RelatedTourCards } from "@/components/blog/RelatedTourCards";
+import { InlineCTA } from "@/components/blog/InlineCTA";
 
 const TsukijiMarketGuide = () => {
   return (
     <Layout>
       <SEO
-        title="Tsukiji Outer Market 2026: Still Open & What to Eat"
-        description="Yes, Tsukiji outer market is still open in 2026 with 400+ shops. A local guide shares the best food stalls, timing tips & what changed since 2018."
+        title="Tsukiji Outer Market Guide 2026: Yes, It's Still Open (Hours & Tips)"
+        description="Yes, Tsukiji Outer Market is still open in 2026 with 460+ shops. Most stalls open 5AM–2PM, closed Sundays & select Wednesdays. Complete visitor guide by a local guide."
         canonicalPath="/blog/tsukiji-market-guide"
       />
 
@@ -26,7 +27,7 @@ const TsukijiMarketGuide = () => {
             </Link>
             <p className="text-label text-accent mb-3">Tokyo Area Guides</p>
             <h1 className="heading-display text-foreground">
-              Tsukiji Market Guide: What's Still Worth Seeing in 2026
+              Tsukiji Outer Market Guide 2026: Yes, It's Still Open
             </h1>
             <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
               <span className="flex items-center gap-2">
@@ -58,6 +59,15 @@ const TsukijiMarketGuide = () => {
       <section className="py-16">
         <div className="container-section">
           <article className="max-w-3xl mx-auto prose-custom">
+            {/* Quick Answer Box — Featured Snippet target */}
+            <div className="bg-accent/10 border border-accent/30 rounded-lg p-6 mb-10">
+              <p className="text-foreground leading-relaxed">
+                <strong>Is Tsukiji Outer Market still open in 2026?</strong> Yes! Tsukiji Outer Market remains fully open with 460+ shops, restaurants, and street food stalls. Only the inner wholesale auction moved to Toyosu Fish Market in October 2018. The outer market operates daily from around 5:00 AM, with most shops closing by 2:00 PM. Closed on Sundays and select Wednesdays — check the{" "}
+                <a href="https://www.tsukiji.or.jp/english/calendar/" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">official market calendar</a>
+                {" "}before your visit.
+              </p>
+            </div>
+
             {/* Introduction */}
             <p className="text-lg text-muted-foreground leading-relaxed mb-4">
               "Isn't Tsukiji closed?" I hear this question at least once a week from visitors planning their Tokyo itinerary. And I understand the confusion. The headlines from 2018 were everywhere: Tsukiji Market closes, the tuna auctions move to Toyosu, an era ends. But here's what those headlines got wrong, or at least left out. Only the inner wholesale market moved. The outer market, the part that matters most to visitors, never closed. It's still here, still thriving, and still one of the best food experiences in Tokyo.
@@ -192,6 +202,8 @@ const TsukijiMarketGuide = () => {
               </figcaption>
             </figure>
 
+            <InlineCTA message="Want to explore Tsukiji with a guide who knows every stall?" href="/tours/tsukiji-ginza" />
+
             {/* Section 4: Getting There */}
             <h2 className="heading-section text-foreground mt-12 mb-6">
               How to Get There and When to Arrive
@@ -206,7 +218,7 @@ const TsukijiMarketGuide = () => {
               <strong className="text-foreground">Getting there:</strong> The easiest route is the <strong className="text-foreground">Tokyo Metro Hibiya Line</strong> to Tsukiji Station (Exit 1). You'll be at the market's edge in a two-minute walk. Alternatively, the Oedo Line stops at Tsukiji-shijo Station, which is slightly closer to the former inner market site. From most central Tokyo hotels, the journey takes 15 to 25 minutes by subway.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
-              <strong className="text-foreground">Best days to visit:</strong> Weekday mornings are ideal. Tuesday, Thursday, and Friday give you the best combination of full stock and manageable crowds. Saturdays are doable but significantly more crowded, especially after 9 AM. <strong className="text-foreground">Avoid Sundays and Wednesdays</strong>. Most stalls are closed on both days, and you'll be wandering through empty lanes wondering where all the food went. Always check the market's official calendar before your visit, as additional closure days occur around holidays. If you only have one morning in Tokyo for food, make it a Tuesday, Thursday, or Friday at Tsukiji.
+              <strong className="text-foreground">Best days to visit:</strong> Weekday mornings are ideal. Tuesday, Thursday, and Friday give you the best combination of full stock and manageable crowds. Saturdays are doable but significantly more crowded, especially after 9 AM. <strong className="text-foreground">Avoid Sundays and select Wednesdays</strong>. Most stalls are closed on Sundays and on certain Wednesdays that follow the Tokyo Central Wholesale Market calendar (not every Wednesday). Always check the <a href="https://www.tsukiji.or.jp/english/calendar/" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">market's official calendar</a> before your visit, as additional closure days occur around holidays. If you only have one morning in Tokyo for food, make it a Tuesday, Thursday, or Friday at Tsukiji.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-8">
               Plan to spend 90 minutes to two hours for a thorough visit. That gives you enough time to walk the full market, eat three or four things, browse the knife shops and pickle vendors, and leave satisfied rather than overwhelmed. If you're interested in pairing your market visit with ramen later in the day, my{" "}
@@ -273,7 +285,7 @@ const TsukijiMarketGuide = () => {
                 <div>
                   <h3 className="text-lg font-medium text-foreground mb-2">Is Tsukiji open on weekends?</h3>
                   <p className="text-muted-foreground leading-relaxed">
-                    Saturday mornings are open but very crowded with both tourists and local shoppers. Most stalls are closed on Sundays and Wednesdays. Weekday mornings (Tuesday, Thursday, and Friday) offer the best experience: full selection, fewer crowds, and a more relaxed atmosphere.
+                    Saturday mornings are open but very crowded with both tourists and local shoppers. Most stalls are closed on Sundays and on select Wednesdays (following the wholesale market calendar — not every Wednesday). Weekday mornings (Tuesday, Thursday, and Friday) offer the best experience: full selection, fewer crowds, and a more relaxed atmosphere. Check the official market calendar before your visit.
                   </p>
                 </div>
                 <div>
@@ -300,7 +312,7 @@ const TsukijiMarketGuide = () => {
 
             <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
         "@context": "https://schema.org", "@type": "BlogPosting",
-        headline: "Tsukiji Market Guide: What's Still Worth Seeing in 2026",
+        headline: "Tsukiji Outer Market Guide 2026: Yes, It's Still Open (Hours & Tips)",
         description: "The inner market closed in 2018. But the outer market is alive. A local guide explains what remains, what's worth eating, and how to visit right.",
         author: { "@type": "Person", name: "Manabu", jobTitle: "National Government Licensed Guide Interpreter", url: "https://tanuki-tabi-travel.com/about" },
         datePublished: "2026-03-07", dateModified: "2026-03-07",
@@ -313,7 +325,7 @@ const TsukijiMarketGuide = () => {
         mainEntity: [
           { "@type": "Question", name: "Is Tsukiji Market still open in 2026?", acceptedAnswer: { "@type": "Answer", text: "Yes. The inner wholesale market moved to Toyosu in 2018, but the outer market with over 400 shops, restaurants, and food stalls remains open and thriving." }},
           { "@type": "Question", name: "What time should I arrive at Tsukiji?", acceptedAnswer: { "@type": "Answer", text: "Aim for 8:00 AM. Stalls are fully stocked, grills are hot, and crowds are manageable. Most stalls close by 1-2 PM." }},
-          { "@type": "Question", name: "Is Tsukiji open on weekends?", acceptedAnswer: { "@type": "Answer", text: "Saturday mornings are open but crowded. Most stalls are closed on Sundays and Wednesdays. Weekday mornings (Tuesday, Thursday, Friday) are best." }},
+          { "@type": "Question", name: "Is Tsukiji open on weekends?", acceptedAnswer: { "@type": "Answer", text: "Saturday mornings are open but crowded. Most stalls are closed on Sundays and select Wednesdays. Weekday mornings (Tuesday, Thursday, Friday) are best. Check the official market calendar." }},
           { "@type": "Question", name: "Should I visit Tsukiji or Toyosu?", acceptedAnswer: { "@type": "Answer", text: "For most visitors, Tsukiji is the better choice for food variety and atmosphere. Toyosu is worth it only for the tuna auction, which requires winning a monthly lottery." }},
           { "@type": "Question", name: "How do I get to Tsukiji Market?", acceptedAnswer: { "@type": "Answer", text: "Take the Tokyo Metro Hibiya Line to Tsukiji Station (Exit 1). The outer market is a 2-minute walk. Journey from central Tokyo: 15-25 minutes." }}
         ]


### PR DESCRIPTION
## Summary
This PR adds FAQ sections to tour detail pages with structured schema markup, introduces a reusable InlineCTA component for blog articles, and updates blog content with improved SEO and internal linking.

## Key Changes

### Tour Detail Pages (TourDetail.tsx)
- Added `tourFAQs` data structure with Q&A pairs for 7 tour types (Tsukiji-Ginza, Nikko, Kamakura, Hakone, Asakusa, Shibuya-Harajuku, and custom tours)
- Implemented FAQ section rendering with card-based layout
- Added FAQ schema markup (FAQPage structured data) for improved SEO and rich snippets
- FAQs conditionally render only when data exists for a tour

### New Component (InlineCTA.tsx)
- Created reusable `InlineCTA` component for contextual call-to-action boxes within blog articles
- Accepts customizable message, link text, and href props
- Styled with accent color border and background for visual distinction
- Integrated into 9 blog articles for better conversion and internal linking

### Blog Content Updates
- **JapanRailPass.tsx**: Updated Nozomi/Mizuho coverage info (now purchasable with supplement since Oct 2023), clarified JR Pass purchase location (online only for nationwide pass), added internal links to tour pages, added "Explore Tokyo With a Local Guide" section with tour links
- **TsukijiMarketGuide.tsx**: Added featured snippet box with quick answer, updated title/description for better SEO, added InlineCTA, corrected closure day information with link to official calendar
- **IsItWorthHiringGuide.tsx**: Removed broken link to deleted "licensed-tour-guide-japan" article
- **Multiple blog articles**: Added InlineCTA components to AsakusaGuideNew, KamakuraDayTrip, NikkoDayTrip, ShibuyaHarajukuGuide, ShinjukuGuide, TempleEtiquette, Tokyo3DayItinerary, TokyoItinerary5Days

### Blog Index & Redirects
- Removed "licensed-tour-guide-japan" from blog index
- Added 301 redirect from `/blog/licensed-tour-guide-japan` to `/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` in netlify.toml

## Implementation Details
- FAQ data is keyed by tour ID for easy lookup and conditional rendering
- Schema markup uses standard FAQPage structure for Google rich results
- InlineCTA component provides consistent styling and messaging across blog articles
- All internal links use React Router's `Link` component for client-side navigation
- Blog updates maintain existing prose styling and improve SEO through better structure and internal linking

https://claude.ai/code/session_01AjqySvGpR5MXtQvXNsb2sh