### PR TITLE
brief: 2026-06-01 — One Day in Old Tokyo: Ueno, Yanaka & Shitamachi with a Private Guide

### DIFF
--- a/seo-pipeline/briefs/2026-06-01-old-tokyo-ueno-yanaka-private-guide.md
+++ b/seo-pipeline/briefs/2026-06-01-old-tokyo-ueno-yanaka-private-guide.md
@@ -1,0 +1,148 @@
+---
+date: 2026-06-01
+slug: old-tokyo-ueno-yanaka-private-guide
+slug_es: tokio-antiguo-ueno-yanaka-guia-privado
+status: pending  # pending | approved | rejected | needs-changes
+priority: high  # high | medium | low
+category: Neighborhoods  # Decision Helpers crossover
+estimated_word_count: 2400
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low  # vs yanaka-walking-tour-guide (different scope + intent)
+competitor_difficulty: medium  # low | medium | high
+ai_overview_risk: low  # experience/judgment content, not factual lookup
+---
+
+# One Day in Old Tokyo: Ueno, Yanaka & Shitamachi with a Private Guide
+
+**Spanish Title**: Un Día en el Tokio Antiguo: Ueno, Yanaka y Shitamachi con Guía Privado
+
+---
+
+> **データ注記**: 2026-06-01のGSCフェッチはAPI接続エラー（google-api-python-clientライブラリ未インストール）のため失敗。
+> 下記の数値はすべて直近の実データ（2026-05-22スナップショット、集計期間 2026-04-24〜05-22）に基づく。
+
+---
+
+## Why this article (data-driven rationale)
+
+- **GSC signal（Yanaka cluster強度）**: `/blog/yanaka-tokyo-walking-route` が直近28日で 表示 813、クリック 6、順位 6.02。さらにGA4では **71.4% engagement rate・平均滞在時間 757秒**（サイト全体で最長）を記録。このクラスターへの需要は実証済み。
+- **GSC signal（Old Shitamachi）**: `/blog/old-tokyo-shitamachi` が表示 624、クリック 2、順位 8.06。エンゲージメント 66.7%・99秒 — 小規模ながらも関心が高い。
+- **構造的ギャップ**: Ueno単体の記事がサイトに存在しない。東京観光の主要エリアにもかかわらずカバーゼロ。Yanaka・Shitamachi記事は既存だが「3エリアを通しで回る + private guide判断」という上位記事が欠けている。
+- **Near page one**: 「japan private tour guide cost」が表示 107、順位 9.37。この記事で「Ueno/Yanaka/Shitamachiにこそガイドが必要な理由」を説明することで `/blog/tokyo-private-tour-guide-cost`（GA4 83.3% engagement）への内部リンクが強化される。
+- **想定CV影響**: **high** — 「ガイドあり vs 自力」の判断フェーズに刺さる。old-tokyoエリアは歴史背景・路地の読み方・英語対応の不在が顕著なため、ガイド価値が最も可視化しやすいカテゴリ。
+- **競合状況**: TripAdvisor・Time Out・Japan Guide がUeno単体は網羅するが「Ueno + Yanaka + Shitamachi をプライベートガイドと回る価値」という体験+判断記事は DR20台サイトでも差別化できる余地あり。
+
+## Target keyword cluster
+
+- **Primary**: "ueno yanaka private tour tokyo"
+- **Secondary**: "old tokyo private guide", "ueno yanaka shitamachi day trip", "is ueno worth visiting tokyo"
+- **Search intent**: commercial investigation（「どのガイドに頼むか」「自力で行けるか」判断段階）
+
+## Differentiation slant (Manabuならでは)
+
+1. **戦争と震災を逃れた「生き残りの街」ストーリー**: 山手線の外側、Yanaka・Shitamachiは1923年関東大震災と1945年の東京大空襲を奇跡的に免れたエリア。全国通訳案内士として日本史試験を合格しているManabuだからこそ、路地を歩きながら「なぜここだけ古い街並みが残っているのか」を語れる。
+   - **[プレースホルダー: Manabuさんが実際にゲストに話した "survival of Yanaka" のエピソードを1〜2文で追記してください。例:「あの角の木造家屋は〇〇年築で…」など具体的な1棟の話があるとベスト]**
+
+2. **東京国立博物館の「正しい歩き方」**: 一般ガイドブックは「全部見ろ」と言うが、3時間で満足感を最大化する展示の選び方がある。Manabuが実際にゲストを案内して「これが一番反応が良かった」と感じる常設展示のルートを具体的に提案。
+   - **[プレースホルダー: Manabuさんが実際に「ここは必ず見せる」と決めている展示（法隆寺宝物館・埴輪・縄文土器など）と、その理由を追記してください]**
+
+3. **アメ横のベストタイミングとゲストの反応**: 「市場は混雑する」という先入観を崩す、Manabuが案内で学んだ最適な訪問時間帯（早朝 vs 昼 vs 夕方）と、実際のゲストが驚いた光景のエピソード。
+   - **[プレースホルダー: ゲストが一番驚いた・喜んだアメ横のシーン（例:「ドリアンを切り売りする店を前に……」）を1文追記してください]**
+
+## Meta tags (SEO)
+
+- **Title (EN)** (58文字): `Old Tokyo Private Tour: Ueno, Yanaka & Shitamachi 2026`
+- **Meta description (EN)** (154文字): `Explore Old Tokyo's trio—Ueno's museums, Yanaka's ancient temples & Shitamachi's shotengai—with a licensed private guide. Is it worth it? A guide's honest take.`
+- **Title (ES)** (59文字): `Tour Privado Tokio Antiguo: Ueno, Yanaka y Shitamachi 2026`
+- **Meta description (ES)** (146文字): `Museos de Ueno, los templos de Yanaka y el Shitamachi con guía privado oficial. Descubre si vale la pena contratar un guía para el Tokio histórico.`
+
+## H2 outline (6 sections + FAQ)
+
+1. **Section 01 · What Is "Old Tokyo"?** — Ueno・Yanaka・Shitamachiが地理的・歴史的に1つのクラスターを形成する理由。山手線の内外、震災/戦争サバイバルの背景を簡潔に説明。読者に「なぜここ3エリアをセットで回るのか」を納得させる導入。
+
+2. **Section 02 · Ueno: Where High Culture Meets Street Life** — 東京国立博物館・東京都美術館・国立西洋美術館の選び方。上野公園（花見シーズン外の楽しみ方）。アメ横の食と雑貨。1日だと多すぎる→優先度の付け方。
+
+3. **Section 03 · Yanaka: Tokyo Frozen in the Meiji Era** — 谷中霊園・下町歩き・根津神社・谷中ぎんざ商店街。「なぜ古い建物が残っているのか」の歴史解説。写真映えスポットと地元民御用達の差。
+
+4. **Section 04 · Shitamachi: The Merchant Quarter** — 谷根千エリア、かつての下町文化。Asakusaとの距離感・連携提案。アクセス経路の選び方（Ueno公園 → 谷中方面の徒歩ルート）。
+
+5. **Section 05 · Private Guide vs. Self-Guided for Old Tokyo** — 決断支援セクション（核心）。「なぜOld Tokyoはガイドが特に効くのか」：英語案内の少なさ、路地の読み方、博物館コンテキスト、隠れスポットへのアクセス。「自力でも十分な人」の条件も正直に提示（cannibal防止・信頼性向上）。
+
+6. **Section 06 · Sample Private Tour Itinerary** — 9:00-16:00の時間別プラン（博物館1〜2h → アメ横 → 谷中 → 根津 → 昼食）。天候別・家族連れ別のバリエーション示唆。
+
+7. **Section 07 · FAQ** — 4〜5問
+   - "How long do you need in Ueno?"
+   - "Can you combine Ueno and Asakusa in one day?"
+   - "Is the Tokyo National Museum worth it?"
+   - "Is Yanaka far from Ueno station?"
+   - "Do I need a guide for Old Tokyo, or can I explore alone?"
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] **東京国立博物館**: 開館時間・休館日（月曜）・入館料（一般・大学生・高校生以下）・常設展 vs 特別展の料金差
+- [ ] **東京都美術館**: 開館時間・休館日・企画展スケジュール（2026年）
+- [ ] **上野動物園**: 開園時間・休園日・入園料（2026年現在の料金）
+- [ ] **アメ横商店街**: 公式の定休日設定有無・营業時間の目安（店舗によって異なる点も）
+- [ ] **谷中ぎんざ商店街**: 各店舗の営業時間・定休日（観光案内サイト or 商店街公式）
+- [ ] **根津神社**: 拝観無料確認・社務所時間
+- [ ] **アクセス**: 上野駅（JR・東京メトロ） → 谷中方面（鶯谷 or 日暮里）の徒歩・電車ルートと所要時間
+- [ ] **博物館エリア全体の「ミュージアムパスポート」等割引制度**: 複数館共通券の有無（2026年現在）
+
+## Internal link plan (既存記事への参照)
+
+- [Yanaka Tokyo Walking Route](/blog/yanaka-tokyo-walking-route) — 自力ウォーキング派への選択肢。"if you prefer to self-guide" セクションで自然に参照
+- [Yanaka Walking Tour Guide](/blog/yanaka-walking-tour-guide) — 谷中単体のより詳しいガイドとして Section 03 末尾で参照
+- [Old Tokyo: Exploring Shitamachi](/blog/old-tokyo-shitamachi) — Section 04 でShitamachi詳細への誘導
+- [Asakusa Complete Guide](/blog/asakusa-guide) — Section 04 末尾「Asakusaと組み合わせるなら」でリンク
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — Section 05 冒頭で「迷っている方はまずこちら」として参照
+- [How to Choose a Private Tokyo Guide](/blog/how-to-choose-private-tokyo-guide) — Section 05 末尾のCTA前に参照
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["tokyo-highlights", "old-tokyo-shitamachi-tour"]} />`
+
+> **注記**: 既存ツアーIDは `src/pages/tours/` または `TourData` 定義を確認してください。Ueno/Yanaka/Shitamachi対応ツアーIDを正確に使用すること。
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/` 内のYanaka・Ueno関連写真を確認（yanaka-*, ueno-*, shitamachi-*）
+- **不足分（撮影 or ライセンス取得提案）**:
+  - 東京国立博物館 正面外観（フリーアングル）
+  - 谷中ぎんざ商店街 昼間の賑わい
+  - アメ横 夕方の活気（人物・屋台）
+  - 根津神社 つつじ or 通常境内（季節によって差し替え）
+  - 上野公園から不忍池方向の眺め
+
+## Risk notes
+
+- **AI Overview リスク: LOW** — 「ガイドと行くべきか？」「何を優先して見るか？」は主観・体験判断ベースのため、AI Overviewがゼロクリック化するリスクは低い
+- **カニバリリスク: LOW-MEDIUM** — `yanaka-walking-tour-guide`（Yanaka単体）と一部H2がかぶりうる。Section 03の記述をYanaka単体ガイドとは差別化し、「3エリアの連携理解」と「ガイド価値の判断材料」に絞ること
+- **競合難易度: MEDIUM** — TripAdvisor・Japan Guide がUeno個別記事で上位だが「old Tokyo private guide」という複合クエリは DR80+独占ではない。Manabuの一次体験で差別化可能
+- **ファクト変動リスク: MEDIUM** — 博物館入館料・休館日は年次変更あり。Last updated表示と執筆前verification必須
+- **内部競合: 注意** — `asakusa-guide`・`senso-ji-most-visited-temple`と同日掲載しないよう編集カレンダー調整を
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `templates/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/OldTokyoUenoYanakaPrivateGuide.tsx` を作成
+2. `src/pages/es/blog/EsOldTokyoUenoYanakaPrivateGuide.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/old-tokyo-ueno-yanaka-private-guide` と `/es/blog/tokio-antiguo-ueno-yanaka-guia-privado`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. tsc で型チェック
+7. `feature/old-tokyo-ueno-yanaka-private-guide` ブランチ作成 + commit
+
+---
+
+## 選定理由サマリー
+
+| 評価軸 | スコア | 根拠 |
+|--------|--------|------|
+| CV影響 (40%) | ★★★★☆ | Old Tokyoは「ガイド価値が最も可視化しやすいエリア」。is-it-worth-hiring系への橋渡し |
+| 検索量×難易度 (25%) | ★★★☆☆ | Yanaka 813impr + Old Shitamachi 624impr の既存クラスター。Ueno単体はゼロからの積み上げ |
+| 内部リンク強化 (20%) | ★★★★★ | yanaka-walking (71.4% eng/757sec)・old-shitamachi・asakusa への送客ハブになる |
+| Manabuの強み (15%) | ★★★★★ | 歴史試験合格・500+ツアー・博物館案内の一次体験 = 代替不能な差別化ソース |

