### PR TITLE
brief: 2026-05-24 — Is Kamakura Worth Visiting? A Guide's Honest Answer 2026

### DIFF
--- a/seo-pipeline/briefs/2026-05-24-is-kamakura-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-05-24-is-kamakura-worth-visiting.md
@@ -1,0 +1,114 @@
+---
+date: 2026-05-24
+slug: is-kamakura-worth-visiting
+slug_es: vale-la-pena-ir-a-kamakura
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: medium
+---
+
+# Is Kamakura Worth Visiting? A Guide's Honest Answer 2026
+
+**Spanish Title**: ¿Vale la Pena Ir a Kamakura? La Opinión Real de un Guía 2026
+
+## Why this article (data-driven rationale)
+
+- **GSC signal**: 「is kamakura worth visiting」直近28日（〜2026-05-22）で 表示 **27**、クリック **1**、順位 **3.11**（→ 専用記事なしでも3位圏に浮上。記事をターゲット化すれば1-2位狙える）
+- **クラスター実績**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` は同期間で 表示 **3,292**、クリック **37**、CTR **1.12%**、順位 **6.23**（サイト内インプレッション4位）。GA4では有機検索セッション **47**、平均セッション時間 **2,982秒（≒50分）**— サイト全体で最高のエンゲージメントを誇るKamakuraクラスターの入口記事が存在しない
+- **既存記事ギャップ**: `kamakura-day-trip-from-tokyo`（「どうやって行くか」）と `kamakura-day-trip-guide-vs-solo`（「ガイドが必要か」）は下流の判断を扱うが、**最上流の「そもそも行く価値があるか」**をターゲットした記事がない。同パターンの `is-it-worth-hiring-a-tour-guide-in-tokyo` はサイト内CTR **0.72%**（全記事上位）で有効性が実証済み
+- **想定CV影響**: **high** — 旅行前の「行くべきか」判断フェーズ。YESなら `kamakura-day-trip-guide-vs-solo` → ツアー問い合わせへの自然な誘導が成立する
+
+## Target keyword cluster
+
+- **Primary**: "is kamakura worth visiting"
+- **Secondary**: "kamakura day trip worth it", "kamakura one day trip", "what to see in kamakura one day", "is kamakura worth a day trip"
+- **Search intent**: commercial / informational — 旅程計画中の「行くべきか」判断フェーズ
+
+## Differentiation slant (Manabuならでは)
+
+- **[Manabuさんの実体験エピソード挿入]**: Kamakuraツアーで「来るか迷っていた」クライアントが、ある瞬間（具体的な場所・状況・言葉）に「来てよかった」と確信した1エピソードを1〜2段落で。読者が追体験できる具体性が必要（「晴天の大仏で...」のような書き出し）
+- **「向かない人には正直に言う」スタンス**: 政府公認ガイドとして500回超のツアー経験から「Kamakuraが合わない旅行者の特徴」を率直に伝える。混雑ピーク（GW・紅葉期）の失望例、「寺社建築に関心ない層への正直な代替案提示」など。他の記事が"全員にオススメ"と書く中、この誠実さが差別化になる
+- **「ガイドしか使わない動線とタイミング」**: 一般観光客が並ぶ場所を午前8時前に回るルート、または観光ルート外の裏径（北鎌倉エリア等）— Manabuが実際のツアーで使うものを1〜2点具体的に紹介
+
+## Meta tags (SEO)
+
+- **Title (EN)** (57字): Is Kamakura Worth Visiting? A Guide's Honest Answer 2026
+- **Meta description (EN)** (120字): Guide Manabu has taken hundreds of visitors to Kamakura. Here's his honest take on who'll love it — and when to skip it.
+- **Title (ES)** (57字): ¿Vale la Pena Ir a Kamakura? Opinión Real de un Guía 2026
+- **Meta description (ES)** (155字): El guía Manabu ha llevado a cientos de viajeros a Kamakura. Su opinión sincera sobre lo que vale la pena, para quién es ideal y cuándo no merece la visita.
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · What Kamakura Actually Is** — 「Kyotoの小型版」というイメージの修正。元鎌倉幕府の都、現在は1時間のデイトリップ圏、大仏・寺社・ハイキング・海岸の組み合わせを率直に紹介。期待値の設定
+2. **Section 02 · What Genuinely Impressed My Clients** — Manabuが100回以上案内してきた中で「来てよかった」と言われた瞬間のトップ3。高徳院（鎌倉大仏）の圧倒的な存在感、長谷寺からの相模湾の眺望、北鎌倉の円覚寺・東慶寺の静けさ。[Manabuエピソード挿入箇所]
+3. **Section 03 · Who Kamakura Is Really For** — 具体的ペルソナ別の「行くべき/スキップすべき」チェックリスト。歴史・仏教文化好き→GO、写真家→GO（早朝推奨）、アートファン→GO（鎌倉彫・近代美術館）、リピーター→GO、「東京の都市観光だけでいい」層→SKIP、「風景より体験重視」→Hakone検討を
+4. **Section 04 · When Kamakura Isn't Worth It** — 率直な評価。GW・紅葉期（11月）のインスタ映えスポット渋滞問題、雨天の泥濘ハイキング、「お土産通りを歩くだけ」でがっかりするパターン、「Hakoneを選ぶべき人」との分岐基準
+5. **Section 05 · How to Make the Most of One Day** — Manabuが実際のツアーで使うルート骨格（時間帯・移動手段・skip推奨スポット含む）。江ノ電の使い方、混雑回避の鍵となる北鎌倉スタート戦略
+6. **Section 06 · FAQ** — 「鎌倉vsハコネはどちら？」「1日で足りる？」「ガイドなしで大丈夫？」「一番空いている時期は？」「子連れでも楽しめる？」
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 高徳院（鎌倉大仏）入場料と営業時間（¥300 + 胎内拝観 ¥50 — 変更確認要）
+- [ ] 長谷寺入山料と開門時間（季節変動があるため公式サイトで確認）
+- [ ] 江ノ電「のりおりくん」1日乗車券の現在価格（¥800 — 変更確認要）
+- [ ] 東京駅・新宿→鎌倉の最短ルートと現在の運賃・所要時間（JR横須賀線、湘南新宿ライン）
+- [ ] 2026年の主要混雑ピーク情報（GW渋滞状況、紅葉シーズンの現状）
+
+## Internal link plan
+
+- [Kamakura Day Trip from Tokyo](/blog/kamakura-day-trip-from-tokyo) — 「行く」と決めた読者の次のステップ：具体的な計画立案へ
+- [Kamakura: With a Guide or Solo?](/blog/kamakura-day-trip-guide-vs-solo) — 行くことが決まったら「ガイドが必要か」の判断へ
+- [Kamakura vs Hakone vs Nikko](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — どのデイトリップにするか迷っている読者の比較判断へ
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — プライベートガイドの価値に興味を持った読者へ
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["kamakura-day-trip"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: 実際のツアー写真（高徳院の大仏、長谷寺の境内・相模湾、北鎌倉の参道）がある場合は `/public/images/blog/` 内から探す
+- **不足分**: 鎌倉大仏の正面・全体像（Wikimedia Commons 利用可）、長谷寺の紫陽花（6月シーズナル）、鶴岡八幡宮の参道と若宮大路
+
+## Risk notes
+
+- **AI Overview ゼロクリック化リスク（MEDIUM）**: 「is kamakura worth visiting」はシンプルな情報クエリに見えるが、「あなたのタイプ別」ペルソナ判断フレームと「正直な"向かない人"評価」を前面に出すことでAI Overviewが代替しにくい内容にする。体験ベースの判断 = AI が直接答えにくい領域
+- **カニバリリスク（LOW）**: 既存の `kamakura-day-trip-from-tokyo`（HOW）と `kamakura-day-trip-guide-vs-solo`（WITH GUIDE OR NOT）は下流の判断を扱う。「行く価値があるか（WHY GO）」は未カバー。重複度 70% 未満と判断
+- **競合難易度（MEDIUM）**: 想定上位は Lonely Planet、Japan-guide.com、Tokyo Cheapo。いずれも「オススメ理由一覧」形式。「正直に向かない人に伝える＋ペルソナ別判断＋ガイドの一次情報」で差別化可能
+- **ファクト変動リスク**: 入場料・営業時間は年次変動あり。記事に「Last updated: May 2026」を表示し、Required facts を執筆前に必ず確認すること
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsKamakuraWorthVisiting.tsx` を作成（slug: `is-kamakura-worth-visiting`）
+2. `src/pages/es/blog/EsValelapenaIraKamakura.tsx` を作成（slug_es: `vale-la-pena-ir-a-kamakura`）
+3. `src/AppRoutes.tsx` に import + Route 追加
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加（末尾スラッシュなし）
+6. `tsc` で型チェック
+7. feature ブランチ作成 + commit
+
+---
+
+## ES brief supplement
+
+スペイン語版は同じ構成・同じslantで作成。以下の調整を適用：
+
+- section-eyebrow ラベルはスペイン語（"Sección 01 · Qué es realmente Kamakura" 等）
+- FAQの見出しは「Preguntas Frecuentes」（faq-block ラップ必須）
+- 「When Kamakura Isn't Worth It」セクションのスペイン語見出し案: "Cuándo Kamakura No Vale la Pena"
+- ES CTAリンク: `/es/tours/kamakura-day-trip`（存在確認済）
+- 内部リンク先: `/es/blog/kamakura-desde-tokio`、`/es/blog/comparativa-excursiones`
+
+---
+
+> *Fetch note: 2026-05-24 real-time fetch failed (GOOGLE_APPLICATION_CREDENTIALS_JSON not set). Analysis based on 2026-05-22 GSC+GA4 data (28-day window: 2026-04-24–2026-05-22).*

