### PR TITLE
brief: 2026-05-30 — Is Kamakura Worth Visiting in 2026?

### DIFF
--- a/seo-pipeline/briefs/2026-05-30-is-kamakura-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-05-30-is-kamakura-worth-visiting.md
@@ -1,0 +1,116 @@
+---
+date: 2026-05-30
+slug: is-kamakura-worth-visiting
+slug_es: vale-la-pena-visitar-kamakura
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Is Kamakura Worth Visiting in 2026? A Licensed Guide's Honest Take
+
+**Spanish Title**: ¿Vale la Pena Visitar Kamakura en 2026? La Opinión Honesta de un Guía Oficial
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (2026-04-24 → 2026-05-22)**: 「is kamakura worth visiting」直近28日で 表示 27、クリック 1、順位 3.11（Top 3だがクリックが獲れていない → タイトルCTR改善で取れる）
+- **GSC Kamakura cluster**: 「kamakura」403表示/2クリック/pos 4.37、「kamakura vs hakone」86表示/2クリック/pos 6.14 → Kamakura意思決定クエリ群への露出が続いている
+- **GA4ハイライト**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` が オーガニック 47セッション、エンゲージメント率 63.8%、**平均セッション時間 2,982秒（約49分）** — サイト全体で最長。読者がこのカテゴリで深く悩んでいることを示す
+- **既存記事ギャップ**: `/blog/kamakura-day-trip-from-tokyo`（ロジスティクス）、`/blog/kamakura-day-trip-guide-vs-solo`（ガイドの要否）、`/blog/kamakura-vs-hakone-vs-nikko-day-trip`（比較）はある。しかし「**そもそも行く価値があるか**」という入口クエリに正面から答える記事が不在
+- **テンプレート実績**: `/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` → 1,414表示/10クリック/**CTR 0.72%**。同じ "is it worth" 形式が Decision Helper として機能している。`/blog/is-hakone-worth-visiting` も同パターン
+- **想定CV影響**: high — 「行く価値があるか」と検索する読者は旅程決定の直前段階。記事内でツアー案内まで繋ぐことで form_submit に直結
+- **競合状況**: 上位は japan-guide.com、timeout.com、tsunagujapan.com。いずれも一般情報記事。政府公認ガイドによる「何百回もガイドした現場の声」という slant は不在
+
+## Target keyword cluster
+
+- **Primary**: "is kamakura worth visiting"
+- **Secondary**: "kamakura day trip from tokyo worth it", "kamakura worth it 2026", "should i visit kamakura or hakone", "kamakura what to expect"
+- **Search intent**: commercial investigation（旅程決定直前の判断支援）
+
+## Differentiation slant (Manabuならでは)
+
+> [ここにManabuさんの実体験エピソードを挿入してください。以下は提案スロット3点]
+
+1. **「どんな客が後悔したか」の具体例**: 「短時間でハイライトだけを回ろうとして鶴岡八幡宮しか見られなかった方、逆に1日かけすぎて北鎌倉から銭洗弁天まで全部回ろうとして体力を使い果たした方など、500回以上ガイドして失敗パターンが見えてきた」——この視点は一般旅行ブログには書けない
+2. **「空いている曜日・時間帯を知っているガイドの話」**: 「週末の鎌倉大仏（高徳院）は10時を過ぎると大型バスツアーと重なる。私は9時前にご案内することが多い。小町通りの行列を避けて地元民が使う裏道など、現地に何百回も通っているから分かること」
+3. **「リピーター旅行者への推薦度が特に高い理由」**: 「初めての東京旅行ならShibuya/Asakusa必須。でも2回目以降の方には、私は必ず鎌倉を勧める。あの鎌倉の寺社が持つ静けさ、海への近さ、東京との対比は他の日帰り先では得られない体験だと確信している」
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Kamakura Worth Visiting in 2026? A Guide's Honest Take`
+- **Meta description (EN)** (155字以内): `Licensed Tokyo guide Manabu answers the question honestly: who should visit Kamakura, who should skip it, and what makes the 90-min day trip truly worth it in 2026.`
+- **Title (ES)** (60字以内): `¿Vale la Pena Visitar Kamakura en 2026? Guía Oficial Responde`
+- **Meta description (ES)** (155字以内): `Manabu, guía oficial de Tokio, responde con honestidad: quién debería visitar Kamakura, quién puede saltársela y qué hace que la excursión de un día realmente valga la pena en 2026.`
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Short Answer** — Quick Decision Box: 「はい、ほぼ全員に価値がある。ただし〇〇な人は例外」を冒頭に置く。スキャン読者を掴む
+2. **Section 02 · What Makes Kamakura Unique** — 東京と30分圏内なのに別世界な理由を整理（山・海・古都の三要素）。初めて来る読者の期待値を適切に設定する
+3. **Section 03 · Who Should Definitely Go** — タイプ別推薦：初来日者、2回目以上のリピーター、ハイカー、寺社好き、写真好き、ファミリー（鎌倉大仏の中に入れる）
+4. **Section 04 · Who Might Want to Skip It** — 正直な除外条件：足が不自由な場合（階段が多い）、真夏のピーク（熱射病リスク）、Nikkoと同行程では被る観光ポイントあり
+5. **Section 05 · How to Get the Most Out of One Day** — 半日 vs 1日の違い、何を捨てるか、私（Manabu）が実際に組む午前ルートの概要
+6. **Section 06 · Does a Private Guide Make a Difference in Kamakura?** — 65以上の寺社から何を選ぶかは情報戦。ガイドがいると得られる具体的な体験の差（歴史背景、混雑回避、隠れスポット）
+7. **Section 07 · FAQ** — 4-5問（下記参照）
+
+### FAQ候補（5問）
+- Is one day in Kamakura enough?
+- What is the best time of year to visit Kamakura?
+- Is Kamakura better than Nikko for a day trip?
+- Can I visit Kamakura without a guide?
+- How far is Kamakura from Tokyo, and how do I get there?
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 鎌倉大仏（高徳院）：入場料（大人・子供）、開館時間、定休日（2026年最新）
+- [ ] 北鎌倉→鎌倉のウォーキングルート所要時間（公式または地図アプリで確認）
+- [ ] 横須賀線/湘南新宿ライン：新宿/東京→鎌倉の所要時間と料金（JR公式）
+- [ ] 週末の混雑ピーク時間帯（現地観光協会や自治体情報）
+- [ ] 2026年現在のJRパスで鎌倉駅は利用可能か（JRグループ対象路線確認）
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura Day Trip from Tokyo](/blog/kamakura-day-trip-from-tokyo) — アクセス・ロジスティクスの詳細はこちらへ誘導
+- [Kamakura: Private Tour Guide vs Going Solo](/blog/kamakura-day-trip-guide-vs-solo) — 「ガイドは必要か」の詳細比較へ
+- [Kamakura vs Hakone vs Nikko: Which Day Trip?](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 他の目的地と迷っている読者へ
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — ガイド雇用コスパの疑問へ
+- [Best Day Trips from Tokyo](/blog/best-day-trips-from-tokyo) — クラスター記事への被リンク強化
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["kamakura-day-trip"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: `/images/tours/kamakura-great-buddha.webp`、`/images/tours/kamakura-coast-enoden.webp`（TourDetail.tsxで既に使用、高品質）
+- **追加候補（Wikimedia）**: 北鎌倉・円覚寺の境内（静寂感）、小町通りの人通り（混雑のリアル）、ハイキングコースからの眺望
+
+## Risk notes
+
+- **AI Overview低リスク**: 「is kamakura worth visiting」は判断・体験クエリ。"opening hours"等の情報型クエリ（position 3前後でゼロクリックの tsukiji 例）とは性質が異なり、AI Overviewに取られにくい
+- **カニバリリスク低**: 既存Kamakura記事3本はすべて「どう行くか」「ガイドvsソロ」「他の目的地と比較」に特化。「そもそも行く価値があるか」の入口クエリは空白
+- **競合難易度中**: japan-guide.com（DR78）等が上位にいるが、政府公認ガイドの一次情報slantで差別化可能。CTR改善余地あり（pos 3.11で現在1クリック）
+- **ファクト変動リスク**: 価格・時刻は年次更新。「Last updated: May 2026」タグ必須。記事公開後も定期確認推奨
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsKamakuraWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsIsKamakuraWorthVisiting.tsx` も作成（hreflang対応、slug: `vale-la-pena-visitar-kamakura`）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/is-kamakura-worth-visiting`、`/es/blog/vale-la-pena-visitar-kamakura`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. tsc で型チェック
+7. feature ブランチ `feature/blog-is-kamakura-worth-visiting` 作成 + commit
+
+---
+
+_Generated by Daily SEO Brief Routine · 2026-05-30 · Data source: seo-pipeline/data/daily/2026-05-22.json_

--- a/seo-pipeline/data/daily/2026-05-30.json
+++ b/seo-pipeline/data/daily/2026-05-30.json
@@ -1,0 +1,13 @@
+{
+  "generated_at": "2026-05-30",
+  "window_days": 28,
+  "_note": "GSC/GA4 fetch failed: GOOGLE_APPLICATION_CREDENTIALS_JSON not set in this execution environment. Analysis for brief generation was performed using data from 2026-05-22.json (window: 2026-04-24 to 2026-05-22). Set the secret in Anthropic Routines to enable live data fetching.",
+  "gsc": {
+    "error": "AuthError: GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable not set",
+    "fallback_ref": "seo-pipeline/data/daily/2026-05-22.json"
+  },
+  "ga4": {
+    "error": "AuthError: GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable not set",
+    "fallback_ref": "seo-pipeline/data/daily/2026-05-22.json"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Kamakura Worth Visiting in 2026? A Licensed Guide's Honest Take
- **slug**: `is-kamakura-worth-visiting` (EN), `vale-la-pena-visitar-kamakura` (ES)
- **category**: Decision Helpers
- **priority**: high

## データ根拠（なぜこの案か）

- 「is kamakura worth visiting」→ 直近28日で **表示27・クリック1・順位 3.11**（Top 3圏内、CTR改善で取れる）
- `/blog/kamakura-vs-hakone-vs-nikko-day-trip` → GA4 **平均セッション時間 2,982秒（約49分）**、エンゲージメント率 63.8% — サイト全体で最も深く読まれている記事
- 「is kamakura worth visiting」に正面から答える記事が現在不在（既存3本は「アクセス」「ガイドvsソロ」「他目的地との比較」に特化）
- 実績テンプレート: `/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` CTR 0.72% → 同「is it worth」形式がDecision Helperとして機能中

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → `/build-article` コマンドで記事化
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit

採用時のチェック：
- [ ] **Manabu独自エピソード（3つのプレースホルダー）に実体験を追記**（最重要 — AI代筆不可の領域）
- [ ] H2 outline（7セクション + FAQ5問）が論理的か
- [ ] Required facts（鎌倉大仏入場料・アクセス時間等）を執筆前にweb検索で確認
- [ ] competitor_difficulty, ai_overview_risk の評価が妥当か

## 留意事項

> ⚠️ 本日のGSC/GA4ライブ取得はスキップされました（`GOOGLE_APPLICATION_CREDENTIALS_JSON` 未設定）。分析は `seo-pipeline/data/daily/2026-05-22.json` の実データに基づきます。Routines の Environment settings でSecretを登録すると次回から自動取得されます。

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-05-30-is-kamakura-worth-visiting.md](seo-pipeline/briefs/2026-05-30-is-kamakura-worth-visiting.md)

---
🤖 Generated by Daily SEO Brief Routine · 2026-05-30

---
_Generated by [Claude Code](https://claude.ai/code/session_01E12VgJrPBjmsuSDHcX1D8A)_