### PR TITLE
brief: 2026-06-04 — Is Nikko Worth Visiting? A Private Guide's Honest Answer (2026)

### DIFF
--- a/seo-pipeline/briefs/2026-06-04-is-nikko-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-06-04-is-nikko-worth-visiting.md
@@ -1,0 +1,120 @@
+---
+date: 2026-06-04
+slug: is-nikko-worth-visiting
+slug_es: vale-la-pena-visitar-nikko
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: medium
+---
+
+# Is Nikko Worth Visiting? A Private Guide's Honest Answer (2026)
+
+**Spanish Title**: ¿Vale la Pena Visitar Nikko? La Opinión Honesta de un Guía Privado (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal**: 「hakone or nikko」直近28日で表示 **45**・クリック 1・順位 **8.92**、「hakone vs nikko」表示 **48**・クリック 1・順位 **8.92**、「nikko or kamakura」表示 **10**・クリック 1・順位 **13.0** — どれもページ1 push-up 圏内。さらに `/blog/nikko-day-trip-from-tokyo` ページは表示 **667**・クリック **0**・順位 **23.8** と深刻なゼロクリック状態で、意思決定フェーズを担う記事が欠落していることを示す。
+- **既存記事ギャップ**: `kamakura-vs-hakone-vs-nikko-day-trip` は GA4 セッション 47・平均滞在時間 **2,982 秒（≈49 分）** で比較コンテンツへの圧倒的需要を証明しているが、「日光に行く価値はあるか？」という単独の意思決定クエリに直接答える記事が存在しない。`is-hakone-worth-visiting` が最近追加されており、Nikko 版は自然な系列拡張。
+- **想定CV影響**: **high** — 「日光 or 箱根」「日光 or 鎌倉」で迷っている読者は day trip の booking 直前フェーズ。記事末の `nikko-day-trip` ツアー CTA への直接誘導が可能で form_submit への影響は大きい。
+- **競合状況**: 「is nikko worth visiting」上位は Japan Guide・Two Wandering Soles・Lonely Planet（DR 65–80+）。ただし「guide's honest take」「worth it for first-timers vs history buffs」のニッチ slant は独占されておらず、DR20 圏でも差別化で戦える余地がある。
+
+## Target keyword cluster
+
+- **Primary**: "is nikko worth visiting"
+- **Secondary**: "nikko or kamakura", "hakone or nikko", "nikko day trip worth it", "is nikko worth a day trip", "nikko for one day"
+- **Search intent**: commercial / decision（旅行前のデスティネーション選定フェーズ）
+
+## Differentiation slant (Manabuならでは)
+
+> ⚠️ 以下 3 点は Manabu さんの一次体験プレースホルダーです。執筆・レビュー時に実体験を追記してください。Claude は代筆できない領域です。
+
+1. **「旅行者タイプ別の正直な verdict」**: 500 ツアー超を案内した Manabu が「あなたのプロフィールなら日光は worth it か否か」を断言するトーンで書く（例：「美術・建築好きには絶対おすすめ。ただし下町散歩と食が目的なら浅草+谷中で十分です」）。
+   - [Manabuさん: 実際に案内したお客様で「行って正解だった」「行かなくてよかったかも」と感じた具体的な場面を 1〜2 文挿入してください]
+
+2. **「ガイドだけが知る"日光の落とし穴"」**: 日光は観光エリアが広大で、多くのツーリストが「東照宮だけ見て終わり」状態で帰る。陽明門・眠り猫・奥宮の意味は英語案内板だけでは伝わらない。徳川家康の生涯と江戸幕府の正当性の文脈がないと、「ただの派手な建物」で終わる。
+   - [Manabuさん: 一人で来たお客様が後悔していたエピソード、またはガイド付きで来た方が「わかった！」となった瞬間の具体例を挿入してください]
+
+3. **「往復2時間を"損"と感じさせないコツ」**: 東京から日光まで東武特急で約2時間。この距離感が「worth it か否か」の最大の懸念点。Manabu が車中でする歴史の予習トーク、帰り道に立ち寄れる隠れスポットの案内で、移動時間ごとコンテンツ化する方法。
+   - [Manabuさん: 電車内でのエピソードや帰路の立ち寄りスポットがあれば追記してください]
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Nikko Worth Visiting? A Local Guide's Honest Answer (2026)`
+- **Meta description (EN)** (155字以内): `After 500+ private tours, Manabu gives his honest take on whether Nikko is worth visiting — and when Kamakura or Hakone is the better choice for your trip.`
+- **Title (ES)** (60字以内): `¿Vale la Pena Visitar Nikko? Opinión de un Guía Local (2026)`
+- **Meta description (ES)** (155字以内): `Tras más de 500 tours privados, Manabu da su opinión honesta sobre si Nikko vale la pena — y cuándo elegir Kamakura o Hakone en su lugar.`
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Verdict** — quick-decision ボックス。読者プロフィール別（初来日 / リピーター / 歴史建築好き / 自然・温泉目的 / シニア家族連れ）に Yes/No を 5 秒で提示する。Manabuの「正直な結論」をここで出し切る
+2. **Section 02 · What Makes Nikko Different from Hakone and Kamakura** — 3 つのデスティネーションの本質的な違い（歴史建築 vs 自然 vs 古都）を整理。「Nikko は日本一"説明のいる"観光地」という軸で差別化
+3. **Section 03 · Who Should Go — and Who Should Skip** — Manabuの体験談を核に「行くべき人・行かなくていい人」を具体的に分類。旅行者タイプ別の正直な推奨を述べる
+4. **Section 04 · The Travel Reality — Time, Cost, and Logistics** — 東武特急 vs JR ルートの比較。所要時間・費用（執筆時に要検証）。「1日で足りるか？」を正直に回答。ランチ・ベストシーズンにも触れる
+5. **Section 05 · Why Nikko Rewards a Guide (More Than Anywhere Else in Tokyo Area)** — 英語案内板の限界・徳川信仰の文脈がガイドなしで理解できない理由。ツアー CTA への自然な誘導
+6. **Section 06 · FAQ** — 4–5 問
+   - Is one day enough for Nikko?
+   - Nikko or Kamakura — which should I choose?
+   - Is Nikko worth it in winter / rainy season?
+   - Is Nikko family-friendly?
+   - Do I need a guide for Nikko?
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 東武日光線 特急スペーシア X の料金（浅草〜東武日光、2026年時点の運賃・特急料金）と所要時間
+- [ ] JR 新宿〜日光ルート（湘南新宿ライン + 日光線）の料金と所要時間
+- [ ] 東照宮・輪王寺・大猷院の拝観料（円建て税込、2026年版）
+- [ ] 東照宮の開門・閉門時間と定休日（2026年版）
+- [ ] 世界遺産めぐりバス（日光）の料金と本数
+- [ ] 日光二社一寺エリア全体の徒歩所要時間目安
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura vs Hakone vs Nikko: Which Day Trip Is Right for You?](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 「まだ 3 択で迷っている方は」の文脈でピラー記事に誘導
+- [Hakone vs Nikko Day Trip](/blog/hakone-vs-nikko-day-trip) — "Hakone or Nikko?" セクションからの直接比較
+- [Nikko Day Trip from Tokyo: Complete Guide](/blog/nikko-day-trip-from-tokyo) — アクセス・ルート詳細の深掘り記事へ
+- [Nikko with a Guide vs Solo](/blog/nikko-day-trip-guide-vs-solo) — Section 05「ガイドの価値」から自然にリンク
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — 「同じ問いを箱根で考えると…」の相互リンク
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["nikko-day-trip"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/nikko-*` または `public/images/tours/nikko-*` を確認
+- **不足分（Wikimedia / Unsplash 提案）**: 陽明門（Yomeimon Gate）の正面写真、奥日光の紅葉、東武スペーシア X の外観、家族・カップルが鳥居前に立つ構図
+
+## Risk notes
+
+- **AI Overview リスク（中）**: "is nikko worth visiting" は意見・判断クエリのため AI Overview による完全吸収は起きにくい。ただし「アクセス方法・料金」セクションは情報型でゼロクリック化リスクあり → 価格情報を主軸にせず「判断基準・体験の質」に重心を置く構成で回避
+- **カニバリリスク（低）**: `nikko-day-trip-from-tokyo` はアクセス実践記事、`nikko-day-trip-guide-vs-solo` はガイド有無の比較記事、`kamakura-vs-hakone-vs-nikko-day-trip` は 3 択比較ピラー。本記事は「そもそも日光に行く価値があるか」の意思決定フェーズを担い、セマンティック重複度は 30% 未満と判断
+- **ファクト変動リスク**: 東武特急料金・東照宮拝観料は年次変動あり → Last updated を前面に表示、執筆時に公式サイトで確認必須
+- **競合過密リスク（中）**: 「nikko day trip from tokyo」は DR65–80+ が上位だが、「is nikko worth visiting + guide's take」ニッチは直接競合が薄く、Manabu の一次情報で差別化可能
+
+---
+
+## データ取得ノート（自動生成）
+
+本 brief は 2026-05-22 の GSC + GA4 データ（直近28日: 2026-04-24 〜 2026-05-22）を分析して生成。
+2026-06-04 のデータ取得は `googleapiclient` ライブラリ未インストールのため API エラーとなった（`seo-pipeline/data/daily/2026-06-04.json` にエラー記録済み）。
+本番運用では `pip install google-api-python-client google-auth` を Routine 環境に追加してください。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsNikkoWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValeLaPenaVisitarNikko.tsx` も作成（hreflang 対応）
+3. `src/AppRoutes.tsx` に import + Route 追加
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に 2 URL 追加（`/blog/is-nikko-worth-visiting` と `/es/blog/vale-la-pena-visitar-nikko`）
+6. `tsc` で型チェック
+7. feature ブランチ作成 + commit

--- a/seo-pipeline/data/daily/2026-06-04.json
+++ b/seo-pipeline/data/daily/2026-06-04.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-04",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Nikko Worth Visiting? A Private Guide's Honest Answer (2026)
- **slug**: `is-nikko-worth-visiting` (EN), `vale-la-pena-visitar-nikko` (ES)
- **category**: Decision Helpers
- **priority**: high

## データ根拠（なぜ日光「worth it?」記事か）

| シグナル | 数値 |
|---|---|
| `hakone or nikko` GSC 表示 | 45 / 28日・順位 8.92 |
| `hakone vs nikko` GSC 表示 | 48 / 28日・順位 8.92 |
| `nikko or kamakura` GSC 表示 | 10 / 28日・順位 13.0 |
| `nikko-day-trip-from-tokyo` ページ | 667表示・0クリック・順位 23.8（深刻なゼロクリック） |
| `kamakura-vs-hakone-vs-nikko` GA4 | 47セッション・**平均2,982秒（49分）** |

→ 比較コンテンツへの需要は実証済み。「日光に行く価値があるか？」の単独意思決定記事が欠落。

## チェックリスト（Manabuさん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus 指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] **Manabuさん独自エピソード**（3箇所のプレースホルダー）に実体験を追記
  - お客様が「行って正解」「行かなくてよかった」となった場面
  - ガイドなしでは伝わらない陽明門のエピソード
  - 電車内での予習トークや帰路の立ち寄りスポット
- [ ] H2 アウトラインが論理的か確認
- [ ] Required facts（東武特急料金・東照宮拝観料・所要時間）を web search で検証

## 記事の差別化スラント

1. **旅行者タイプ別の正直な verdict** — 初来日/リピーター/歴史好き/シニア家族別に Yes/No を断言
2. **「ガイドだけが知る日光の落とし穴」** — 英語案内板の限界・徳川信仰の文脈
3. **往復2時間を"損"と感じさせないコツ** — 移動時間ごとコンテンツ化

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-04-is-nikko-worth-visiting.md](https://github.com/mkmanabu122003/private-tour-page-new/blob/claude/daily-brief-2026-06-04/seo-pipeline/briefs/2026-06-04-is-nikko-worth-visiting.md)

---
⚠️ **APIデータ取得について**: 本番環境に `google-api-python-client` がインストールされていないため、本日のGSC/GA4リアルタイムデータ取得はエラーとなりました。分析は 2026-05-22 のデータを使用しています。Routine 環境に `pip install google-api-python-client google-auth` を追加することで次回から自動取得されます。

🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_018UmWFE8S2MfFQD1Xn3cTDz)_