### PR TITLE
Fix btn-accent text color for WCAG contrast compliance

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -169,7 +169,7 @@
   }
 
   .btn-accent {
-    @apply inline-flex items-center justify-center px-6 py-3 bg-[#C9A84C] text-white font-semibold rounded transition-colors duration-200 hover:bg-[#B8960C];
+    @apply inline-flex items-center justify-center px-6 py-3 bg-[#C9A84C] text-[#0D0D0D] font-semibold rounded transition-colors duration-200 hover:bg-[#E2C07A];
   }
 
   .btn-outline {


### PR DESCRIPTION
Change .btn-accent from text-white to text-[#0D0D0D] on gold background to meet WCAG AA contrast ratio. Also align hover color with hero CTA (hover:bg-[#E2C07A]).

https://claude.ai/code/session_01PrYFq96629SA7oSLN4tHTN