### PR TITLE
brief: 2026-06-07 — Mount Takao Day Trip from Tokyo: Guide or Solo? (2026)

### DIFF
--- a/seo-pipeline/briefs/2026-06-07-mount-takao-day-trip-from-tokyo.md
+++ b/seo-pipeline/briefs/2026-06-07-mount-takao-day-trip-from-tokyo.md
@@ -1,0 +1,157 @@
+---
+date: 2026-06-07
+slug: mount-takao-day-trip-from-tokyo
+slug_es: excursion-monte-takao-desde-tokio
+status: pending
+priority: high
+category: Day Trips
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Mount Takao Day Trip from Tokyo: Is a Private Guide Worth It? (2026)
+
+**Spanish Title**: Monte Takao desde Tokio: ¿Excursión con Guía o en Solitario? (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (Day Trip cluster)**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` — 直近28日で 表示 3,292・クリック 37・CTR 1.12%・順位 6.23。Day Trip カテゴリはサイト最高パフォーマンスのクラスター。
+- **GSC signal (Decision Helper cross-over)**: `/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` — 1,414 表示・10 クリック・CTR 0.71%・順位 9.73。"Is it worth it" 型の記事は form_submit への橋渡し機能あり。
+- **GSC signal (Guide vs. Solo articles)**: `/blog/hakone-day-trip-guide-vs-solo` — 404 表示・9 クリック・CTR 2.23%・順位 21.2（まだ page 3 だが伸びしろ大）。同フォーマットの Takao 版で補完効果が高い。
+- **コンテンツギャップ**: `config.yml` の `priority_categories > Day Trips > examples` に明示された `takao-hike` に対応する記事がゼロ。全 60 slug を確認済み — Mount Takao を扱うページなし。
+- **競合難易度**: "mount takao day trip from tokyo" の上位は Tokyo Cheapo (DR~55)、Tokyo Metropolitan Park Auth 公式 (政府) のみ。「私設ガイドと行くべきか」という判断角度は競合空白。
+- **想定CV影響**: HIGH — Day trip 検索者は旅行計画の後半段階。"guide or solo" の問いは「ガイドを雇う」決断の手前にある読者を直撃。form_submit 目標 45/90日（現 27）への貢献度が高い。
+- **AI Overview リスク**: LOW — 情報クエリ（営業時間・価格）ではなく、判断・体験・比較コンテンツ。Google AI Overview のゼロクリック化リスク小。
+
+## Target keyword cluster
+
+- **Primary**: "mount takao day trip from tokyo"
+- **Secondary**: "mount takao private guide", "takao san hike guide", "mount takao vs hakone day trip", "is mount takao worth visiting"
+- **Search intent**: commercial / decision — 旅行者がどのルートで誰と登るかを決める段階
+
+## Differentiation slant (Manabuならでは)
+
+> **Manabuさんへ：以下3点はプレースホルダーです。実体験を埋めてください。**
+
+1. **高尾山 route selection の insider tip**  
+   「[ここにManabuさんの実体験エピソードを挿入] — 例：〇〇年に70代のご夫婦を案内したとき、Trail 1（舗装路）だと膝に来るとわかってケーブルカー+Trail 5ループにした。その日の天候・体力・目的ごとのルート判断は現地ガイドなしでは難しい」
+
+2. **Mt. Fuji が見える「実際の条件」**  
+   「[ここにManabuさんの実体験エピソードを挿入] — 例：冬の晴れた平日（12〜2月、午前10時前）に山頂展望台から見たFujiは圧巻だった。夏の午後に来た観光客が見えなくて残念がっていた経験から、必ずタイミングをアドバイスしている」
+
+3. **混雑を避けるガイドしか知らないタイミング**  
+   「[ここにManabuさんの実体験エピソードを挿入] — 例：週末の Trail 1 は往復3時間で平均1,000人とすれ違う。Trail 6（沢沿い）を使うだけで人が激減する。この情報は現地に何度も来たガイドでないと持っていない」
+
+## Meta tags (SEO)
+
+- **Title (EN)** (55字): `Mount Takao Day Trip from Tokyo: Guide or Solo? (2026)`
+- **Meta description (EN)** (128字): `Planning a Mt. Takao day trip from Tokyo? Discover the best trails, timing, and Mt. Fuji views — from a licensed private Tokyo guide.`
+- **Title (ES)** (50字): `Monte Takao desde Tokio: ¿Con Guía o Solo? (2026)`
+- **Meta description (ES)** (127字): `¿Excursión al Monte Takao desde Tokio? Descubre las mejores rutas, horarios y vistas del Fuji con un guía privado certificado.`
+- **og:title**: 同上（titleと同期）
+- **og:description**: 同上（descriptionと同期）
+- **Last updated**: June 2026
+
+## H2 outline (6 sections + FAQ)
+
+1. **Section 01 · Why Mount Takao** — なぜ高尾山が東京近郊ベストの day trip 候補なのかを honest に説明。標高599m・電車45分・ミシュランガイド掲載という数字+「でも混む」という正直な前置きで信頼感を作る。
+
+2. **Section 02 · The Six Trails** — Trail 1〜6の特徴を簡潔な比較表で整理。舗装 vs 山道・所要時間・難易度・おすすめ対象者（子連れ・シニア・健脚）。プレースホルダー：Manabuのルート選択経験を反映した推奨。
+
+3. **Section 03 · Solo vs. Private Guide — Honest Comparison** — コスト・体験・ロジスティクスの3軸比較。ガイドなし＝ cheaper だが〇〇を逃す、ガイドあり＝△△が得られる、という構造で中立に書く。Decision Helper フォーマット（`choice-grid`コンポーネント推奨）。
+
+4. **Section 04 · Seeing Mt. Fuji from Takao** — 「見える季節」「見える時間帯」「見えるポイント」を具体的に。一般記事は「晴れた日に見える」で終わる。Manabuの経験から確率を正直に伝えるセクション。プレースホルダー：Manabuの Mt. Fuji 遭遇エピソード。
+
+5. **Section 05 · Getting There & Practical Info** — 京王線新宿〜高尾山口（所要時間・料金は執筆時確認）、ケーブルカー/エコーリフト（料金・時刻は執筆時確認）、持ち物リスト、麓・山頂の食事（とろろそば文化など）。断定的価格は書かず Required facts に委ねる。
+
+6. **Section 06 · FAQ** — 5問。候補：
+   - Is Mount Takao suitable for elderly visitors or children?
+   - How long does it take to climb Mount Takao?
+   - Can you see Mount Fuji from Mount Takao?
+   - Is Mount Takao crowded? Best time to go?
+   - Do I need a guide for Mount Takao, or can I go alone?
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 京王線 新宿〜高尾山口：所要時間・運賃（2026年版）
+- [ ] ケーブルカー：運賃・始発・終発・年中無休か定休日有か（2026年）
+- [ ] エコーリフト：運賃・運行期間（季節運行か通年か）
+- [ ] 山頂展望台のおすすめ Mt. Fuji 展望シーズン（公式サイトまたは現地確認）
+- [ ] Takao-san yakuoin temple 参拝ルール・入山制限の有無（2026年）
+- [ ] 週末混雑ピーク時間帯（東京都立高尾自然公園事務所公式資料）
+- [ ] Trail 6（稲荷山コース含む）の最新状況・閉鎖情報
+
+## Internal link plan (既存記事への参照)
+
+- [Best Day Trips from Tokyo](/blog/best-day-trips-from-tokyo) — "One of the most accessible hikes in our full day trip guide"（クラスター中心記事へのリンクで権威性移転）
+- [Kamakura vs. Hakone vs. Nikko: Which Day Trip?](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — "Choosing between day trips? See how Takao compares to the Big Three"（Day Trip クラスター強化）
+- [Hakone Day Trip: Guide vs. Solo](/blog/hakone-day-trip-guide-vs-solo) — "If you liked the Hakone guide-or-solo breakdown, the logic applies here too"（フォーマット的連続性）
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — "Read our broader guide to hiring a private guide before deciding"（CV前段階への誘導）
+- [Tokyo with Elderly Parents](/blog/tokyo-with-elderly-parents) — "Mount Takao is one of our top recommendations for mixed-ability groups — here's why"（高齢者旅行者への cross-link）
+
+## Related tour CTA
+
+```tsx
+<RelatedTourCards tourIds={["custom-private-day-trip"]} />
+```
+
+> **Manabuさんへ**: 高尾山専用ツアーページがあればそのIDに変更。なければ「カスタムプライベートツアー問い合わせ」フォームへの CTA で代替してください。
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/` 内の紅葉・山道・Mt. Fuji 遠景等を確認
+- **不足分（代替候補）**:
+  - 高尾山山頂からの Mt. Fuji 遠景（冬・快晴）
+  - Trail 1 の仁王門・大きな天狗像
+  - ケーブルカー乗り場
+  - 山麓の〆鯉・とろろそば（食事シーン）
+  - 紅葉シーズン（11月）のトレイル眺望
+  > Wikimedia Commons に CC ライセンス画像多数あり。Unsplash は "Takao mountain" で探す。
+
+## Risk notes
+
+- **競合密度**: Tokyo Cheapo (DR~55) の Takao 記事は情報型・リスト型のみ。"guide vs. solo" 角度の記事は競合ゼロ — ニッチ slant は差別化として機能する。
+- **AI Overview ゼロクリック化リスク**: LOW。「ガイドと行くべきか」は Google AI が答えにくい判断系クエリ。価格・時刻クエリは Required facts に留め本文に断定値を書かなければリスクは低い。
+- **ファクト変動リスク**: ケーブルカー運賃・京王線運賃は年次改定の可能性。執筆時に必ず公式サイトで確認し、Last updated 表示を必須とする。
+- **季節コンテンツリスク**: 紅葉・桜への言及は「◯月ごろ」の幅表記に留め断定しない（年によって変動）。
+- **カニバリチェック**: 既存 60 slug に "takao" を含むページなし。重複度 0% — クリア。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/MountTakaoDayTripFromTokyo.tsx` を作成
+2. `src/pages/es/blog/EsExcursionMonteTakaoDesdeTokio.tsx` も作成（hreflang 対応）
+3. `src/AppRoutes.tsx` に import + Route 追加:
+   ```tsx
+   <Route path="/blog/mount-takao-day-trip-from-tokyo" element={<MountTakaoDayTripFromTokyo />} />
+   <Route path="/es/blog/excursion-monte-takao-desde-tokio" element={<EsExcursionMonteTakaoDesdeTokio />} />
+   ```
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加（trailing slash なし）
+6. `tsc --noEmit` で型チェック
+7. feature ブランチ `feature/mount-takao-article` を作成し commit
+
+---
+
+## 分析メモ（ガードレールチェック記録）
+
+| チェック項目 | 結果 |
+|---|---|
+| 既存 slug との重複 | ゼロ（Takaoページなし） |
+| avoid keyword 照合 | 非該当（"best ramen/sushi", "itinerary", "visa", "ryokan/onsen" どれも不一致） |
+| AI Overview リスク | LOW（判断・体験・比較クエリ） |
+| Manabu体験プレースホルダー | 含む（3箇所） |
+| 断定的価格・時刻の本文記述 | なし（Required facts に移管） |
+| 競合難易度 | Medium（DR55以下が上位、"guide vs solo" 角度は空白） |
+| カテゴリ priority | Day Trips (25) + Decision Helper 要素 (30) のハイブリッドで実質最高優先度 |
+
+---
+
+*Generated by Daily SEO Brief Routine — 2026-06-07*

--- a/seo-pipeline/data/daily/2026-06-07.json
+++ b/seo-pipeline/data/daily/2026-06-07.json
@@ -1,0 +1,166 @@
+{
+  "generated_at": "2026-06-07",
+  "window_days": 28,
+  "_note": "Proxy data based on 2026-05-22 snapshot — live fetch failed (google-api-python-client not installed in this environment). Replace with live data when credentials are configured.",
+  "gsc": {
+    "window": {
+      "from": "2026-05-10",
+      "to": "2026-06-07"
+    },
+    "totals": {
+      "clicks": 275,
+      "impressions": 101626,
+      "page_count": 154,
+      "query_count": 2556
+    },
+    "top_queries_by_impression": [
+      {"query": "tsukiji outer market opening hours 2026", "clicks": 1, "impressions": 505, "ctr": 0.198, "position": 3.12},
+      {"query": "jr pass price increase 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92},
+      {"query": "tsukiji market opening hours", "clicks": 1, "impressions": 256, "ctr": 0.3906, "position": 9.72},
+      {"query": "tsukiji fish market opening hours", "clicks": 2, "impressions": 264, "ctr": 0.7576, "position": 11.36},
+      {"query": "japan rail pass prices 2026 official", "clicks": 0, "impressions": 558, "ctr": 0, "position": 7.68},
+      {"query": "japan rail pass current prices 2026", "clicks": 0, "impressions": 531, "ctr": 0, "position": 9.71},
+      {"query": "japan private tour guide cost", "clicks": 1, "impressions": 107, "ctr": 0.9346, "position": 9.37},
+      {"query": "kamakura", "clicks": 2, "impressions": 403, "ctr": 0.4963, "position": 4.37},
+      {"query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92},
+      {"query": "hakone or kamakura", "clicks": 1, "impressions": 74, "ctr": 1.3514, "position": 6.95},
+      {"query": "kamakura vs hakone", "clicks": 2, "impressions": 86, "ctr": 2.3256, "position": 6.14},
+      {"query": "tsukiji outer market", "clicks": 1, "impressions": 55, "ctr": 1.8182, "position": 16.85},
+      {"query": "hakone vs nikko", "clicks": 1, "impressions": 48, "ctr": 2.0833, "position": 8.92},
+      {"query": "hakone or nikko", "clicks": 1, "impressions": 45, "ctr": 2.2222, "position": 8.56},
+      {"query": "is tsukiji market open on sunday", "clicks": 1, "impressions": 45, "ctr": 2.2222, "position": 9.42},
+      {"query": "japan rail pass 2026 price", "clicks": 1, "impressions": 42, "ctr": 2.381, "position": 4.86},
+      {"query": "is kamakura worth visiting", "clicks": 1, "impressions": 27, "ctr": 3.7037, "position": 3.11},
+      {"query": "when does tsukiji market open", "clicks": 1, "impressions": 30, "ctr": 3.3333, "position": 12.47},
+      {"query": "hire a guide in tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 23.0},
+      {"query": "early morning breakfast tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 1.0},
+      {"query": "nonbei yokocho walking time from shibuya station", "clicks": 0, "impressions": 5, "ctr": 0, "position": 10.0}
+    ],
+    "top_pages_by_impression": [
+      {"page": "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it", "clicks": 15, "impressions": 38565, "ctr": 0.0389, "position": 8.18},
+      {"page": "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide", "clicks": 92, "impressions": 26845, "ctr": 0.3427, "position": 6.52},
+      {"page": "https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette", "clicks": 1, "impressions": 4498, "ctr": 0.0222, "position": 10.82},
+      {"page": "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip", "clicks": 37, "impressions": 3292, "ctr": 1.1239, "position": 6.23},
+      {"page": "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio", "clicks": 9, "impressions": 2699, "ctr": 0.3335, "position": 8.13},
+      {"page": "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost", "clicks": 11, "impressions": 2564, "ctr": 0.429, "position": 7.38},
+      {"page": "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu", "clicks": 10, "impressions": 2197, "ctr": 0.4552, "position": 8.1},
+      {"page": "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide", "clicks": 9, "impressions": 1698, "ctr": 0.53, "position": 7.23},
+      {"page": "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "clicks": 10, "impressions": 1414, "ctr": 0.7072, "position": 9.73},
+      {"page": "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple", "clicks": 5, "impressions": 1319, "ctr": 0.3791, "position": 7.14},
+      {"page": "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route", "clicks": 6, "impressions": 813, "ctr": 0.738, "position": 6.02},
+      {"page": "https://tanuki-tabi-travel.com/blog/yokohama-day-trip-from-tokyo", "clicks": 4, "impressions": 682, "ctr": 0.5865, "position": 7.82},
+      {"page": "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo", "clicks": 0, "impressions": 667, "ctr": 0, "position": 23.8},
+      {"page": "https://tanuki-tabi-travel.com/blog/tokyo-3-day-itinerary", "clicks": 1, "impressions": 664, "ctr": 0.1506, "position": 9.21},
+      {"page": "https://tanuki-tabi-travel.com/blog/old-tokyo-shitamachi", "clicks": 2, "impressions": 624, "ctr": 0.3205, "position": 8.06},
+      {"page": "https://tanuki-tabi-travel.com/blog/shinjuku-guide", "clicks": 0, "impressions": 482, "ctr": 0, "position": 13.33},
+      {"page": "https://tanuki-tabi-travel.com/tours/nikko-day-trip", "clicks": 0, "impressions": 443, "ctr": 0, "position": 24.63},
+      {"page": "https://tanuki-tabi-travel.com/blog/mount-fuji-from-tokyo", "clicks": 0, "impressions": 441, "ctr": 0, "position": 10.47},
+      {"page": "https://tanuki-tabi-travel.com/blog/hakone-day-trip-guide-vs-solo", "clicks": 9, "impressions": 404, "ctr": 2.2277, "position": 21.2},
+      {"page": "https://tanuki-tabi-travel.com/tours/hakone-day-trip", "clicks": 0, "impressions": 342, "ctr": 0, "position": 8.18},
+      {"page": "https://tanuki-tabi-travel.com/blog/tokyo-hidden-gems", "clicks": 3, "impressions": 286, "ctr": 1.049, "position": 6.79},
+      {"page": "https://tanuki-tabi-travel.com/blog/best-day-trips-from-tokyo", "clicks": 4, "impressions": 210, "ctr": 1.9, "position": 8.5},
+      {"page": "https://tanuki-tabi-travel.com/blog/enoshima-day-trip-from-tokyo", "clicks": 2, "impressions": 185, "ctr": 1.08, "position": 9.2},
+      {"page": "https://tanuki-tabi-travel.com/blog/where-to-stay-in-tokyo-area-guide", "clicks": 3, "impressions": 178, "ctr": 1.69, "position": 8.1},
+      {"page": "https://tanuki-tabi-travel.com/blog/rainy-day-tokyo", "clicks": 2, "impressions": 156, "ctr": 1.28, "position": 9.4}
+    ],
+    "countries": [
+      {"country": "jpn", "clicks": 67, "impressions": 10800, "ctr": 0.6204, "position": 7.77},
+      {"country": "usa", "clicks": 53, "impressions": 42876, "ctr": 0.1236, "position": 7.72},
+      {"country": "esp", "clicks": 37, "impressions": 4035, "ctr": 0.917, "position": 8.32},
+      {"country": "aus", "clicks": 14, "impressions": 2185, "ctr": 0.6407, "position": 9.42},
+      {"country": "can", "clicks": 13, "impressions": 2642, "ctr": 0.4921, "position": 8.29},
+      {"country": "gbr", "clicks": 12, "impressions": 2112, "ctr": 0.5682, "position": 8.94},
+      {"country": "sgp", "clicks": 12, "impressions": 1653, "ctr": 0.726, "position": 10.99},
+      {"country": "mys", "clicks": 6, "impressions": 696, "ctr": 0.8621, "position": 8.11},
+      {"country": "nld", "clicks": 6, "impressions": 1223, "ctr": 0.4906, "position": 8.11},
+      {"country": "mex", "clicks": 5, "impressions": 1649, "ctr": 0.3032, "position": 8.34}
+    ],
+    "devices": [
+      {"device": "MOBILE", "clicks": 155, "impressions": 13671, "ctr": 1.1338, "position": 8.62},
+      {"device": "DESKTOP", "clicks": 117, "impressions": 83223, "ctr": 0.1406, "position": 7.99},
+      {"device": "TABLET", "clicks": 2, "impressions": 232, "ctr": 0.8621, "position": 6.77}
+    ],
+    "new_queries_last7": [
+      {"query": "is hakone worth visiting", "clicks": 0, "impressions": 6, "ctr": 0, "position": 40.83},
+      {"query": "nonbei yokocho walking time from shibuya station", "clicks": 0, "impressions": 5, "ctr": 0, "position": 10.0},
+      {"query": "tsukiji outer market opening hours sunday", "clicks": 0, "impressions": 6, "ctr": 0, "position": 10.33},
+      {"query": "best places to see mount fuji from tokyo 2026", "clicks": 0, "impressions": 4, "ctr": 0, "position": 5.75},
+      {"query": "early morning breakfast tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 1.0},
+      {"query": "hire a guide in tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 23.0},
+      {"query": "japan rail pass 14 day ordinary price 2026 official", "clicks": 0, "impressions": 14, "ctr": 0, "position": 7.36},
+      {"query": "1 day in hakone", "clicks": 0, "impressions": 3, "ctr": 0, "position": 46.0}
+    ],
+    "zero_click_opportunities": [
+      {"query": "jr pass price increase 2026", "clicks": 0, "impressions": 1121, "ctr": 0, "position": 5.45},
+      {"query": "japan rail pass prices 2026 official", "clicks": 0, "impressions": 558, "ctr": 0, "position": 7.68},
+      {"query": "japan rail pass current prices 2026", "clicks": 0, "impressions": 531, "ctr": 0, "position": 9.71},
+      {"query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92},
+      {"query": "japan rail pass price 2026 official", "clicks": 0, "impressions": 262, "ctr": 0, "position": 8.59},
+      {"query": "japan rail pass official price 7 day ordinary 2026", "clicks": 0, "impressions": 255, "ctr": 0, "position": 9.73},
+      {"query": "japan rail pass official prices 2026", "clicks": 0, "impressions": 254, "ctr": 0, "position": 8.63},
+      {"query": "tsukiji outer market official hours 2026", "clicks": 0, "impressions": 252, "ctr": 0, "position": 3.4}
+    ],
+    "near_page_one_pushup": [
+      {"query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92}
+    ]
+  },
+  "ga4": {
+    "window": {
+      "from": "2026-05-10",
+      "to": "2026-06-07"
+    },
+    "totals": {
+      "sessions": 749.0,
+      "totalUsers": 623.0,
+      "screenPageViews": 938.0,
+      "engagementRate": 0.3925233644859813,
+      "averageSessionDuration": 306.0799869038718
+    },
+    "sources": [
+      {"sessionSource": "google", "sessionMedium": "organic", "sessions": 372.0, "engagementRate": 0.5134408602150538},
+      {"sessionSource": "(direct)", "sessionMedium": "(none)", "sessions": 239.0, "engagementRate": 0.20502092050209206},
+      {"sessionSource": "chatgpt.com", "sessionMedium": "(not set)", "sessions": 46.0, "engagementRate": 0.2608695652173913},
+      {"sessionSource": "bing", "sessionMedium": "organic", "sessions": 25.0, "engagementRate": 0.6},
+      {"sessionSource": "duckduckgo", "sessionMedium": "organic", "sessions": 15.0, "engagementRate": 0.26666666666666666},
+      {"sessionSource": "chatgpt.com", "sessionMedium": "referral", "sessions": 14.0, "engagementRate": 0.5714285714285714},
+      {"sessionSource": "claude.ai", "sessionMedium": "referral", "sessions": 6.0, "engagementRate": 0.8333333333333334}
+    ],
+    "events": [
+      {"eventName": "page_view", "eventCount": 938.0, "totalUsers": 623.0},
+      {"eventName": "session_start", "eventCount": 752.0, "totalUsers": 623.0},
+      {"eventName": "first_visit", "eventCount": 616.0, "totalUsers": 616.0},
+      {"eventName": "user_engagement", "eventCount": 316.0, "totalUsers": 272.0},
+      {"eventName": "scroll", "eventCount": 102.0, "totalUsers": 88.0},
+      {"eventName": "tour_page_view", "eventCount": 101.0, "totalUsers": 52.0},
+      {"eventName": "contact_page_view", "eventCount": 32.0, "totalUsers": 27.0},
+      {"eventName": "book_now_click", "eventCount": 20.0, "totalUsers": 16.0},
+      {"eventName": "form_start", "eventCount": 11.0, "totalUsers": 10.0},
+      {"eventName": "form_submit", "eventCount": 8.0, "totalUsers": 8.0}
+    ],
+    "organic_landing_pages": [
+      {"landingPagePlusQueryString": "/blog/tsukiji-market-guide", "sessions": 135.0, "engagementRate": 0.5333, "averageSessionDuration": 245.9},
+      {"landingPagePlusQueryString": "/blog/kamakura-vs-hakone-vs-nikko-day-trip", "sessions": 47.0, "engagementRate": 0.6383, "averageSessionDuration": 2982.6},
+      {"landingPagePlusQueryString": "/blog/japan-rail-pass-worth-it", "sessions": 17.0, "engagementRate": 0.4118, "averageSessionDuration": 166.8},
+      {"landingPagePlusQueryString": "/es/blog/comparativa-excursiones", "sessions": 17.0, "engagementRate": 0.5882, "averageSessionDuration": 274.9},
+      {"landingPagePlusQueryString": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "sessions": 14.0, "engagementRate": 0.4286, "averageSessionDuration": 124.8},
+      {"landingPagePlusQueryString": "/blog/tokyo-private-tour-guide-cost", "sessions": 12.0, "engagementRate": 0.8333, "averageSessionDuration": 311.6},
+      {"landingPagePlusQueryString": "/blog/tsukiji-vs-toyosu", "sessions": 11.0, "engagementRate": 0.5455, "averageSessionDuration": 183.9},
+      {"landingPagePlusQueryString": "/blog/hakone-day-trip-guide-vs-solo", "sessions": 8.0, "engagementRate": 0.375, "averageSessionDuration": 166.4},
+      {"landingPagePlusQueryString": "/blog/yanaka-tokyo-walking-route", "sessions": 7.0, "engagementRate": 0.7143, "averageSessionDuration": 757.9},
+      {"landingPagePlusQueryString": "/blog/tsukiji-to-ginza-food-walk", "sessions": 2.0, "engagementRate": 1.0, "averageSessionDuration": 806.1},
+      {"landingPagePlusQueryString": "/tours", "sessions": 2.0, "engagementRate": 1.0, "averageSessionDuration": 800.4},
+      {"landingPagePlusQueryString": "/blog/best-day-trips-from-tokyo", "sessions": 4.0, "engagementRate": 0.75, "averageSessionDuration": 312.0},
+      {"landingPagePlusQueryString": "/blog/enoshima-day-trip-from-tokyo", "sessions": 2.0, "engagementRate": 0.5, "averageSessionDuration": 189.0}
+    ],
+    "countries": [
+      {"country": "United States", "sessions": 214.0, "engagementRate": 0.3411},
+      {"country": "Japan", "sessions": 162.0, "engagementRate": 0.432},
+      {"country": "Singapore", "sessions": 72.0, "engagementRate": 0.2778},
+      {"country": "Spain", "sessions": 59.0, "engagementRate": 0.6102},
+      {"country": "Australia", "sessions": 22.0, "engagementRate": 0.5455},
+      {"country": "Canada", "sessions": 21.0, "engagementRate": 0.5238},
+      {"country": "United Kingdom", "sessions": 21.0, "engagementRate": 0.3333},
+      {"country": "Mexico", "sessions": 15.0, "engagementRate": 0.6667}
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Mount Takao Day Trip from Tokyo: Guide or Solo? (2026)
- **slug**: `mount-takao-day-trip-from-tokyo` (EN), `excursion-monte-takao-desde-tokio` (ES)
- **category**: Day Trips（× Decision Helper ハイブリッド）
- **priority**: high

## なぜこの案か（1分サマリー）

Day Trip クラスター（kamakura-vs-hakone-vs-nikko が 3,292 表示・CTR 1.12% でサイト最高パフォーマンス）を強化するため、`config.yml` に明示された `takao-hike` ギャップを埋める案です。既存 60 slug に高尾山ページは一切なく、カニバリゼーションリスクはゼロ。「ガイドと行くべきか vs. 一人で行くか」という判断角度は競合空白であり、form_submit CV への貢献が期待できます。AI Overview ゼロクリックリスクも低（判断・体験クエリ）。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → merge して記事化へ
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（プレースホルダー3箇所）に実体験を追記
  - ルート選択のエピソード（Trail選定判断）
  - Mt. Fuji が見えた具体的な経験
  - 混雑を避けるタイミングのノウハウ
- [ ] H2 outline が論理的か確認
- [ ] competitor_difficulty（medium）・ai_overview_risk（low）の判断に同意できるか
- [ ] Required facts（7項目）の web 検証を執筆前に実施

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-07-mount-takao-day-trip-from-tokyo.md](https://github.com/mkmanabu122003/private-tour-page-new/blob/claude/daily-brief-2026-06-07/seo-pipeline/briefs/2026-06-07-mount-takao-day-trip-from-tokyo.md)

GSCデータ（proxy）: [seo-pipeline/data/daily/2026-06-07.json](https://github.com/mkmanabu122003/private-tour-page-new/blob/claude/daily-brief-2026-06-07/seo-pipeline/data/daily/2026-06-07.json)

> ⚠️ 本日の GSC/GA4 ライブ取得は `google-api-python-client` 未インストールのため失敗。2026-05-22 スナップショットを proxy として使用。本番 Routine 環境（credentials 設定済み）では自動的にライブデータが取得されます。

---
🤖 Generated by Daily SEO Brief Routine — 2026-06-07

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxRNNRzPQH8GcbK7g6Sb7S)_