### PR TITLE
brief: 2026-05-31 — Is Nikko Worth Visiting from Tokyo? A Licensed Guide's Verdict 2026

### DIFF
--- a/seo-pipeline/briefs/2026-05-31-is-nikko-worth-visiting-from-tokyo.md
+++ b/seo-pipeline/briefs/2026-05-31-is-nikko-worth-visiting-from-tokyo.md
@@ -1,0 +1,107 @@
+---
+date: 2026-05-31
+slug: is-nikko-worth-visiting-from-tokyo
+slug_es: vale-la-pena-visitar-nikko
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2000
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: medium
+---
+
+# Is Nikko Worth Visiting from Tokyo? A Licensed Guide's Verdict 2026
+
+**Spanish Title**: ¿Vale la Pena Visitar Nikko desde Tokio? La Opinión de un Guía Oficial 2026
+
+## Why this article (data-driven rationale)
+
+> ⚠️ **データ注記**: 2026-05-31 の API フェッチは認証情報未設定により失敗。以下の数値は 2026-04-24〜2026-05-22（28日間）スナップショット（`2026-05-22.json`）に基づく。
+
+- **GSC signal**: `/blog/nikko-day-trip-from-tokyo` は直近28日で表示 667、クリック 0、順位 23.8（完全な機会損失）。`/tours/nikko-day-trip` も表示 443、クリック 0、順位 24.63 でツアーページが検索から取りこぼし中。並行して「is kamakura worth visiting」が 27 impressions・順位 3.11 と既存の「worth visiting」フォーマットが機能していることを確認。
+- **既存記事ギャップ**: `nikko-day-trip-from-tokyo`（ロジスティクス中心）と `nikko-day-trip-guide-vs-solo`（ガイド有無の比較）はいずれも「そもそも日光は行く価値があるか」という検索意図（Decision Helper）に直接答えていない。`is-hakone-worth-visiting`（EN）と `vale-la-pena-visitar-hakone`（ES）は存在するが **日光版が EN・ES ともに不在**。
+- **想定CV影響**: high — 「is nikko worth visiting」を検索するユーザーは旅程最終判断フェーズにあり、yes判定 → `/tours/nikko-day-trip` への誘導で form_submit 直結。`/blog/tokyo-private-tour-guide-cost`（GA4: 12 sessions、83.3% engagement）の高CV率と同様のファネル動線が期待できる。
+- **競合状況**: Japan-Guide.com（DR90+）、Lonely Planet（DR90+）が上位。ただしいずれも中立的な観光情報記事。「政府公認ガイドの正直な verdict」という一人称スラントは十分に差別化可能。
+
+## Target keyword cluster
+
+- **Primary**: "is nikko worth visiting"
+- **Secondary**: "is nikko worth a day trip from tokyo", "nikko day trip worth it", "should i visit nikko from tokyo", "is nikko worth it"
+- **Search intent**: commercial / decision（旅程の最終可否判断）
+
+## Differentiation slant (Manabuならでは)
+
+[ここにManabuさんの実体験エピソードを挿入]
+
+- **エピソード枠1 — "これは来て正解だった" 瞬間**: 日光東照宮の陽明門を初めて見たゲストの反応。「東京の浅草寺では得られないスケール感」を体感した具体的な場面を一人称で書く。（例: 2024年に案内した家族連れ、またはシニアカップルが陽明門の前で立ち止まったときのエピソード）
+- **エピソード枠2 — "あの失敗は防げた" 反省事例**: 実際に日光ツアーでゲストをがっかりさせかけたパターン（例: 紅葉ピークの大渋滞、急な天気の悪化、体力不足で輪王寺まで回れなかった等）と、それを防ぐためにManabuが事前に伝えるようになったこと。政府公認ガイドとして「次回からこう提案する」という学びとして締める。
+- **エピソード枠3 — "日光を勧めない" 判断基準**: Manabuが初回相談時に日光を勧めない客層のパターン（例: 日本初訪問でまだ浅草・新宿を見ていない人、寺社仏閣に関心が薄い人、体力に不安があるシニア等）。「勧めない」という正直さがE-E-A-Tと読者信頼を高める。
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Nikko Worth Visiting from Tokyo? A Guide's Verdict 2026` (58 chars)
+- **Meta description (EN)** (155字以内): `A licensed Tokyo guide answers honestly: is Nikko worth the day trip? What you'll really see, when crowds peak, and who should skip it entirely.` (144 chars)
+- **Title (ES)** (60字以内): `¿Vale la Pena Visitar Nikko desde Tokio? Opinión 2026` (53 chars)
+- **Meta description (ES)** (155字以内): `Un guía oficial de Tokio responde sin rodeos: ¿merece la pena ir a Nikko en un día? Qué verás, cuándo evitar las multitudes y quién debería saltárselo.` (151 chars)
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Verdict** — quick-decision ボックスで「行くべき人 / やめるべき人」を冒頭に明示。読者が最初の30秒で判断できる構成。Manabuの総合評価（★など）を添えてもよい。
+2. **Section 02 · What Makes Nikko Different from Tokyo's Temples** — 東照宮・輪王寺・二荒山神社の三社の規模感を、浅草寺・明治神宮との対比で説明。「都市観光では得られない山岳×歴史」の価値を具体化。
+3. **Section 03 · What One Day Actually Looks Like** — 往復2時間（東武特急または新幹線+接続）＋現地4〜5時間の現実的タイムライン。歩行距離・アップダウン・疲労度を正直に記述。シニア・子連れへの注記必須。
+4. **Section 04 · The Crowd and Weather Problem** — 紅葉ピーク（10〜11月）・GW・夏休みの混雑実態と、それを避けるベストシーズン（初春・平日）。山間部の天気急変リスクと服装アドバイス。
+5. **Section 05 · Nikko vs Kamakura vs Hakone — Which Should You Pick?** — 三択で迷う読者への最終ガイダンス。「初日本 → Kamakura」「自然重視 → Hakone」「歴史・寺社が好き → Nikko」など判断ツリー形式で整理。`/blog/kamakura-vs-hakone-vs-nikko-day-trip` へのリンクで詳細比較に誘導。
+6. **Section 06 · Go with a Guide or Solo?** — ガイド同行で変わる3点（非公開エリアの解説・移動効率・現地の突発対応）を具体的に説明し、`/tours/nikko-day-trip` へのCTA。`/blog/nikko-day-trip-guide-vs-solo` も内部リンクで補足。
+7. **Section 07 · FAQ** — 4〜5問
+   - "Is one day enough for Nikko from Tokyo?"
+   - "How long is the train ride from Tokyo to Nikko?"
+   - "Is Nikko better than Kamakura?"
+   - "Is Nikko worth visiting in winter?"
+   - "Do I need a guide for Nikko?"
+
+## Required facts (web search before writing)
+
+- [ ] 東武日光線・JR日光線の東京からの所要時間・運賃（2026年版、東武スペーシアX含む）
+- [ ] 日光東照宮の拝観料（2026年現在、税込・セット券情報）
+- [ ] 輪王寺・日光二荒山神社の拝観料・営業時間・定休日（2026年）
+- [ ] 紅葉・混雑ピークの公式または信頼できる観光統計（直近年）
+- [ ] 「日光・鬼怒川パス」等の割引きっぷの2026年時点での有効性・価格
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura vs Hakone vs Nikko Day Trip from Tokyo](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 三択比較の詳細記事として本文Section 05からリンク。クラスターの要として相互強化。
+- [Nikko Day Trip: With a Guide vs Going Solo](/blog/nikko-day-trip-guide-vs-solo) — 「行くと決めた読者」をSection 06から誘導。
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — Section 05の「Hakone選択肢」言及時に並行決定記事として参照。
+- [Best Day Trips from Tokyo](/blog/best-day-trips-from-tokyo) — 記事冒頭でNikkoの選択肢として言及する際に参照。
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["nikko-day-trip"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/nikko/` または既存ツアーページ (`/tours/nikko-day-trip`) で使用している日光東照宮・杉並木・輪王寺の写真を流用
+- **不足分（Wikimedia/Unsplash提案）**: 陽明門（Yomeimon Gate）の正面高解像度写真、日光杉並木（Cedar Avenue of Nikko）の朝景、紅葉シーズンの東照宮境内
+
+## Risk notes
+
+- **AI Overview ゼロクリック化リスク（medium）**: "is nikko worth visiting" は情報型クエリで AI Overview 候補。ただし「政府公認ガイドの主観的 verdict」「勧めない客層の明示」「一次体験エピソード」はAIが要約しにくい独自情報。opinionated slant を徹底することでリスクを低減。
+- **カニバリリスク（low）**: `nikko-day-trip-guide-vs-solo`（ガイド比較）・`nikko-day-trip-from-tokyo`（ロジスティクス）との主題重複は低い。Section 06でガイド比較記事へのリンクを入れクラスター強化。
+- **競合過密**: Japan-Guide.com・Lonely Planet が上位独占。Manabuの生の体験談（E-E-A-T）と「行くべきでない人への正直なアドバイス」で差別化。
+- **ファクト変動リスク**: 東武スペーシアX の運賃・時刻、拝観料は年次変動あり。執筆時に必ず最新情報を確認し「Last updated: June 2026」を明記。
+- **データ品質注記**: 本brief は 2026-05-22 スナップショットベース。ADC 認証設定後に `fetch_daily.py` を再実行して最新データで優先度を再検証することを推奨。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsNikkoWorthVisitingFromTokyo.tsx` を作成
+2. `src/pages/es/blog/EsValelapenaVisitarNikko.tsx` も作成（hreflang 対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/is-nikko-worth-visiting-from-tokyo` と `/es/blog/vale-la-pena-visitar-nikko`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に 2 URL 追加
+6. `tsc` で型チェック
+7. feature ブランチ作成 + commit

--- a/seo-pipeline/data/daily/2026-05-31.json
+++ b/seo-pipeline/data/daily/2026-05-31.json
@@ -1,0 +1,13 @@
+{
+  "generated_at": "2026-05-31",
+  "window_days": 28,
+  "fetch_status": "error",
+  "fetch_error": "GOOGLE_APPLICATION_CREDENTIALS_JSON not set in this execution environment. Analysis based on last known good snapshot: 2026-05-22.",
+  "data_source_note": "Brief generated using 2026-05-22 snapshot (seo-pipeline/data/daily/2026-05-22.json). Re-run fetch_daily.py with valid ADC credentials to populate today's data.",
+  "gsc": {
+    "error": "Your default credentials were not found. To set up Application Default Credentials, see https://cloud.google.com/docs/authentication/external/set-up-adc for more information."
+  },
+  "ga4": {
+    "error": "Your default credentials were not found. To set up Application Default Credentials, see https://cloud.google.com/docs/authentication/external/set-up-adc for more information."
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Nikko Worth Visiting from Tokyo? A Licensed Guide's Verdict 2026
- **slug**: `is-nikko-worth-visiting-from-tokyo` (EN), `vale-la-pena-visitar-nikko` (ES)
- **category**: Decision Helpers
- **priority**: high

## なぜこの案か（データ根拠）

- `/blog/nikko-day-trip-from-tokyo` が 28日間で **667 impressions・0 clicks・順位 23.8** → 大幅な機会損失
- `/tours/nikko-day-trip` も **443 impressions・0 clicks** と tour page が検索から取りこぼし中
- "is kamakura worth visiting" が **27 impressions・順位 3.11** と、同フォーマットの効果実証済み
- `is-hakone-worth-visiting` (EN/ES) は存在するが **Nikko版が EN・ES ともに不在**
- Decision Helper カテゴリ（form_submit 直結）× Manabu の一次情報 = 最高スコア

> ⚠️ **データ注意**: 2026-05-31 の API フェッチは認証情報未設定により失敗。分析は 2026-05-22 スナップショットに基づく。ADC 設定後に `fetch_daily.py` を再実行すると最新データが取得できます。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → マージして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus 指示を書いて commit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu 独自エピソード（3つのプレースホルダー）に実体験を追記
  - エピソード枠1: 陽明門を初めて見たゲストの反応（具体的なゲスト名/国籍/年）
  - エピソード枠2: 失敗しかけたツアーのケーススタディ
  - エピソード枠3: 日光を「勧めない」と判断する基準
- [ ] Required facts 5項目を web search で検証（東武料金・拝観料・営業時間）
- [ ] H2 outline が論理的か（7 sections + FAQ）
- [ ] competitor_difficulty / ai_overview_risk の評価が妥当か

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-05-31-is-nikko-worth-visiting-from-tokyo.md](seo-pipeline/briefs/2026-05-31-is-nikko-worth-visiting-from-tokyo.md)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hi4epEwf4CJP7KK3oCDxgw)_