### PR TITLE
Refine trust signals typography and spacing

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -209,11 +209,11 @@ const Index = () => {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
             {trustSignals.map((signal) => (
               <div key={signal.title} className="text-center group">
-                <signal.icon className="w-7 h-7 text-accent mx-auto mb-4" strokeWidth={1.2} />
-                <h3 className="text-lg font-semibold text-foreground">
+                <signal.icon className="w-8 h-8 text-accent mx-auto mb-4" strokeWidth={1.2} />
+                <h3 className="text-base font-medium tracking-wide text-foreground">
                   {signal.title}
                 </h3>
-                <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+                <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
                   {signal.description}
                 </p>
               </div>

--- a/src/pages/es/EsIndex.tsx
+++ b/src/pages/es/EsIndex.tsx
@@ -210,11 +210,11 @@ const EsIndex = () => {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
             {trustSignals.map((signal) => (
               <div key={signal.title} className="text-center group">
-                <signal.icon className="w-7 h-7 text-accent mx-auto mb-4" strokeWidth={1.2} />
-                <h3 className="text-lg font-medium text-foreground">
+                <signal.icon className="w-8 h-8 text-accent mx-auto mb-4" strokeWidth={1.2} />
+                <h3 className="text-base font-medium tracking-wide text-foreground">
                   {signal.title}
                 </h3>
-                <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+                <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
                   {signal.description}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
Updated the trust signals section styling in both English and Spanish index pages to improve visual hierarchy and readability through refined typography and spacing adjustments.

## Key Changes
- **Icon sizing**: Increased icon dimensions from `w-7 h-7` to `w-8 h-8` for better prominence
- **Title typography**: 
  - Reduced font size from `text-lg` to `text-base`
  - Changed font weight from `font-semibold` to `font-medium` (in Index.tsx)
  - Added `tracking-wide` letter spacing for improved readability
- **Description spacing**: Increased top margin from `mt-2` to `mt-3` for better visual separation

## Implementation Details
These changes were applied consistently across both `src/pages/Index.tsx` and `src/pages/es/EsIndex.tsx` to maintain parity between language versions. The adjustments create a more balanced visual hierarchy while maintaining the overall grid layout structure.

https://claude.ai/code/session_01AgkvAV57FaJPFhzFUrUfZA