--- a/seo-pipeline/data/daily/2026-06-01.json
+++ b/seo-pipeline/data/daily/2026-06-01.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-01",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要
本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: One Day in Old Tokyo: Ueno, Yanaka & Shitamachi with a Private Guide
- **slug**: `old-tokyo-ueno-yanaka-private-guide` (EN), `tokio-antiguo-ueno-yanaka-guia-privado` (ES)
- **category**: Neighborhoods（Decision Helper クロスオーバー）
- **priority**: high

## なぜこの案か（GSCデータ根拠）

- `yanaka-tokyo-walking-route` が直近28日で **表示813・エンゲージ71.4%・平均滞在757秒**（サイト最長）。このクラスターに上位ハブ記事が欠けている
- `old-tokyo-shitamachi` も表示624・エンゲージ66.7% — Old Tokyoへの需要は実証済み
- **Ueno単体の記事がサイトに存在しない**（東京主要観光エリアとして大きなギャップ）
- 「private guide判断」フレーミングにより form_submit への高い影響が期待できる

## ⚠️ 技術的注記

`seo-pipeline/data/daily/2026-06-01.json` はGSC APIライブラリ未インストール（`google-api-python-client` 不在）のためエラー。ブリーフの数値は直近実データ（2026-05-22スナップショット）に基づく。

次回Routine実行前に以下を確認してください：
```
pip install google-api-python-client google-auth
```

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] **Manabu独自エピソード（プレースホルダー3箇所）** に実体験を追記
  1. 谷中の「戦争を生き延びた建物」の具体エピソード
  2. 東京国立博物館で必ず案内する展示と理由
  3. アメ横でゲストが一番驚いた光景
- [ ] H2 outline（7セクション）が論理的か
- [ ] competitor_difficulty, ai_overview_risk の評価が妥当か
- [ ] Required facts（8項目）のチェックリストが執筆前に網羅されているか

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-01-old-tokyo-ueno-yanaka-private-guide.md](`https://github.com/mkmanabu122003/private-tour-page-new/blob/claude/daily-brief-2026-06-01/seo-pipeline/briefs/2026-06-01-old-tokyo-ueno-yanaka-private-guide.md)`

---
🤖 Generated by Daily SEO Brief Routine
https://claude.ai/code/session_011jse2ao2FJ8gHipawA21Qe

---
_Generated by [Claude Code](https://claude.ai/code/session_011jse2ao2FJ8gHipawA21Qe)_