--- a/seo-pipeline/data/daily/2026-05-24.json
+++ b/seo-pipeline/data/daily/2026-05-24.json
@@ -1,0 +1,123 @@
+{
+  "generated_at": "2026-05-24",
+  "window_days": 28,
+  "fetch_note": "GOOGLE_APPLICATION_CREDENTIALS_JSON not set in this execution environment. Analysis uses most recent available data (2026-05-22) as fallback.",
+  "gsc": {
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "clicks": 275,
+      "impressions": 101626,
+      "page_count": 154,
+      "query_count": 2556
+    },
+    "top_queries_by_impression": [
+      { "query": "kamakura", "clicks": 2, "impressions": 403, "ctr": 0.4963, "position": 4.37 },
+      { "query": "tsukiji outer market opening hours 2026", "clicks": 1, "impressions": 505, "ctr": 0.198, "position": 3.12 },
+      { "query": "tsukiji fish market opening hours", "clicks": 2, "impressions": 264, "ctr": 0.7576, "position": 11.36 },
+      { "query": "tsukiji market opening hours", "clicks": 1, "impressions": 256, "ctr": 0.3906, "position": 9.72 },
+      { "query": "japan private tour guide cost", "clicks": 1, "impressions": 107, "ctr": 0.9346, "position": 9.37 },
+      { "query": "kamakura vs hakone", "clicks": 2, "impressions": 86, "ctr": 2.3256, "position": 6.14 },
+      { "query": "hakone or kamakura", "clicks": 1, "impressions": 74, "ctr": 1.3514, "position": 6.95 },
+      { "query": "tsukiji outer market", "clicks": 1, "impressions": 55, "ctr": 1.8182, "position": 16.85 },
+      { "query": "hakone vs nikko", "clicks": 1, "impressions": 48, "ctr": 2.0833, "position": 8.92 },
+      { "query": "hakone or nikko", "clicks": 1, "impressions": 45, "ctr": 2.2222, "position": 8.56 },
+      { "query": "is tsukiji market open on sunday", "clicks": 1, "impressions": 45, "ctr": 2.2222, "position": 9.42 },
+      { "query": "japan rail pass 2026 price", "clicks": 1, "impressions": 42, "ctr": 2.381, "position": 4.86 },
+      { "query": "is kamakura worth visiting", "clicks": 1, "impressions": 27, "ctr": 3.7037, "position": 3.11 },
+      { "query": "tsukiji hours", "clicks": 1, "impressions": 23, "ctr": 4.3478, "position": 8.39 },
+      { "query": "jr pass price increase", "clicks": 1, "impressions": 20, "ctr": 5.0, "position": 11.35 }
+    ],
+    "top_pages_by_impression": [
+      { "page": "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it", "clicks": 15, "impressions": 38565, "ctr": 0.0389, "position": 8.18 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide", "clicks": 92, "impressions": 26845, "ctr": 0.3427, "position": 6.52 },
+      { "page": "https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette", "clicks": 1, "impressions": 4498, "ctr": 0.0222, "position": 10.82 },
+      { "page": "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip", "clicks": 37, "impressions": 3292, "ctr": 1.1239, "position": 6.23 },
+      { "page": "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio", "clicks": 9, "impressions": 2699, "ctr": 0.3335, "position": 8.13 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost", "clicks": 11, "impressions": 2564, "ctr": 0.429, "position": 7.38 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu", "clicks": 10, "impressions": 2197, "ctr": 0.4552, "position": 8.1 },
+      { "page": "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide", "clicks": 9, "impressions": 1698, "ctr": 0.53, "position": 7.23 },
+      { "page": "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "clicks": 10, "impressions": 1414, "ctr": 0.7072, "position": 9.73 },
+      { "page": "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple", "clicks": 5, "impressions": 1319, "ctr": 0.3791, "position": 7.14 },
+      { "page": "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route", "clicks": 6, "impressions": 813, "ctr": 0.738, "position": 6.02 },
+      { "page": "https://tanuki-tabi-travel.com/blog/yokohama-day-trip-from-tokyo", "clicks": 4, "impressions": 682, "ctr": 0.5865, "position": 7.82 },
+      { "page": "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo", "clicks": 0, "impressions": 667, "ctr": 0, "position": 23.8 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tokyo-3-day-itinerary", "clicks": 1, "impressions": 664, "ctr": 0.1506, "position": 9.21 },
+      { "page": "https://tanuki-tabi-travel.com/blog/old-tokyo-shitamachi", "clicks": 2, "impressions": 624, "ctr": 0.3205, "position": 8.06 },
+      { "page": "https://tanuki-tabi-travel.com/blog/shinjuku-guide", "clicks": 0, "impressions": 482, "ctr": 0, "position": 13.33 },
+      { "page": "https://tanuki-tabi-travel.com/blog/mount-fuji-from-tokyo", "clicks": 0, "impressions": 441, "ctr": 0, "position": 10.47 },
+      { "page": "https://tanuki-tabi-travel.com/blog/hakone-day-trip-guide-vs-solo", "clicks": 9, "impressions": 404, "ctr": 2.2277, "position": 21.2 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tokyo-hidden-gems", "clicks": 3, "impressions": 286, "ctr": 1.049, "position": 6.79 }
+    ],
+    "new_queries_last7": [
+      { "query": "is hakone worth visiting", "clicks": 0, "impressions": 6, "ctr": 0, "position": 40.83 },
+      { "query": "nonbei yokocho walking time from shibuya station", "clicks": 0, "impressions": 5, "ctr": 0, "position": 10.0 },
+      { "query": "best places to see mount fuji from tokyo 2026", "clicks": 0, "impressions": 4, "ctr": 0, "position": 5.75 },
+      { "query": "japan rail pass worth it tokyo kyoto osaka 2026", "clicks": 0, "impressions": 4, "ctr": 0, "position": 8.5 },
+      { "query": "1 day in hakone", "clicks": 0, "impressions": 3, "ctr": 0, "position": 46.0 },
+      { "query": "early morning breakfast tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 1.0 },
+      { "query": "hire a guide in tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 23.0 },
+      { "query": "japan rail pass worth it 2026 current prices", "clicks": 0, "impressions": 2, "ctr": 0, "position": 6.0 },
+      { "query": "japan rail pass 14 day ordinary price 2026 official", "clicks": 0, "impressions": 14, "ctr": 0, "position": 7.36 }
+    ],
+    "zero_click_opportunities": [
+      { "query": "jr pass price increase 2026", "clicks": 0, "impressions": 1121, "ctr": 0, "position": 5.45 },
+      { "query": "japan rail pass prices 2026 official", "clicks": 0, "impressions": 558, "ctr": 0, "position": 7.68 },
+      { "query": "japan rail pass current prices 2026", "clicks": 0, "impressions": 531, "ctr": 0, "position": 9.71 },
+      { "query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92 },
+      { "query": "japan rail pass price 2026 official", "clicks": 0, "impressions": 262, "ctr": 0, "position": 8.59 },
+      { "query": "japan rail pass official price 7 day ordinary 2026", "clicks": 0, "impressions": 255, "ctr": 0, "position": 9.73 },
+      { "query": "japan rail pass official prices 2026", "clicks": 0, "impressions": 254, "ctr": 0, "position": 8.63 },
+      { "query": "tsukiji outer market official hours 2026", "clicks": 0, "impressions": 252, "ctr": 0, "position": 3.4 }
+    ],
+    "near_page_one_pushup": [
+      { "query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92 }
+    ]
+  },
+  "ga4": {
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "sessions": 749.0,
+      "totalUsers": 623.0,
+      "screenPageViews": 938.0,
+      "engagementRate": 0.3925,
+      "averageSessionDuration": 306.08
+    },
+    "sources": [
+      { "sessionSource": "google", "sessionMedium": "organic", "sessions": 372.0, "engagementRate": 0.5134 },
+      { "sessionSource": "(direct)", "sessionMedium": "(none)", "sessions": 239.0, "engagementRate": 0.205 },
+      { "sessionSource": "chatgpt.com", "sessionMedium": "(not set)", "sessions": 46.0, "engagementRate": 0.2609 },
+      { "sessionSource": "bing", "sessionMedium": "organic", "sessions": 25.0, "engagementRate": 0.6 }
+    ],
+    "events": [
+      { "eventName": "page_view", "eventCount": 938.0, "totalUsers": 623.0 },
+      { "eventName": "session_start", "eventCount": 752.0, "totalUsers": 623.0 },
+      { "eventName": "form_submit", "eventCount": 8.0, "totalUsers": 8.0 },
+      { "eventName": "book_now_click", "eventCount": 20.0, "totalUsers": 16.0 },
+      { "eventName": "contact_page_view", "eventCount": 32.0, "totalUsers": 27.0 },
+      { "eventName": "tour_page_view", "eventCount": 101.0, "totalUsers": 52.0 }
+    ],
+    "organic_landing_pages": [
+      { "landingPagePlusQueryString": "/blog/tsukiji-market-guide", "sessions": 135.0, "engagementRate": 0.5333, "averageSessionDuration": 245.95 },
+      { "landingPagePlusQueryString": "/blog/kamakura-vs-hakone-vs-nikko-day-trip", "sessions": 47.0, "engagementRate": 0.6383, "averageSessionDuration": 2982.62 },
+      { "landingPagePlusQueryString": "/blog/japan-rail-pass-worth-it", "sessions": 17.0, "engagementRate": 0.4118, "averageSessionDuration": 166.83 },
+      { "landingPagePlusQueryString": "/es/blog/comparativa-excursiones", "sessions": 17.0, "engagementRate": 0.5882, "averageSessionDuration": 274.91 },
+      { "landingPagePlusQueryString": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "sessions": 14.0, "engagementRate": 0.4286, "averageSessionDuration": 124.77 },
+      { "landingPagePlusQueryString": "/blog/tokyo-private-tour-guide-cost", "sessions": 12.0, "engagementRate": 0.8333, "averageSessionDuration": 311.57 },
+      { "landingPagePlusQueryString": "/blog/yanaka-tokyo-walking-route", "sessions": 7.0, "engagementRate": 0.7143, "averageSessionDuration": 757.88 },
+      { "landingPagePlusQueryString": "/blog/hakone-day-trip-guide-vs-solo", "sessions": 8.0, "engagementRate": 0.375, "averageSessionDuration": 166.43 },
+      { "landingPagePlusQueryString": "/blog/tsukiji-to-ginza-food-walk", "sessions": 2.0, "engagementRate": 1.0, "averageSessionDuration": 806.06 }
+    ],
+    "countries": [
+      { "country": "United States", "sessions": 214.0, "engagementRate": 0.3411 },
+      { "country": "Japan", "sessions": 162.0, "engagementRate": 0.4321 },
+      { "country": "Singapore", "sessions": 72.0, "engagementRate": 0.2778 },
+      { "country": "Spain", "sessions": 59.0, "engagementRate": 0.6102 }
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Kamakura Worth Visiting? A Guide's Honest Answer 2026
- **slug**: `is-kamakura-worth-visiting` (EN), `vale-la-pena-ir-a-kamakura` (ES)
- **category**: Decision Helpers
- **priority**: high

## データ根拠（抜粋）

| 指標 | 値 |
|------|-----|
| GSC「is kamakura worth visiting」表示回数（28日） | 27 |
| 同クエリ 平均順位 | 3.11（専用記事なしでも3位圏） |
| クラスター記事インプレッション（kamakura-vs-hakone-vs-nikko） | 3,292 |
| クラスター記事 GA4 平均セッション時間 | **2,982秒（≒50分）** — サイト最高 |
| 同パターン記事（is-it-worth-hiring）のCTR | 0.72%（全記事上位） |

## ガードレールチェック結果

- ✅ カニバリリスク **LOW**: 既存Kamakura記事は「HOW（行き方）」と「WITH GUIDE OR NOT」。「WHY GO（行く価値）」は未カバー
- ✅ avoid キーワード対象外
- ⚠️ AI Overview リスク **MEDIUM**: 「ペルソナ別判断 + 正直な向かない人評価」slantで軽減
- ✅ Manabuエピソードプレースホルダー含む

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → `/build-article` コマンドで記事化へ
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit

採用時の確認：
- [ ] Manabu独自エピソード（2箇所のプレースホルダー）に実体験を追記
- [ ] Required facts（入場料・営業時間・運賃）を執筆前にweb検索で検証
- [ ] H2 outlineの流れが論理的か確認

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-05-24-is-kamakura-worth-visiting.md](seo-pipeline/briefs/2026-05-24-is-kamakura-worth-visiting.md)

> ⚠️ **Fetch note**: 2026-05-24 リアルタイムフェッチは GOOGLE_APPLICATION_CREDENTIALS_JSON 未設定のため失敗。分析は 2026-05-22 GSC+GA4 データ（28日ウィンドウ）をフォールバック使用。Routine 本番環境ではシークレット設定済みのため通常動作します。

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aset3KAiK6JzrYdj2R1bKZ)_