### PR TITLE
brief: 2026-05-25 — Is Kamakura Worth Visiting? A Private Guide's Honest Take (2026)

### DIFF
--- a/seo-pipeline/briefs/2026-05-25-is-kamakura-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-05-25-is-kamakura-worth-visiting.md
@@ -1,0 +1,136 @@
+---
+date: 2026-05-25
+slug: is-kamakura-worth-visiting
+slug_es: vale-la-pena-visitar-kamakura
+status: pending  # pending | approved | rejected | needs-changes
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: medium
+---
+
+# Is Kamakura Worth Visiting? A Private Guide's Honest Take (2026)
+
+**Spanish Title**: ¿Vale la Pena Visitar Kamakura? La Opinión Honesta de un Guía Privado (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (主キー)**: 「is kamakura worth visiting」直近28日で 表示 **27**、クリック **1**、順位 **3.11**（すでにページ1圏内—専用記事で 1-3 位にロックする好機）
+- **GSC signal (クラスター全体)**: 「kamakura」関連クエリ群で 直近28日 表示 **3,292**、クリック **37**、CTR **1.12%**、順位 **6.23**（`/blog/kamakura-vs-hakone-vs-nikko-day-trip`）
+- **GA4 最高エンゲージメント**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` がオーガニックLPで **47 セッション・エンゲージメント率 64%・平均滞在 2,983 秒（≒ 50 分）**—サイト全体の最高値。Kamakura クラスターへの読者需要は実証済み。
+- **既存記事ギャップ**:
+  - `kamakura-day-trip-from-tokyo` → アクセス・手順（How）
+  - `kamakura-day-trip-guide-vs-solo` → ガイドか一人旅か（Who goes with）
+  - `kamakura-vs-hakone-vs-nikko-day-trip` → どの行き先を選ぶか（Which destination）
+  - **「そもそも行く価値があるか」（Should I go）= 意思決定最上流が空白**
+- **成功パターンの踏襲**: `/blog/is-hakone-worth-visiting` が同フォーマットで運用済み。Kamakura 版が未存在。
+- **想定CV影響**: **high** — 「worth visiting」クエリは旅程最終確定前の意思決定段階。この段階でManabuの声が届けばそのままツアー問合せへ誘導できる（`form_submit` 直結）
+- **競合状況**: 上位は Japan Guide、Time Out Tokyo、TripAdvisor。ただし DR80+ でも「ガイドの体験談・本音評価」角度は空白。ニッチ slant で差別化可能。
+
+## Target keyword cluster
+
+- **Primary**: "is kamakura worth visiting"
+- **Secondary**: "kamakura day trip worth it", "kamakura worth visiting 2026", "is kamakura worth it", "what is kamakura known for", "kamakura highlights"
+- **Search intent**: commercial investigation（「行くべきか判断したい」段階。情報収集ではなく意思決定）
+
+## Differentiation slant (Manabuならでは)
+
+> [ここにManabuさんの実体験エピソードを挿入]
+
+**具体的な差別化案を3つ提案（プレースホルダーを置き換えてください）:**
+
+1. **「混雑前の鎌倉」体験談** — 例: 「60代のご夫婦を案内した時、朝8時に高徳院に着いたら大仏を貸し切りに近い状態で見られた。9時を過ぎると団体バスが5台来た」— 混雑タイミングの実データをガイドとして持っている点が他記事にない武器。
+
+2. **「Kamakura は何度目の日本か」判断軸** — 例: 「初来日の方には大仏・小町通りだけでも十分感動してもらえる。2回目以降の方には建長寺や衣張山ハイキングルートを勧めることが多い」— リピーター vs 初心者で推薦が異なる、という実ガイド目線の判断軸は AI では出せない。
+
+3. **「行かなくていい人への正直な意見」** — 例: 「自然・温泉メインで考えているなら箱根の方が満足度が高い。歴史・寺社仏閣に関心がない方には鎌倉より上野の方がコンパクトで効率的、というアドバイスもする」— 正直に「合わない人もいる」と言えるガイドだけの信頼性。
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Kamakura Worth Visiting? A Private Guide's Honest Take 2026` — 59 chars ✓
+- **Meta description (EN)** (155字以内): `Is Kamakura worth a day trip from Tokyo? Licensed guide Manabu gives an honest verdict—what's spectacular, what's overhyped, and who should skip it.` — 149 chars ✓
+- **Title (ES)** (60字以内): `¿Vale la Pena Visitar Kamakura? Opinión de Guía Privado 2026` — 60 chars ✓
+- **Meta description (ES)** (155字以内): `¿Merece la pena Kamakura desde Tokio? Guía privado con licencia oficial da su veredicto honesto: lo mejor, lo sobrevalorado y a quién no le conviene.` — 150 chars ✓
+
+## H2 outline (6 sections + FAQ)
+
+1. **Section 01 · Quick Verdict** — Quick Decision ボックス（「行く価値ある？→ はい、ただし…」の一行回答）。対象別: 初来日、リピーター、子連れ、シニア。50文字以内で結論。
+
+2. **Section 02 · What Makes Kamakura Genuinely Worth It** — 大仏（高徳院）、鶴岡八幡宮、衣張山ハイキング、小町通りの見どころを *体験ベースで* 描写。「写真映え」より「なぜ感動するか」の説明を優先。
+
+3. **Section 03 · What's Overhyped (and How to Avoid It)** — 正直な本音コーナー。混雑・行列・「思ったより小さい」大仏問題。代替案（早朝訪問、穴場スポット）を提示。
+
+4. **Section 04 · Who Should Go — and Who Might Prefer Elsewhere** — 「行くべき人・行かなくていい人」を明確化。自然派→箱根、現代カルチャー派→渋谷/原宿、歴史重視→鎌倉に向いている、という判断フレーム。
+
+5. **Section 05 · Half Day vs. Full Day — What Actually Fits** — 実際のモデルコース。4時間コース（大仏+小町通りのみ）vs 7時間コース（ハイキング含む）の違いを具体的に。プライベートツアーとの比較。
+
+6. **Section 06 · FAQ** — 4-5問
+   - Is Kamakura worth visiting without a guide?
+   - How many days do you need in Kamakura?
+   - Is Kamakura better than Kyoto for a day trip?
+   - When is the best time to visit Kamakura?
+   - Can you do Kamakura and Hakone in one day?
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 高徳院（鎌倉大仏）の入場料・営業時間・定休日（公式サイト確認）
+- [ ] 鶴岡八幡宮の参拝時間・入場料（無料か有料か）
+- [ ] 東京→鎌倉のアクセス（JR横須賀線、北鎌倉経由のオプション、所要時間・運賃）
+- [ ] Kamakura Hiking Trail（天園ハイキングコース/衣張山）の現況・所要時間・閉鎖情報
+- [ ] 小町通りの主要営業時間帯（朝は何時から？）
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura Day Trip from Tokyo Guide](/blog/kamakura-day-trip-from-tokyo) — アクセス・行き方詳細へ誘導（Section 05 内）
+- [Kamakura: Private Guide vs. Going Solo](/blog/kamakura-day-trip-guide-vs-solo) — 「ガイドをつけるべきか」の判断をサポート（Section 05 末尾 or CTA）
+- [Kamakura vs. Hakone vs. Nikko Day Trip](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — Section 04「他のオプションと比較」から誘導
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — Section 04「自然派には箱根が向いている」への関連リンク
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["kamakura-day-trip", "tokyo-private-tour"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/kamakura-*` があればそちらを優先
+- **不足分（撮影 or Wikimedia）**:
+  - 高徳院・鎌倉大仏（早朝、人が少ない構図）
+  - 小町通り（賑やかな雰囲気を写す）
+  - 天園ハイキングコースからの眺望
+  - 鶴岡八幡宮・本宮の石段
+
+## Risk notes
+
+- **AI Overview リスク（medium）**: 「is kamakura worth visiting」は意思決定クエリのため純粋情報型より AI Overview 化しにくい。ただし「おすすめスポット」「入場料」等の情報型セクションは AI に吸い取られるリスクあり → 体験・判断ベースの記述で対策
+- **カニバリゼーションリスク（low）**: `kamakura-day-trip-from-tokyo`（アクセス情報）、`kamakura-day-trip-guide-vs-solo`（ガイド判断）とは intent が異なり重複度は低い。ただし両記事に内部リンクを張ることでクラスター強化に活用
+- **競合リスク（medium）**: Japan Guide・TripAdvisor 等 DR80+ が上位だが「licensed guide の本音評価」角度は空白。Manabu の一次体験情報が差別化の核心
+- **ファクト変動リスク**: 入場料・営業時間は年次変動。「Last updated: May 2026」表示と Required facts チェックリストで対策
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsKamakuraWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValeLaPenaVisitarKamakura.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（EN: `/blog/is-kamakura-worth-visiting`、ES: `/es/blog/vale-la-pena-visitar-kamakura`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. `tsc` で型チェック
+7. feature ブランチ作成: `feature/is-kamakura-worth-visiting` + commit
+
+---
+
+## 選定理由サマリー（優先度スコア）
+
+| 評価軸 | 重み | 評価 | 根拠 |
+|--------|------|------|------|
+| form_submit への影響 | 40% | ◎ | 「worth visiting?」= 旅程決定直前の意思決定クエリ → ツアー問合せへの最短ルート |
+| 検索ボリューム × 競合難易度 | 25% | ○ | position 3.11 で既出し済み、クラスター全体 3,292 impressions。競合は DR80+ だが体験角度で差別化余地あり |
+| 既存記事との内部リンク網強化 | 20% | ◎ | Kamakura 3記事への双方向リンクで pillar 構造を完成させる |
+| Manabuの強み（一次情報）が活きる度合い | 15% | ◎ | ガイドとしての本音評価・混雑タイミング情報・「行かなくていい人」への正直意見は AI 代替不可 |

--- a/seo-pipeline/data/daily/2026-05-25.json
+++ b/seo-pipeline/data/daily/2026-05-25.json
@@ -1,0 +1,368 @@
+{
+  "generated_at": "2026-05-25",
+  "window_days": 28,
+  "fetch_note": "API credentials not available in this session (GOOGLE_APPLICATION_CREDENTIALS_JSON not set). Data below is carried over from 2026-05-22 fetch as fallback. Re-run fetch_daily.py with credentials to update.",
+  "gsc": {
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "clicks": 275,
+      "impressions": 101626,
+      "page_count": 154,
+      "query_count": 2556
+    },
+    "top_queries_by_impression": [
+      {
+        "query": "kamakura",
+        "clicks": 2,
+        "impressions": 403,
+        "ctr": 0.4963,
+        "position": 4.37
+      },
+      {
+        "query": "kamakura vs hakone",
+        "clicks": 2,
+        "impressions": 86,
+        "ctr": 2.3256,
+        "position": 6.14
+      },
+      {
+        "query": "tsukiji outer market opening hours 2026",
+        "clicks": 1,
+        "impressions": 505,
+        "ctr": 0.198,
+        "position": 3.12
+      },
+      {
+        "query": "tsukiji market opening hours",
+        "clicks": 1,
+        "impressions": 256,
+        "ctr": 0.3906,
+        "position": 9.72
+      },
+      {
+        "query": "japan private tour guide cost",
+        "clicks": 1,
+        "impressions": 107,
+        "ctr": 0.9346,
+        "position": 9.37
+      },
+      {
+        "query": "japan rail pass",
+        "clicks": 2,
+        "impressions": 11,
+        "ctr": 18.1818,
+        "position": 5.09
+      },
+      {
+        "query": "is kamakura worth visiting",
+        "clicks": 1,
+        "impressions": 27,
+        "ctr": 3.7037,
+        "position": 3.11
+      },
+      {
+        "query": "hakone or kamakura",
+        "clicks": 1,
+        "impressions": 74,
+        "ctr": 1.3514,
+        "position": 6.95
+      },
+      {
+        "query": "hakone or nikko",
+        "clicks": 1,
+        "impressions": 45,
+        "ctr": 2.2222,
+        "position": 8.56
+      },
+      {
+        "query": "hakone vs nikko",
+        "clicks": 1,
+        "impressions": 48,
+        "ctr": 2.0833,
+        "position": 8.92
+      },
+      {
+        "query": "is tsukiji market open on sunday",
+        "clicks": 1,
+        "impressions": 45,
+        "ctr": 2.2222,
+        "position": 9.42
+      }
+    ],
+    "top_pages_by_impression": [
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it",
+        "clicks": 15,
+        "impressions": 38565,
+        "ctr": 0.0389,
+        "position": 8.18
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide",
+        "clicks": 92,
+        "impressions": 26845,
+        "ctr": 0.3427,
+        "position": 6.52
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette",
+        "clicks": 1,
+        "impressions": 4498,
+        "ctr": 0.0222,
+        "position": 10.82
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip",
+        "clicks": 37,
+        "impressions": 3292,
+        "ctr": 1.1239,
+        "position": 6.23
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost",
+        "clicks": 11,
+        "impressions": 2564,
+        "ctr": 0.429,
+        "position": 7.38
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu",
+        "clicks": 10,
+        "impressions": 2197,
+        "ctr": 0.4552,
+        "position": 8.1
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide",
+        "clicks": 9,
+        "impressions": 1698,
+        "ctr": 0.53,
+        "position": 7.23
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo",
+        "clicks": 10,
+        "impressions": 1414,
+        "ctr": 0.7072,
+        "position": 9.73
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple",
+        "clicks": 5,
+        "impressions": 1319,
+        "ctr": 0.3791,
+        "position": 7.14
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route",
+        "clicks": 6,
+        "impressions": 813,
+        "ctr": 0.738,
+        "position": 6.02
+      }
+    ],
+    "zero_click_opportunities": [
+      {
+        "query": "jr pass price increase 2026",
+        "clicks": 0,
+        "impressions": 1121,
+        "ctr": 0,
+        "position": 5.45
+      },
+      {
+        "query": "japan rail pass prices 2026 official",
+        "clicks": 0,
+        "impressions": 558,
+        "ctr": 0,
+        "position": 7.68
+      },
+      {
+        "query": "japan rail pass current prices 2026",
+        "clicks": 0,
+        "impressions": 531,
+        "ctr": 0,
+        "position": 9.71
+      },
+      {
+        "query": "japan rail pass price 2026",
+        "clicks": 0,
+        "impressions": 400,
+        "ctr": 0,
+        "position": 11.92
+      },
+      {
+        "query": "japan rail pass price 2026 official",
+        "clicks": 0,
+        "impressions": 262,
+        "ctr": 0,
+        "position": 8.59
+      },
+      {
+        "query": "tsukiji outer market official hours 2026",
+        "clicks": 0,
+        "impressions": 252,
+        "ctr": 0,
+        "position": 3.4
+      }
+    ],
+    "near_page_one_pushup": [
+      {
+        "query": "japan rail pass price 2026",
+        "clicks": 0,
+        "impressions": 400,
+        "ctr": 0,
+        "position": 11.92
+      }
+    ],
+    "new_queries_last7": [
+      {
+        "query": "is hakone worth visiting",
+        "clicks": 0,
+        "impressions": 6,
+        "ctr": 0,
+        "position": 40.83
+      },
+      {
+        "query": "nonbei yokocho walking time from shibuya station",
+        "clicks": 0,
+        "impressions": 5,
+        "ctr": 0,
+        "position": 10
+      },
+      {
+        "query": "best places to see mount fuji from tokyo 2026",
+        "clicks": 0,
+        "impressions": 4,
+        "ctr": 0,
+        "position": 5.75
+      },
+      {
+        "query": "early morning breakfast tokyo",
+        "clicks": 0,
+        "impressions": 2,
+        "ctr": 0,
+        "position": 1
+      },
+      {
+        "query": "hire a guide in tokyo",
+        "clicks": 0,
+        "impressions": 2,
+        "ctr": 0,
+        "position": 23
+      }
+    ]
+  },
+  "ga4": {
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "sessions": 749.0,
+      "totalUsers": 623.0,
+      "screenPageViews": 938.0,
+      "engagementRate": 0.3925233644859813,
+      "averageSessionDuration": 306.0799869038718
+    },
+    "sources": [
+      {
+        "sessionSource": "google",
+        "sessionMedium": "organic",
+        "sessions": 372.0,
+        "engagementRate": 0.5134408602150538
+      },
+      {
+        "sessionSource": "(direct)",
+        "sessionMedium": "(none)",
+        "sessions": 239.0,
+        "engagementRate": 0.20502092050209206
+      },
+      {
+        "sessionSource": "chatgpt.com",
+        "sessionMedium": "(not set)",
+        "sessions": 46.0,
+        "engagementRate": 0.2608695652173913
+      }
+    ],
+    "events": [
+      {
+        "eventName": "page_view",
+        "eventCount": 938.0,
+        "totalUsers": 623.0
+      },
+      {
+        "eventName": "form_submit",
+        "eventCount": 8.0,
+        "totalUsers": 8.0
+      },
+      {
+        "eventName": "book_now_click",
+        "eventCount": 20.0,
+        "totalUsers": 16.0
+      },
+      {
+        "eventName": "contact_page_view",
+        "eventCount": 32.0,
+        "totalUsers": 27.0
+      },
+      {
+        "eventName": "tour_page_view",
+        "eventCount": 101.0,
+        "totalUsers": 52.0
+      }
+    ],
+    "organic_landing_pages": [
+      {
+        "landingPagePlusQueryString": "/blog/tsukiji-market-guide",
+        "sessions": 135.0,
+        "engagementRate": 0.5333333333333333,
+        "averageSessionDuration": 245.94640525185181
+      },
+      {
+        "landingPagePlusQueryString": "/blog/kamakura-vs-hakone-vs-nikko-day-trip",
+        "sessions": 47.0,
+        "engagementRate": 0.6382978723404256,
+        "averageSessionDuration": 2982.624405851064
+      },
+      {
+        "landingPagePlusQueryString": "/blog/japan-rail-pass-worth-it",
+        "sessions": 17.0,
+        "engagementRate": 0.4117647058823529,
+        "averageSessionDuration": 166.8300424117647
+      },
+      {
+        "landingPagePlusQueryString": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo",
+        "sessions": 14.0,
+        "engagementRate": 0.42857142857142855,
+        "averageSessionDuration": 124.77351257142857
+      },
+      {
+        "landingPagePlusQueryString": "/blog/tokyo-private-tour-guide-cost",
+        "sessions": 12.0,
+        "engagementRate": 0.8333333333333334,
+        "averageSessionDuration": 311.56787275
+      },
+      {
+        "landingPagePlusQueryString": "/blog/tsukiji-vs-toyosu",
+        "sessions": 11.0,
+        "engagementRate": 0.5454545454545454,
+        "averageSessionDuration": 183.90271609090908
+      },
+      {
+        "landingPagePlusQueryString": "/blog/yanaka-tokyo-walking-route",
+        "sessions": 7.0,
+        "engagementRate": 0.7142857142857143,
+        "averageSessionDuration": 757.8761270000001
+      },
+      {
+        "landingPagePlusQueryString": "/blog/hakone-day-trip-guide-vs-solo",
+        "sessions": 8.0,
+        "engagementRate": 0.375,
+        "averageSessionDuration": 166.4286725
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 概要
本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Kamakura Worth Visiting? A Private Guide's Honest Take (2026)
- **slug**: `is-kamakura-worth-visiting` (EN), `vale-la-pena-visitar-kamakura` (ES)
- **category**: Decision Helpers
- **priority**: high

## なぜこの案か（データ根拠）

- 「is kamakura worth visiting」が GSC で **表示 27・順位 3.11（ページ1圏内）** — 専用記事でトップ3にロック可能
- Kamakura クラスター全体で GA4 最高エンゲージメント: **47 セッション・64% 関与率・平均滞在 2,983 秒（≈ 50 分）**
- 既存 Kamakura 3記事（アクセス方法／ガイド判断／行き先比較）が揃っているのに「**そもそも行く価値があるか？**」という意思決定最上流コンテンツが空白
- `/blog/is-hakone-worth-visiting` の成功フォーマットを踏襲。Kamakura 版が未存在。
- Decision Helper カテゴリ（config weight 30）→ `form_submit` への直接貢献

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit

採用時のチェック：
- [ ] **Manabu独自エピソード（3つのプレースホルダー）に実体験を追記**
  1. 朝8時の高徳院（混雑前の体験）
  2. 「何度目の日本か」による推薦の違い
  3. 「行かなくていい人」への正直な意見
- [ ] H2アウトラインが論理的か（6セクション + FAQ）
- [ ] Required facts（入場料・営業時間・アクセス）のファクトチェック実施
- [ ] `competitor_difficulty: medium` / `ai_overview_risk: medium` が妥当か確認

## 詳細

ブリーフ本体: `seo-pipeline/briefs/2026-05-25-is-kamakura-worth-visiting.md`

**注意**: 本日のGSC/GA4フェッチは `GOOGLE_APPLICATION_CREDENTIALS_JSON` が未設定のため失敗。2026-05-22のデータをフォールバックとして使用しています。次回 Routine 実行前に secret を設定してください。

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkHkD6rhyz9tEwvea6vZUm)_