### PR TITLE
brief: 2026-05-29 — Solo Traveler Private Tour Tokyo 2026: Is It Worth It?

### DIFF
--- a/seo-pipeline/briefs/2026-05-29-solo-traveler-private-tour-tokyo.md
+++ b/seo-pipeline/briefs/2026-05-29-solo-traveler-private-tour-tokyo.md
@@ -1,0 +1,197 @@
+---
+date: 2026-05-29
+slug: solo-traveler-private-tour-tokyo
+slug_es: tour-privado-tokio-viajero-solo
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Solo Traveler Private Tour Tokyo 2026: Is It Worth It? Cost & What to Expect
+
+**Spanish Title**: Tour Privado en Tokio para Viajeros en Solitario 2026: ¿Vale la Pena? Costo y Qué Esperar
+
+---
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (2026-04-24 → 2026-05-22, 28-day window)**: 「japan private tour guide cost」 107表示・1クリック・順位9.37。親クラスターの`/blog/is-it-worth-hiring-a-tour-guide-in-tokyo`は1,414表示・10クリック・順位9.73（near page one）。新規クエリ「hire a guide in tokyo」が過去7日で2表示・順位23に出現 — ソロ旅行者固有のsub-intentを掘り起こす余地あり。
+- **GA4 signal**: `/blog/tokyo-private-tour-guide-cost` は28日間で12オーガニックセッション・**エンゲージメント率83%**・平均滞在312秒。コスト/価値判断コンテンツが極めて高い読者関与を生む傾向が確認されている。`/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` も14セッション・43% エンゲージメント。
+- **既存記事ギャップ**: Decision Helperクラスター（is-it-worth-hiring / cost / free-vs-private / group-vs-private / what-to-expect）はすべてグループ・家族・一般向けが前提。**ソロ旅行者特化の記事が一本もない**。ソロ旅行者にとって「プライベートツアーはひとりで申し込むもの？変では？」「一人分の料金は？割高？」という疑問は全く別の判断軸であり、既存記事では答えが得られていない。
+- **想定CV影響**: high — ソロ旅行者はCV直前の「申し込む勇気」段階にある読者が多い。Manabuへの直接依頼前の最後の一押しになりうる。ソロ女性旅行者は安全・信頼の観点から「公認ガイド」の権威性が特に効く。
+- **競合状況**: Viator/GetYourGuide の商品ページ、Lonely Planet の一般的なコラム（ソロ旅行向けでない）が上位に散在。「solo traveler private tour tokyo」のニッチな角度で書かれた記事はDR30以下の個人ブログのみ。Manabuの一次体験＋全国通訳案内士資格で差別化可能。
+
+---
+
+## 候補テーマ shortlist（ガードレール通過後）
+
+以下5案を検討し、最終的に①を選定した：
+
+| 案 | テーマ | ガードレール | 却下理由 / 採用理由 |
+|---|---|---|---|
+| ① | Solo Traveler + Private Tour Tokyo | ✅ Pass | **採用** — Decision Helper最高重み(30%)、既存記事との重複率低(< 30%)、AI Overview回避可、Manabu一次情報が最大限活きる |
+| ② | JR Pass Price 2026 cluster article | ❌ AI Overview | zero_click 1,121 impr / pos 5.45 は既存記事で対応中。新記事はカニバリ＋AI Overviewで両方リスク |
+| ③ | Tsukiji Morning Experience | ❌ カニバリ | 既存5記事との H2 重複度が70%超。クラスター補強は既存記事の更新で対応すべき |
+| ④ | Nonbei Yokocho / Shibuya Alley Bar Guide | ⚠️ 低優先 | Neighborhoods(15%)で形式は良好。ただし CV への直結度が低く、今回は見送り |
+| ⑤ | Ueno Tokyo Neighborhood Guide | ⚠️ GSC信号なし | config.ymlに明記された空白だが、GSCデータに表示シグナルがなく投資タイミング不明 |
+
+---
+
+## Target keyword cluster
+
+- **Primary**: "solo traveler private tour tokyo"
+- **Secondary**: "private tour tokyo for one person", "tokyo private guide solo", "hire guide tokyo alone", "solo travel tokyo private tour worth it"
+- **Long-tail**: "tokyo private tour solo female", "how much does a private tokyo tour cost solo", "is private tour awkward as solo traveler"
+- **Search intent**: commercial / decision (CVへの直接影響が高い混合型)
+
+---
+
+## Differentiation slant (Manabuならでは)
+
+**[ここにManabuさんの実体験エピソードを挿入してください — 以下はプレースホルダー案です]**
+
+1. **ソロ客との実体験エピソード**: 「500回以上ガイドした中で、ソロの旅行者はXX人（またはXX割）いる。印象的だったケースを具体的に: 例えば、一人で鎌倉を回りたかったが地図が読めず不安だった◯◯さん（国籍）が、ガイドと二人でのペースで何を発見したか」 → [Manabuさんの実際のエピソードに差し替え]
+
+2. **「ひとりは気まずい？」への率直な回答**: 「正直に言うと、ソロのほうがむしろ会話が弾む。グループツアーと違い、完全にあなたのペース・あなたの興味に合わせられる。私が最も深い会話をするのは、実はソロのクライアントとの時間です」 → [Manabuさんの言葉で書き直してください]
+
+3. **ソロ女性旅行者への安全保証**: 「全国通訳案内士は氏名・登録番号が政府公式サイトで検索できる。ガイドの身元を予約前に第三者機関で確認できるのは公認資格者だけ」 → Manabuさんが実際に女性ソロ客に言っていることがあればそちらに差し替え
+
+---
+
+## Meta tags (SEO)
+
+- **Title (EN)** (55文字): "Solo Traveler Private Tour Tokyo 2026: Is It Worth It?"
+- **Meta description (EN)** (135文字): "Thinking of booking a solo private tour in Tokyo? A licensed guide shares the real cost, what to expect, and when it's genuinely worth it."
+- **OG:title (EN)**: "Solo Traveler Private Tour Tokyo 2026: Is It Worth It?"
+- **OG:description (EN)**: "Thinking of booking a solo private tour in Tokyo? A licensed guide shares the real cost, what to expect, and when it's genuinely worth it."
+- **Title (ES)** (54文字): "Tour Privado en Tokio para Viajeros en Solitario 2026"
+- **Meta description (ES)** (141文字): "¿Vale la pena contratar un guía privado en Tokio viajando solo? Un guía oficial comparte el costo real, qué esperar y cuándo merece la pena."
+- **OG:title (ES)**: "Tour Privado en Tokio para Viajeros en Solitario 2026"
+- **OG:description (ES)**: "¿Vale la pena contratar un guía privado en Tokio viajando solo? Un guía oficial comparte el costo real, qué esperar y cuándo merece la pena."
+- **Last updated (両バージョン)**: May 2026
+
+---
+
+## H2 outline — EN (6 sections + FAQ)
+
+1. **Section 01 · Why Solo Travelers Hesitate** — 「ひとりでプライベートツアー？」という心理的ハードルを言語化。"It's just me" という申し訳なさ、コスト不安、社交的に気まずいかもという3つの懸念点を取り上げ、記事全体でそれぞれに答えると予告する。読者がスクロールを続ける理由を作る。
+
+2. **Section 02 · What a Solo Private Tour Actually Looks Like** — グループツアー（8-20人のバス/ウォーキング）との具体的な違い。ルートの柔軟性、ペース調整、質問し放題という現実。「1対1（または1対2以下）」という体験の質を描写。写真撮影サポート、食事場所の即断変更など実例を含める。[Manabuさんのエピソードプレースホルダー]
+
+3. **Section 03 · The Real Cost for One Person** — 一人あたりのコスト感を正直に開示。「一般的な相場は◯◯〜◯◯円/半日、◯◯〜◯◯円/終日（要執筆前ファクトチェック）」。グループと分割した場合との比較表。「高い」と感じる場合に代替手段として検討できるもの（free walking tour等、内部リンク）。ソロで雇う価値が費用を上回るシチュエーション3例。
+
+4. **Section 04 · [Manabu's Perspective: What Solo Clients Discover]** — [Manabuさんの実体験エピソードを挿入。ソロ客がグループ客では気づかなかった何かを発見した事例、ソロ客との印象的な対話など。Claude代筆不可の領域です。]
+
+5. **Section 05 · When It's Worth It — and When It's Not** — 率直な推薦条件表。YES（初めての日本、時間が限られている、言語バリアが不安、特定の関心（歴史・食・建築）がある、ソロ女性旅行者の安全安心）/ NO（バックパッカー型で偶然性を楽しみたい、十分な旅行経験+日本語基礎あり、予算最優先）。"Manabu's Honest Verdict" スタイルで書く。
+
+6. **Section 06 · How to Book Safely (Especially as a Solo Traveler)** — 公認ガイドの身元確認方法（全国通訳案内士 登録検索リンク）。Viator/GetYourGuide経由 vs. 直接予約のトレードオフ。予約前に確認すべき3つの質問。キャンセルポリシーの確認。[内部リンク: licensed-vs-unlicensed-tour-guides-japan, how-to-choose-private-tokyo-guide]
+
+7. **Section 07 · FAQ** — 4-5問:
+   - "Do I need to talk the whole time? What if I'm introverted?" → ガイドが会話をリードする vs. 静かに歩きたいリクエストもOK
+   - "Is it weird to be the only client?" → よくある疑問を正面から否定
+   - "Is Tokyo safe for solo female travelers? Does a guide help?" → 安全性の文脈
+   - "How far ahead should a solo traveler book?" → 直前OK or リードタイム推奨
+   - "Can I customize the route on the day?" → 柔軟性の説明
+
+---
+
+## H2 outline — ES (6 secciones + FAQ)
+
+1. **Sección 01 · Por Qué los Viajeros en Solitario Dudan** — Las 3 dudas principales: "¿No es raro ir solo?", el costo por persona, la incomodidad social.
+
+2. **Sección 02 · Cómo Es Realmente un Tour Privado para Una Persona** — Diferencias concretas con los tours grupales. Flexibilidad de ruta, ritmo personalizado, fotos sin prisa.
+
+3. **Sección 03 · El Costo Real para un Viajero Solo** — Tabla comparativa: costo en solitario vs. compartido. Cuándo vale la inversión.
+
+4. **Sección 04 · [La Perspectiva de Manabu: Qué Descubren los Viajeros en Solitario]** — [Placeholder: experiencias reales de Manabu con clientes en solitario]
+
+5. **Sección 05 · Cuándo Vale la Pena — y Cuándo No** — Tabla de recomendación honesta: SÍ / NO. "El Veredicto Honesto de Manabu".
+
+6. **Sección 06 · Cómo Reservar con Seguridad** — Cómo verificar un guía oficial en Japón. Preguntas a hacer antes de reservar.
+
+7. **Sección 07 · Preguntas Frecuentes** — 4-5 preguntas adaptadas al público hispanohablante (México, España, Argentina como mercados clave según GA4).
+
+---
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] **プライベートツアー相場（2026年）**: 半日・終日の一般的な料金レンジ（円建て税込）。公認ガイドとアンリセンスのガイドの価格差。Manabuの実際の料金表と照合
+- [ ] **全国通訳案内士の登録検索**: JNTO または観光庁の公式ガイド検索ページのURL（2026年時点で有効か確認）
+- [ ] **Viator/GetYourGuide の東京ソロツアー掲載状況**: "tokyo private tour solo" "tokyo tour for one person" の検索結果1ページ目の競合URL・価格帯（執筆時点での最新情報）
+- [ ] **ソロ女性旅行者向けの安全情報**: 外務省・JNTOの2026年最新治安情報（断定表記を避けつつ参照）
+- [ ] **tour_page_view → form_submit のCVR確認**: Manabuのサイトでソロ申込みが実際に何件あるか（Manabuさんに直接確認）
+
+---
+
+## Internal link plan (既存記事への参照)
+
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — 一般的な「雇う価値あり？」の姉妹記事。Section 01でリンク
+- [Tokyo Private Tour Guide Cost](/blog/tokyo-private-tour-guide-cost) — Section 03でコスト詳細の深掘りとしてリンク
+- [What to Expect on a Private Tour Tokyo](/blog/what-to-expect-private-tour-tokyo) — Section 02で「どんな体験か」の補足としてリンク
+- [Free Walking Tour vs. Private Tour Tokyo](/blog/free-walking-tour-vs-private-tokyo) — Section 05「NOT worth it」ケースの代替案としてリンク
+- [Licensed vs. Unlicensed Tour Guides Japan](/blog/licensed-vs-unlicensed-tour-guides-japan) — Section 06で身元確認の根拠としてリンク
+- [How to Choose a Private Tokyo Guide](/blog/how-to-choose-private-tokyo-guide) — Section 06でガイド選定プロセスへリンク
+
+---
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["private-tokyo-day-tour", "custom-private-tour"]} />`
+（実際のtour IDはManabuさんのツアー一覧から確認・差し替えてください）
+
+---
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/` 配下にある Manabu とソロゲストの2ショット（もし存在すれば）。ガイドと1対1で歩いている写真
+- **不足分（探すべき被写体）**:
+  - ひとり旅行者が地図を見ずにガイドと歩いている情景（Unsplash: "tokyo walking tour guide")
+  - 鎌倉・浅草などの路地でのガイドと観光客の2ショット（1対1感が伝わるもの）
+  - スマホで写真を撮る旅行者をガイドがサポートしている場面
+
+---
+
+## Risk notes
+
+- **カニバリゼーション低**: 既存Decision Helperクラスター5記事はすべてグループ/一般向け。ソロ固有の記事は新規。H2重複率は推定20-30%（well below 70% threshold）
+- **AI Overview リスク LOW**: "solo traveler private tour tokyo worth it?" は決断支援クエリ。Googleが体験談・個人判断をAI Overviewに丸飲みするリスクは低い。ただし「price」セクションは情報型なので価格断定を避け「check before booking」スタンスで
+- **競合難易度 MEDIUM**: Viator/GetYourGuide の商品ページがSERPに入るが、これらは「予約ページ」であり「記事コンテンツ」ではない。DR80+の記事型競合は確認されていない（執筆前に再確認）
+- **ファクト変動リスク**: 料金は季節・円安為替で変動。「記事公開時の参考値」と明記し、Last updated: May 2026を必ず表示
+- **Helpful Content System**: ソロ旅行者固有のFirsthand experienceがなければGoogleはE-Eのシグナルを拾わない。Manabuさんのエピソードプレースホルダーが未記入のまま公開しないこと
+
+---
+
+## Analysis notes: why NOT the alternatives
+
+### JR Pass articles（却下）
+- `zero_click_opportunities` に 「jr pass price increase 2026」 が1,121表示・pos5.45・クリック0で最大シグナルを示す
+- しかし既存 `/blog/japan-rail-pass-worth-it` が38,565表示を抱えており、新記事はカニバリ確定
+- 解決策: **既存記事の更新**（新記事ではなくfact-check + 2026価格差し替え）
+
+### Tsukiji cluster（却下）
+- `zero_click_opportunities` に「tsukiji outer market official hours 2026」が252表示・pos3.4
+- 既存5記事のH2重複度が高く、ガードレール（70%閾値）に引っかかる
+- 解決策: 既存 `/blog/tsukiji-market-guide` に「2026年最新営業時間」セクションを追加更新
+
+---
+
+## Build instructions for Claude Code（承認後）
+
+1. `templates/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/SoloTravelerPrivateTourTokyo.tsx` を作成
+2. `src/pages/es/blog/EsTourPrivadoTokioViajeroSolo.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加:
+   - `<Route path="/blog/solo-traveler-private-tour-tokyo" element={<SoloTravelerPrivateTourTokyo />} />`
+   - `<Route path="/es/blog/tour-privado-tokio-viajero-solo" element={<EsTourPrivadoTokioViajeroSolo />} />`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加（末尾スラッシュなし）
+6. `tsc` で型チェック
+7. feature ブランチ作成: `git checkout -b feature/blog-solo-traveler-private-tour-tokyo`
+8. commit + PR作成（`build-article` スキル使用）

--- a/seo-pipeline/data/daily/2026-05-29.json
+++ b/seo-pipeline/data/daily/2026-05-29.json
@@ -1,0 +1,36 @@
+{
+  "generated_at": "2026-05-29",
+  "window_days": 28,
+  "fetch_status": "api_unavailable",
+  "fetch_note": "Google API client library (googleapiclient) unavailable in execution environment. Brief analysis based on most recent complete dataset: 2026-05-22.json. Re-run fetch_daily.py in a local environment with valid ADC credentials to get today's data.",
+  "fallback_data_date": "2026-05-22",
+  "gsc": {
+    "error": "google-api-python-client unavailable (cffi/cryptography library conflict in execution env)",
+    "see_fallback": "seo-pipeline/data/daily/2026-05-22.json"
+  },
+  "ga4": {
+    "error": "google-api-python-client unavailable (cffi/cryptography library conflict in execution env)",
+    "see_fallback": "seo-pipeline/data/daily/2026-05-22.json"
+  },
+  "analysis_summary": {
+    "based_on": "2026-05-22 data (28-day window: 2026-04-24 to 2026-05-22)",
+    "top_gsc_signals": {
+      "highest_impression_page": "/blog/japan-rail-pass-worth-it (38,565 impr, 15 clicks, pos 8.18)",
+      "highest_click_page": "/blog/tsukiji-market-guide (26,845 impr, 92 clicks, pos 6.52)",
+      "near_page_one": "japan rail pass price 2026 (400 impr, pos 11.92)",
+      "zero_click_leader": "jr pass price increase 2026 (1,121 impr, pos 5.45, 0 clicks)",
+      "new_query_of_note": "hire a guide in tokyo (2 impr, pos 23) / nonbei yokocho walking time from shibuya station (5 impr, pos 10)",
+      "private_tour_signal": "japan private tour guide cost (107 impr, 1 click, pos 9.37)"
+    },
+    "top_ga4_signals": {
+      "total_sessions_28d": 749,
+      "form_submit_28d": 8,
+      "highest_engagement_page": "/blog/tokyo-private-tour-guide-cost (83% engagement, 312s avg duration)",
+      "highest_session_page": "/blog/tsukiji-market-guide (135 organic sessions)",
+      "star_engagement": "/blog/kamakura-vs-hakone-vs-nikko-day-trip (47 sessions, 64% engagement, 2982s avg)",
+      "hidden_gem": "/blog/tsukiji-to-ginza-food-walk (2 sessions, 100% engagement, 806s avg)"
+    },
+    "selected_brief_topic": "solo-traveler-private-tour-tokyo",
+    "selection_rationale": "Decision Helper (30% weight) + highest-engagement-rate cluster (cost/value pages at 83% engagement) + solo traveler angle absent from site + low cannibalization risk + low AI Overview risk"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Solo Traveler Private Tour Tokyo 2026: Is It Worth It? Cost & What to Expect
- **slug**: `solo-traveler-private-tour-tokyo` (EN), `tour-privado-tokio-viajero-solo` (ES)
- **category**: Decision Helpers
- **priority**: high

## データシグナル（2026-05-22, 28日間）

| シグナル | 数値 |
|---|---|
| `japan private tour guide cost` GSC | 107表示 / 1クリック / 順位9.37 |
| `/blog/is-it-worth-hiring` GSC | 1,414表示 / 10クリック / 順位9.73 |
| `/blog/tokyo-private-tour-guide-cost` GA4 engagement | **83%**（28日間最高） |
| `hire a guide in tokyo` (新規クエリ) | 2表示 / 順位23 |
| form_submit 28日合計 | 8件（目標KPI: 27/90日） |

## なぜこの案か

Decision Helperカテゴリ（重み30%）かつ既存クラスター（is-it-worth-hiring / cost / free-vs-private / group-vs-private / what-to-expect）の**ソロ旅行者特化の空白**を埋める。既存5記事はすべてグループ/一般向けが前提。H2重複率推定20-30%でカニバリゼーション閾値（70%）を大きく下回る。AI Overview リスクLOW（決断支援クエリ）。

## ⚠️ 注意: API fetch 失敗

`fetch_daily.py` の実行中に Google API クライアントライブラリ（cffi/cryptography）のランタイムエラーが発生し、本日のGSC/GA4データ取得に失敗しました。分析は **2026-05-22.json**（最新の完全データ）を使用しています。次回実行前にローカル環境でのライブラリ再インストールを確認してください。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → `build-article` スキルで記事化
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] **Manabu独自エピソード**（Section 04 のプレースホルダー）に実体験を追記 ← 必須
- [ ] H2 outline（7セクション + FAQ）が論理的か
- [ ] Required facts（料金・公認ガイド検索URL・競合状況）を執筆前にweb検索で検証
- [ ] competitor_difficulty（medium）・ai_overview_risk（low）の評価が妥当か

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-05-29-solo-traveler-private-tour-tokyo.md](seo-pipeline/briefs/2026-05-29-solo-traveler-private-tour-tokyo.md)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMLR2yw1y2DCsqDmo3WSmb)_