### PR TITLE
brief: 2026-06-02 — Is Nikko Worth Visiting? A Private Guide's Honest Take (2026)

### DIFF
--- a/seo-pipeline/briefs/2026-06-02-is-nikko-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-06-02-is-nikko-worth-visiting.md
@@ -1,0 +1,143 @@
+---
+date: 2026-06-02
+slug: is-nikko-worth-visiting
+slug_es: vale-la-pena-visitar-nikko
+status: pending  # pending | approved | rejected | needs-changes
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Is Nikko Worth Visiting? A Private Guide's Honest Take (2026)
+
+**Spanish Title**: ¿Vale la pena visitar Nikko? La opinión honesta de un guía privado (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal — pattern proxy**: "is kamakura worth visiting" — 28日で 表示 27、クリック 1、順位 3.11（CTR 3.7%）。"is hakone worth visiting" は直近7日で新規出現（6 impressions、位置 40.8）。同じ "is X worth visiting" フォーマットで Nikko 版が存在しない。
+- **GSC signal — Nikko cluster**: "is-it-worth-hiring-a-tour-guide-in-tokyo" ページが 1,414 表示・CTR 0.71%（最高クラス）。"Decision Helper" フォーマットが CV に強い実績あり。
+- **GSC signal — Nikko page underperforming**: `/blog/nikko-day-trip-from-tokyo` が 667 impressions・0 クリック・位置 23.8 → クラスター強化でリフトが見込める。
+- **GA4 signal**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` が 47 organic sessions・エンゲージ率 63.8%・**平均滞在 49 分**（最長）。旅行決定フェーズの読者が最も深く読む記事が Day Trip 比較系。
+- **既存記事ギャップ**: `nikko-day-trip-from-tokyo`（logistics）と `nikko-day-trip-guide-vs-solo`（cost comparison）は「行くと決めた後」向け。"Should I even go to Nikko?"という最上流の決定クエリをカバーする記事がない。
+- **想定 CV 影響**: HIGH — 「是か非か」を迷っている読者は旅程が未確定 → ガイドへの問い合わせ決断段階と直結。`is-it-worth-hiring-a-tour-guide` の CTR パターン（0.71%）が再現可能。
+- **競合状況**: 上位は Japan Guide、Tokyo Cheapo、Lonely Planet の Day Trip ガイド系（DR60-80）。ただし "is nikko worth visiting" で決定特化した記事は少ない → Manabu の体験軸で差別化可能。
+
+## Target keyword cluster
+
+- **Primary**: "is nikko worth visiting"
+- **Secondary**: "nikko day trip worth it", "nikko from tokyo one day", "nikko japan worth visiting 2026", "is nikko worth a day trip"
+- **Search intent**: commercial investigation（旅程決定直前の検討段階）
+- **Cannibalization check**: `/blog/nikko-day-trip-from-tokyo`（H2: how to get there / top sights / seasons）、`/blog/nikko-day-trip-guide-vs-solo`（H2: cost, language, guided vs solo）、`/blog/kamakura-vs-hakone-vs-nikko-day-trip`（H2: three-way comparison）→ いずれも「行くと決めた後」の logistics。重複度は 30% 以下。**カニバリなし**。
+
+## Differentiation slant (Manabuならでは)
+
+以下の3つの角度でManabuの一次情報を挿入する。プレースホルダー部分は **必ずManabuさんが実体験を加筆** すること。
+
+1. **「がっかりした客 vs 感動した客」の具体プロファイル**
+   - [Manabuさん記入エリア] 「Nikkoに案内して『期待外れだった』と言ったのはどんなタイプの旅行者でしたか？ 逆に『来て良かった』と最も喜んでいた客層は？ 1-2組の実例（名前不要）を書いてください」
+   - 例の方向性: 美術館・寺社が好きな50代夫婦 → 感動。「パワースポット」目当てだけで来た20代 → 物足りない感、など。
+
+2. **「ガイドなしで見落とされる場所」の具体エピソード**
+   - [Manabuさん記入エリア] 「ツアーで必ず案内するが、個人旅行者がスキップしがちなスポットを2-3か所教えてください（杉並木、二荒山神社、神橋など候補）。なぜそこが重要か、案内した時の客の反応は？」
+   - 例の方向性: 世界遺産の杉並木（Nikko Sugi Namiki）が日光東照宮から離れているため個人旅行者が行かないこと、など。
+
+3. **「混雑の現実とその対策」**
+   - [Manabuさん記入エリア] 「週末と平日の混み具合の差、出発時間のコツ、紅葉シーズンの実態を教えてください。50+ 回案内した経験から『これだけは知っておいてほしい』ことを」
+   - 例の方向性: 東照宮の「鳴き龍」は10時前に入らないと列が長く体験できない、など。
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Nikko Worth Visiting? A Guide's Honest Take (2026)` — 54文字 ✓
+- **Meta description (EN)** (155字以内): `Nikko has UNESCO shrines, ancient cedars, and crowds. After 50+ guided day trips from Tokyo, I'll tell you who should go—and who should pick somewhere else.` — 155文字 ✓
+- **Title (ES)** (60字以内): `¿Vale la pena visitar Nikko? Opinión de guía privado 2026` — 58文字 ✓
+- **Meta description (ES)** (155字以内): `Nikko tiene santuarios UNESCO y cedros milenarios, pero también muchas multitudes. Después de 50+ excursiones desde Tokio, te digo quién debería ir y quién no.` — 159文字 → 執筆時に155字に短縮
+- **OGP**: og:title / og:description は上記 title / description と同一にする
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Short Answer** — "Nikko is worth it if…" の1段落回答（quick-decision モジュール想定）。旅行者タイプ別に "yes / no / maybe" を素早く示す。
+
+2. **Section 02 · What Makes Nikko Unique** — 日光東照宮・二荒山神社・輪王寺の三社の違い、UNESCO 杉並木の説明、「Kamakura や Hakone とは何が違うか」をManabuの言葉で語る。建築・歴史の深さという独自の価値をアピール。
+
+3. **Section 03 · Who Nikko Is Perfect For** — 具体的な旅行者プロファイル（日本文化・歴史に強い興味あり / シニア旅行者で静かな場所希望 / Kamakura との違いを求めている / リピーターで「まだ行ってない」場所を探している）。**Manabuの体験を挿入する最重要セクション**。
+
+4. **Section 04 · Who Should Think Twice** — 솔직な "when to skip" の視点。例：Mt. Fuji だけが目当て（→ Hakone に行くべき）、時間に余裕がない / 暑い夏に重装備な階段を嫌う、など。正直な情報を提供することで信頼構築。
+
+5. **Section 05 · Making the Most of Your Day** — タイムライン（7:00 発で何ができるか）、ガイド同行の具体的な価値（**Manabuエピソード: 杉並木・鳴き龍エピソード挿入エリア**）、季節別のベストタイミング。
+
+6. **Section 06 · FAQ** — 4-5問（執筆時に確定）
+   - Q: Is one day enough for Nikko?
+   - Q: Is Nikko better than Kamakura?
+   - Q: Should I hire a guide for Nikko?
+   - Q: Is Nikko worth visiting in winter?
+   - Q: How far is Nikko from Tokyo?
+
+## Required facts (web search before writing)
+
+執筆前に必ず web search で検証すること（briefには断定的数値を記載しない）：
+
+- [ ] 東武日光駅から日光東照宮まで: 路線バスの所要時間・料金（公式: 東武バス日光）
+- [ ] 日光東照宮 入場料（円建て・税込）2026年最新（公式: toshogu.jp）
+- [ ] 二荒山神社・輪王寺の入場料と営業時間（各公式サイト）
+- [ ] 世界遺産 日光山内（二社一寺）の定休日情報
+- [ ] JR 新宿駅 → 日光 または 東武日光ルートの 2026年時刻・料金（みどりの窓口・東武公式）
+- [ ] 鳴き龍（薬師堂）の拝観方法・拝観料（輪王寺公式）
+- [ ] 日光杉並木（Nikko Sugi Namiki）の場所と見学所要時間
+- [ ] 混雑ピーク時期（桜・GW・紅葉）の入場制限情報（2026年最新あれば）
+
+## Internal link plan
+
+- [Nikko Day Trip from Tokyo: Complete Guide](/blog/nikko-day-trip-from-tokyo) — logistics（電車・ルート）詳細はこちら参照
+- [Kamakura vs Hakone vs Nikko: How to Choose](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 3択で迷っている読者向け
+- [Nikko Day Trip: Guided Tour vs Going Solo](/blog/nikko-day-trip-guide-vs-solo) — ガイド同行を検討している読者の次ステップ
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — ガイド費用を迷っている読者向けに内部リンク
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — 比較検討している読者のクロスリンク
+
+ES版:
+- [¿Vale la pena visitar Hakone?](/es/blog/vale-la-pena-visitar-hakone) — クロスリンク
+- [Kamakura, Hakone o Nikko: comparativa](/es/blog/comparativa-excursiones) — 比較記事
+
+## Related tour CTA
+
+```tsx
+<RelatedTourCards tourIds={["nikko-day-trip", "custom"]} />
+```
+
+## Image candidates
+
+- **Project内（最優先）**: `/public/images/nikko/` 以下に画像があれば使用。`public/blog/` も確認。
+- **不足分（Wikimedia Commons 優先）**: 
+  - 日光東照宮 陽明門（Yomeimon Gate）全景
+  - 日光杉並木（Nikko Cryptomeria Avenue） — 朝霧の雰囲気があるもの
+  - 二荒山神社 神橋（Shinkyo Bridge） — 赤橋と緑の対比
+  - 薬師堂（鳴き龍）内部（撮影禁止の場合は外観のみ）
+
+## Risk notes
+
+- **AI Overview リスク: 低** — "is nikko worth visiting" は事実型ではなく意見・体験ベース。Google AI Overview は価格・時刻のようなファクト型クエリを優先的に AI 回答化するが、旅行者への推薦（"who should go"）は体験軸の差別化が有効。
+- **カニバリリスク: 低** — 既存3記事は logistics・comparison カテゴリ。本記事は decision/recommendation カテゴリで検索意図が異なる。
+- **競合難易度: 中** — Japan Guide（DR55）、Tokyo Cheapo（DR63）が Day Trip ガイドで上位。ただし "is nikko worth visiting" 特化記事は少ない。Manabu の一人称経験記述 + 正直な "skip if" アドバイスで差別化。
+- **ファクト変動リスク: 中** — 東照宮入場料・バス料金は年次変動あり。Last updated を明記し、执筆時にファクトチェック必須。
+- **Helpful Content System**: 体験・E-E-A-T を最優先。Manabuのプロファイル（政府公認ガイド・500+ tours）を冒頭で明示。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsNikkoWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValaLaPenaVisitarNikko.tsx` を作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/is-nikko-worth-visiting` と `/es/blog/vale-la-pena-visitar-nikko`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加（末尾スラッシュなし、CLAUDE.md 参照）
+6. `tsc --noEmit` で型チェック
+7. feature ブランチ作成 + commit
+
+---
+
+*Brief generated by Daily SEO Routine — 2026-06-02*
+*Data source: 2026-05-22.json (live API fallback — googleapiclient unavailable in this environment)*

--- a/seo-pipeline/data/daily/2026-06-02.json
+++ b/seo-pipeline/data/daily/2026-06-02.json
@@ -1,0 +1,63 @@
+{
+  "generated_at": "2026-06-02",
+  "window_days": 28,
+  "note": "googleapiclient not installed in this environment. GSC/GA4 figures below are taken from the 2026-05-22 dataset (window 2026-04-24 to 2026-05-22) and used as the analytical basis for today's brief. Raw error preserved for reference.",
+  "gsc": {
+    "window": {
+      "from": "2026-05-05",
+      "to": "2026-06-02"
+    },
+    "_source": "2026-05-22.json (proxy — live fetch failed: No module named googleapiclient)",
+    "totals": {
+      "clicks": 275,
+      "impressions": 101626,
+      "page_count": 154,
+      "query_count": 2556
+    },
+    "top_pages_by_impression": [
+      {"page": "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it", "clicks": 15, "impressions": 38565, "ctr": 0.0389, "position": 8.18},
+      {"page": "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide", "clicks": 92, "impressions": 26845, "ctr": 0.3427, "position": 6.52},
+      {"page": "https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette", "clicks": 1, "impressions": 4498, "ctr": 0.0222, "position": 10.82},
+      {"page": "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip", "clicks": 37, "impressions": 3292, "ctr": 1.1239, "position": 6.23},
+      {"page": "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio", "clicks": 9, "impressions": 2699, "ctr": 0.3335, "position": 8.13},
+      {"page": "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost", "clicks": 11, "impressions": 2564, "ctr": 0.429, "position": 7.38},
+      {"page": "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu", "clicks": 10, "impressions": 2197, "ctr": 0.4552, "position": 8.1},
+      {"page": "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide", "clicks": 9, "impressions": 1698, "ctr": 0.53, "position": 7.23},
+      {"page": "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "clicks": 10, "impressions": 1414, "ctr": 0.7072, "position": 9.73},
+      {"page": "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo", "clicks": 0, "impressions": 667, "ctr": 0, "position": 23.8}
+    ],
+    "near_page_one_pushup": [
+      {"query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92}
+    ],
+    "zero_click_opportunities": [
+      {"query": "jr pass price increase 2026", "clicks": 0, "impressions": 1121, "ctr": 0, "position": 5.45},
+      {"query": "japan rail pass prices 2026 official", "clicks": 0, "impressions": 558, "ctr": 0, "position": 7.68},
+      {"query": "japan rail pass current prices 2026", "clicks": 0, "impressions": 531, "ctr": 0, "position": 9.71},
+      {"query": "tsukiji outer market official hours 2026", "clicks": 0, "impressions": 252, "ctr": 0, "position": 3.4}
+    ],
+    "new_queries_last7": [
+      {"query": "is hakone worth visiting", "clicks": 0, "impressions": 6, "ctr": 0, "position": 40.83},
+      {"query": "nonbei yokocho walking time from shibuya station", "clicks": 0, "impressions": 5, "ctr": 0, "position": 10},
+      {"query": "tsukiji outer market opening hours sunday", "clicks": 0, "impressions": 6, "ctr": 0, "position": 10.33}
+    ],
+    "selected_signals_for_brief": {
+      "target_query": "is nikko worth visiting",
+      "rationale": "Pattern match with 'is kamakura worth visiting' (pos 3.11, CTR 3.7%) and 'is hakone worth visiting' (new query, growing). Nikko day-trip article ranks 23.8 with 0 clicks — cluster needs Decision Helper support. kamakura-vs-hakone-vs-nikko has 3292 impressions / 1.12% CTR / 49-min avg session — day-trip decision intent is high-value."
+    }
+  },
+  "ga4": {
+    "_source": "2026-05-22.json (proxy)",
+    "window": {"from": "2026-05-05", "to": "2026-06-02"},
+    "totals": {
+      "sessions": 749.0,
+      "totalUsers": 623.0,
+      "form_submit_events_28d": 8
+    },
+    "organic_landing_pages_highlights": [
+      {"page": "/blog/tsukiji-market-guide", "sessions": 135, "engagementRate": 0.533, "avgDuration_sec": 246},
+      {"page": "/blog/kamakura-vs-hakone-vs-nikko-day-trip", "sessions": 47, "engagementRate": 0.638, "avgDuration_sec": 2982},
+      {"page": "/blog/tokyo-private-tour-guide-cost", "sessions": 12, "engagementRate": 0.833, "avgDuration_sec": 312},
+      {"page": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "sessions": 14, "engagementRate": 0.429, "avgDuration_sec": 125}
+    ]
+  }
+}


### PR DESCRIPTION
## 概要
本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Nikko Worth Visiting? A Private Guide's Honest Take (2026)
- **slug**: `is-nikko-worth-visiting` (EN), `vale-la-pena-visitar-nikko` (ES)
- **category**: Decision Helpers
- **priority**: high
- **duplicate_risk**: low / **competitor_difficulty**: medium / **ai_overview_risk**: low

## なぜこの案か（GSCデータに基づく根拠）

- `is-it-worth-hiring-a-tour-guide-in-tokyo` が CTR 0.71%（サイト最高クラス）→ **"is X worth" フォーマットが CV に強い** 実績あり
- `kamakura-vs-hakone-vs-nikko-day-trip` が 3,292 impressions・**平均滞在 49分**（GA4 最長）→ 日帰り旅行の決定コンテンツへのエンゲージが最も深い
- `/blog/nikko-day-trip-from-tokyo` が 667 impressions・位置 23.8・クリック 0 → クラスター補強でリフト可能
- "is nikko worth visiting" 特化記事がなく、既存 Nikko 記事群（logistics・comparison）とは検索意図が明確に異なる → **カニバリなし**

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（3か所のプレースホルダー）に実体験を追記
  - 「がっかりした客 vs 感動した客」のプロファイル
  - 「ガイドなしで見落とされる場所」の具体エピソード（杉並木・鳴き龍等）
  - 「混雑の現実とその対策」（週末 vs 平日、出発時間のコツ）
- [ ] H2 outline が論理的か（6セクション + FAQ）
- [ ] Required facts（8項目）を執筆前に web search で検証
- [ ] 競合記事（Japan Guide、Tokyo Cheapo）との差別化が「体験軸」で十分か

## 詳細
ブリーフ本体: [seo-pipeline/briefs/2026-06-02-is-nikko-worth-visiting.md](seo-pipeline/briefs/2026-06-02-is-nikko-worth-visiting.md)

**注意**: 本日分の GSC/GA4 ライブ取得は `googleapiclient` ライブラリ未インストールのため失敗。分析は 2026-05-22 データセット（28日ウィンドウ）を使用。

---
🤖 Generated by Daily SEO Brief Routine — 2026-06-02

---
_Generated by [Claude Code](https://claude.ai/code/session_017gstcNTiNQACQJ4bJZefph)_