### PR TITLE
brief: 2026-06-03 — Kawagoe Day Trip: Private Guide vs. Solo 2026

### DIFF
--- a/seo-pipeline/briefs/2026-06-03-kawagoe-day-trip-guide-vs-solo.md
+++ b/seo-pipeline/briefs/2026-06-03-kawagoe-day-trip-guide-vs-solo.md
@@ -1,0 +1,126 @@
+---
+date: 2026-06-03
+slug: kawagoe-day-trip-guide-vs-solo
+slug_es: kawagoe-excursion-guia-privado-o-solo
+status: pending
+priority: high
+category: Day Trips
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: medium
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Kawagoe Day Trip: Private Guide vs. Solo — Which One Is Worth It in 2026?
+
+**Spanish Title**: Kawagoe: ¿Guía Privado o Solo en la «Pequeña Edo»? (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (2026-05-22 window, 28d)**: The guide-vs-solo format is the site's highest-CTR decision cluster. `hakone-day-trip-guide-vs-solo` earned **2.23% CTR** (9 clicks / 404 impressions, pos 21.2) — nearly 9× the site average CTR of 0.25%. `kamakura-vs-hakone-vs-nikko-day-trip` drove **47 organic sessions with an average session duration of 49.7 minutes** — the strongest engagement signal in the GA4 dataset. The guide-vs-solo angle for Kawagoe replicates this format in an uncontested keyword space.
+- **既存記事ギャップ**: `kawagoe-day-trip-from-tokyo` covers solo logistics (train route, timing, what to see) but does **not** address "should I hire a guide for Kawagoe?" The decision-helper intent is unserved. `kawagoe-day-trip-from-tokyo` did not appear in the top-30 pages by impression in the 28-day window, confirming the existing article has low impression share — a decision-angle article targets a distinct cluster without cannibalising.
+- **想定CV影響**: high — Kawagoe attracts culturally-motivated travellers who value historical depth; this audience overlaps closely with Manabu's ideal booking profile. The article sits one step upstream of a contact form submission.
+- **競合状況**: Primary competitors are generic Japan travel blogs (Japan Travel, Japan Guide, Klook Blog) and Viator listing pages. None addresses Kawagoe from a licensed-guide perspective with a decision-helper framing. DR gap is workable with strong differentiation.
+- **⚠️ Data note**: 2026-06-03 GSC/GA4 fetch failed — `google-api-python-client` module not installed in execution environment. All signals above are from the 2026-05-22 28-day baseline. Today's `data/daily/2026-06-03.json` contains only the error record; re-run `pip install google-api-python-client google-auth && python3 seo-pipeline/scripts/fetch_daily.py` to populate fresh data.
+
+## Target keyword cluster
+
+- **Primary**: "kawagoe day trip private guide"
+- **Secondary**: "kawagoe guide vs solo", "kawagoe private tour from tokyo", "is kawagoe worth visiting with a guide", "little edo tokyo private guide", "kawagoe guided tour 2026"
+- **Search intent**: commercial investigation / decision (user deciding whether to hire a guide for a specific day trip)
+
+## Differentiation slant (Manabuならでは)
+
+> 以下は提案フレームです。Manabuさんの実体験で補足・修正してください。
+
+1. **歴史の深読みが差別化になる**: 川越の蔵造りは単なる「古い建物」ではなく、1893年の大火後に商人階級が防火・財産保護のために建てた生存戦略の産物。全国通訳案内士として日本史を体系的に学んだManabuだからこそ、建物の構造が語る江戸・明治商人文化を説明できる（"Most tourists photograph the building; I explain why it was built that way and whose money paid for it"）。
+   > **[Manabuさんへ: この解説をゲストにした際に相手が驚いた・感動したエピソードを1〜2文で追記してください]**
+
+2. **観光客が見逃す時間帯の知識**: 菓子屋横丁と蔵造り一番街は午前9〜10時が最も静かで写真映えする。団体バスは11時以降に到着するため、ガイドとともに早朝スタートするだけで体験の質が大きく変わる。
+   > **[Manabuさんへ: 朝イチの川越で印象的だったゲストとのエピソードを1文で追記してください]**
+
+3. **ガイドした実体験の具体性**: Manabu has guided 500+ private tours across the Kanto region. Kawagoe's proximity to Tokyo (30 minutes from Ikebukuro) makes it a natural extension of his day-trip expertise alongside Kamakura, Nikko, and Hakone.
+   > **[Manabuさんへ: 川越でガイドした経験の有無・回数・印象に残ったゲスト層を教えてください。経験がない場合は「現在ツアーメニュー拡張中」のフレームで書きます]**
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Kawagoe Day Trip: Private Guide vs. Solo 2026`
+- **Meta description (EN)** (155字以内): `Planning Kawagoe from Tokyo? Licensed guide Manabu compares solo vs. private guide — Edo history, hidden spots & honest 2026 costs.`
+- **Title (ES)** (60字以内): `Kawagoe: ¿Guía Privado o Solo en la «Pequeña Edo»? 2026`
+- **Meta description (ES)** (155字以内): `¿Guía privado para Kawagoe o ir solo? Manabu, guía oficial en Tokio, compara ambas opciones: historia oculta, rincones exclusivos y costos reales 2026.`
+
+## H2 outline (6 sections + FAQ)
+
+1. **Section 01 · Why Kawagoe Rewards a Deeper Look** — What makes "Little Edo" historically distinct from other day trips; why the kurazukuri warehouses are more than a backdrop for photos; why cultural context matters more here than at most Kanto destinations (~300 words, scene-setting)
+2. **Section 02 · Going Solo: What Works and What Doesn't** — Logistics (Ikebukuro → Hon-Kawagoe, Tobu Tojo Line, ~30 min); what English-speakers can access comfortably alone; honest friction points: minimal English signage in side streets, no interpretation of historical significance, crowd timing, choosing between Kashiya Yokocho and Kurazukuri without context (~400 words)
+3. **Section 03 · With a Private Guide: What Actually Changes** — Concrete examples: warehouse history explained, Kashiya Yokocho vendor stories, hidden alleys and non-tourist lunch spots, flexible pace for photography, early-morning timing advantage; what Manabu does specifically vs. a generic tour operator (~400 words, Manabu's episode placeholder here)
+4. **Section 04 · The Cost Comparison** — Solo cost breakdown (Tobu Tojo train + Seibu Shinjuku Line options, entry fees for Kawagoe Castle / City Museum, lunch) vs. private guide fee per person by group size; honest break-even point (~300 words — verify all prices before writing)
+5. **Section 05 · Who Should Hire a Guide for Kawagoe?** — Decision matrix: history / culture enthusiasts → YES; Instagrammers focused on architecture photos → MAYBE; repeat Japan visitors who've already done Kamakura → HIGHLY YES; first-timers with limited Japan days → YES; travellers combining with Nikko or Kamakura same day → NO (too far) (~300 words)
+6. **Section 06 · Practical Planning** — Best seasons (spring cherry blossoms at Kita-in temple, autumn Kawagoe Festival in October); half-day vs. full-day; what to skip if time is short; combining with Omiya Bonsai Village for a longer day (~250 words)
+7. **Section 07 · FAQ** — 5 questions (see below)
+
+**FAQ questions**:
+- Is Kawagoe easy to visit without a guide?
+- How long does a Kawagoe day trip take from Tokyo?
+- Can I combine Kawagoe with Kamakura or Nikko in one day?
+- Is the Kawagoe Festival worth timing my trip around?
+- How do I book Manabu for a Kawagoe day trip?
+
+## Required facts (web search before writing)
+
+記事執筆前にweb searchで必ず公式ソースを確認：
+
+- [ ] 東武東上線 池袋→川越駅 所要時間・運賃（東武鉄道公式、2026年）
+- [ ] 西武新宿線 西武新宿→本川越駅 所要時間・運賃（西武鉄道公式、2026年）
+- [ ] 川越城本丸御殿 入場料・開館時間・定休日（埼玉県公式サイト）
+- [ ] 川越市立博物館 入場料・開館時間・定休日（川越市公式）
+- [ ] 菓子屋横丁の営業時間目安（川越市観光協会または各店舗）
+- [ ] 川越まつり（川越祭り）2026年開催日程（川越祭り公式サイト）
+- [ ] 喜多院 拝観料・時間（喜多院公式サイト）
+
+## Internal link plan
+
+- [Kawagoe Day Trip from Tokyo](/blog/kawagoe-day-trip-from-tokyo) — logistics bridge; readers who decide to go solo continue here for practical how-to detail
+- [Kamakura Day Trip: Guide vs. Solo](/blog/kamakura-day-trip-guide-vs-solo) — parallel format; cross-reference when comparing which day trip needs a guide more
+- [Best Day Trips from Tokyo](/blog/best-day-trips-from-tokyo) — contextualise where Kawagoe fits among all Kanto day-trip options
+- [Group vs. Private Tour Tokyo](/blog/group-vs-private-tour-tokyo) — upstream decision helper for readers not yet committed to private guide format
+- [Hakone Day Trip: Guide vs. Solo](/blog/hakone-day-trip-guide-vs-solo) — cross-link within the guide-vs-solo cluster; readers comparing Kawagoe vs. Hakone
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["kamakura-day-trip", "custom"]} showViewAll />`
+
+> Note: Kawagoe is currently offered as a custom tour inquiry (no dedicated tour page). Use `"custom"` CTA linking to /contact. If a Kawagoe tour page is created before article launch, update tourId accordingly.
+
+## Image candidates
+
+- **Project内（最優先）**: `/public/images/` 内にKawagoe・蔵造り・Little Edoの写真があれば優先使用
+- **不足分の探し先**:
+  - 蔵造り一番街の外観（夜明け〜朝イチが望ましい）→ Wikimedia Commons "Kawagoe Kurazukuri" でCC-BY/CC0を検索
+  - 時の鐘（Toki no Kane 鐘楼）→ パブリックドメイン画像あり
+  - 菓子屋横丁の色鮮やかな飴・駄菓子 → Unsplash "kawagoe candy" または "kashiya yokocho"
+  - 川越祭り山車（記事をOctober前公開する場合）→ 川越市公式素材を確認
+
+## Risk notes
+
+- **Cannibalization risk (MEDIUM)**: `kawagoe-day-trip-from-tokyo` targets logistics intent; this article targets decision intent. Differentiate clearly in title, intro, and H2 structure. Monitor GSC for shared keyword impressions after publishing; if overlap exceeds 70% on key queries, consider adding `rel="canonical"` pointer or merging sections.
+- **AI Overview risk (LOW)**: Decision/comparison content is judgment-based and less likely to be captured by AI Overview. Avoid inserting bare factual lists (hours, prices) without qualitative context — isolated facts increase featured snippet risk and reduce click incentive.
+- **Helpful Content System**: Manabu's personal episode placeholders (Section 03 and Differentiation Slant) **must be filled with real anecdotes before publishing**. Generic additions will not satisfy first-hand experience requirements.
+- **Seasonal timing**: Article published in June 2026 — mention October Kawagoe Festival as a forward-looking angle that creates urgency for early booking.
+- **No dedicated tour page**: There is no `/tours/kawagoe-day-trip` at time of brief creation. Either create the tour page before article launch (preferred for CTA cohesion) or route CTA to /contact with a Kawagoe note in the form.
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/KawagoeDayTripGuideVsSolo.tsx` を作成
+2. `src/pages/es/blog/EsKawagoeDayTripGuideVsSolo.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加:
+   - EN: `/blog/kawagoe-day-trip-guide-vs-solo`
+   - ES: `/es/blog/kawagoe-excursion-guia-privado-o-solo`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. `tsc --noEmit` で型チェック
+7. feature ブランチ `article/kawagoe-day-trip-guide-vs-solo` を作成 + commit

--- a/seo-pipeline/data/daily/2026-06-03.json
+++ b/seo-pipeline/data/daily/2026-06-03.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-03",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Kawagoe Day Trip: Private Guide vs. Solo 2026
- **slug**: `kawagoe-day-trip-guide-vs-solo` (EN), `kawagoe-excursion-guia-privado-o-solo` (ES)
- **category**: Day Trips
- **priority**: high

## なぜこの案か

guide-vs-solo フォーマットがサイト最高CTRクラスターであることをGSCデータが示しています。`hakone-day-trip-guide-vs-solo` は CTR **2.23%**（サイト平均0.25%の約9倍）、`kamakura-vs-hakone-vs-nikko-day-trip` はGA4で平均滞在時間**49.7分**を記録。川越は同フォーマットで未開拓の目的地。既存の `kawagoe-day-trip-from-tokyo`（logistics intent）とは異なる decision intent を狙い、カニバリリスクを許容範囲に抑えています。

> ⚠️ **データ取得エラー**: `google-api-python-client` モジュール未インストールのため、2026-06-03 のGSC/GA4フェッチが失敗しました。ブリーフは2026-05-22の28日間ベースラインデータに基づいています。`pip install google-api-python-client google-auth` 後に再実行してください。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Section 03「With a Private Guide」のManabu独自エピソード（プレースホルダー3箇所）に実体験を追記
- [ ] 川越でガイドした経験の有無を確認（未経験の場合はフレーム調整）
- [ ] Required facts（営業時間・交通費・拝観料）を公式サイトで検証してから執筆
- [ ] `kawagoe-day-trip-from-tokyo` との差別化が明確かを再確認
- [ ] 川越祭り2026開催日程を追記（季節アングル）

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-03-kawagoe-day-trip-guide-vs-solo.md](seo-pipeline/briefs/2026-06-03-kawagoe-day-trip-guide-vs-solo.md)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01616vakGSfQvfEgLmXkUB2f)_