### PR TITLE
brief: 2026-06-08 — Japan Rail Pass for Tokyo Day Trips 2026: Do You Actually Need It?

### DIFF
--- a/seo-pipeline/briefs/2026-06-08-japan-rail-pass-for-day-trips-from-tokyo.md
+++ b/seo-pipeline/briefs/2026-06-08-japan-rail-pass-for-day-trips-from-tokyo.md
@@ -1,0 +1,117 @@
+---
+date: 2026-06-08
+slug: japan-rail-pass-for-day-trips-from-tokyo
+slug_es: jr-pass-excursiones-desde-tokio
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: medium
+---
+
+# Japan Rail Pass for Tokyo Day Trips 2026: Do You Actually Need It?
+
+**Spanish Title**: JR Pass para Excursiones desde Tokio 2026: ¿Realmente lo Necesitas?
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (zero-click cluster)**: 「jr pass price increase 2026」直近28日で 表示 1,121、クリック 0、順位 5.45 ― ゼロクリック機会最大
+- **GSC signal (zero-click)**: 「japan rail pass prices 2026 official」表示 558、クリック 0、順位 7.68
+- **GSC signal (near page one)**: 「japan rail pass price 2026」表示 400、クリック 0、順位 11.92 → ページ1へのプッシュアップ候補
+- **既存記事ギャップ**: 既存 `/blog/japan-rail-pass-worth-it` は28日で 38,565 表示、15 クリック、CTR **0.04%**（pos 8.18）。読者が求める「日帰り旅行に必要か」という具体的な問いに対するコンテンツが皆無
+- **スコープの差別化**: 既存記事は東京→京都→大阪の長距離ルートが前提。鎌倉・箱根・日光など東京発日帰りに限定した読者（Manabuのターゲット層）は答えを得られていない
+- **想定CV影響**: **high** — 「JRパスに何万円も払う前に」という判断段階にいる読者は、プライベートツアーという代替手段に最もオープン。`form_submit` への直接経路
+- **競合状況**: Japan Guide, Lonely Planet が一般的なJRパス記事を独占（DR80+）。ただし「東京発日帰り専用コスト比較」の角度は手薄。Manabuの実体験データ（各ルートの実費）で差別化可能
+
+## Target keyword cluster
+
+- **Primary**: "japan rail pass tokyo day trips 2026"
+- **Secondary**: "do i need jr pass for day trips from tokyo", "kamakura jr pass worth it", "hakone jr pass 2026", "nikko jr pass from tokyo"
+- **Search intent**: commercial / decision（「買うべきか否か」の意思決定段階）
+
+## Differentiation slant (Manabuならでは)
+
+[ここにManabuさんの実体験エピソードを挿入]
+
+- **プレースホルダー1**: 500回以上のプライベートツアーで毎回聞かれる「JRパスは必要ですか？」という質問への回答パターン。「お客様の旅程が〇〇だった場合、私はいつも〇〇と答えます。具体的には昨年〔季節〕に〔国籍〕のご家族をガイドした時、3日間で鎌倉・日光・箱根を回る予定でしたが、実際に計算すると…」という形で実例を入れる
+- **プレースホルダー2**: Manabuが毎月使う各路線の"ガイドだから知っている裏技"。例：「鎌倉は横須賀線、箱根は小田急ロマンスカーの方が快適で実はJRパス対象外の路線が多い」といった一般読者には見えない情報
+- **プレースホルダー3**: プライベートツアー同行時の交通費の扱い方。「Manabuのツアーでは交通費が含まれる/含まれない」の実態と、それがJRパス不要論にどう繋がるか。自然なCTAとして機能させる
+
+## Meta tags (SEO)
+
+- **Title (EN)** (58字): Japan Rail Pass for Tokyo Day Trips 2026: Do You Need It?
+- **Meta description (EN)** (154字): Kamakura, Hakone, Nikko — does the Japan Rail Pass actually pay off for Tokyo day trips in 2026? A licensed private guide breaks down every route with real costs and a simple calculator.
+- **Title (ES)** (60字): JR Pass para Excursiones desde Tokio 2026: ¿Merece la Pena?
+- **Meta description (ES)** (150字): Kamakura, Hakone, Nikko — ¿compensa el JR Pass para excursiones de un día desde Tokio en 2026? Un guía privado oficial analiza rutas y costes reales con una calculadora sencilla.
+
+## H2 outline (6 sections + FAQ)
+
+1. **Section 01 · The JR Pass Problem** — なぜ東京滞在者がJRパスで損をするのか。全国パスが「東京日帰り旅行者」に向いていない理由を端的に説明するフック。
+2. **Section 02 · Route-by-Route Cost Breakdown** — 鎌倉・箱根・日光・横浜・富士山の5ルートについて、往復電車代（個別購入）vs JRパス日割りコストを表形式で比較。JRパスでカバーできない路線（小田急・東武等）も明示。
+3. **Section 03 · When the JR Pass Actually Pays Off** — 東京+新幹線長距離（京都・大阪・広島）を含む旅程で7日間以上滞在する場合など、JRパスが genuinely worth it なシナリオを正直に提示（信頼性のため逆張り情報を入れる）。
+4. **Section 04 · When to Skip It Completely** — 東京のみ3-5日、または日帰り2-3カ所だけの旅程。ICカード（Suica/Pasmo）で十分なケースを具体的に。
+5. **Section 05 · Private Guide Option: The Transportation Equation Changes** — プライベートツアー同行時は移動の計算式が変わる。Manabuとの日帰りツアーのCTA。[ここにManabuさんの実体験エピソードを挿入]
+6. **Section 06 · FAQ** — 4-5問（"Is JR Pass valid for Shinkansen to Hakone?", "Can I use JR Pass for Kamakura?", "What about Tokyo Metro pass?", "Is the JR Pass price going up in 2026?"）
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 2026年現在のJRパス公式価格（7日間・14日間・21日間、普通・グリーン）— 円建て税込
+- [ ] 東京→鎌倉（横須賀線/湘南新宿ライン）片道・往復運賃（2026年最新）
+- [ ] 東京→箱根湯本（小田急線）片道・往復運賃。ロマンスカー特急券含む
+- [ ] 東京→東武日光（東武特急スペーシア）片道・往復運賃。または宇都宮線+日光線経由
+- [ ] 東京→横浜（JR東海道線/横須賀線）片道・往復運賃
+- [ ] 東京→河口湖/富士山五合目（富士急行またはバス）往復目安額
+- [ ] JRパスで乗れない主要路線（小田急、東武、富士急等）の公式確認
+- [ ] 2026年JRパス価格改定の有無（直近1年以内の価格変更）
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura Day Trip from Tokyo](/blog/kamakura-day-trip-from-tokyo) — JRパスが使える鎌倉ルートの詳細へ
+- [Hakone Day Trip: Guide vs Solo](/blog/hakone-day-trip-guide-vs-solo) — JRパス対象外の小田急ルートを使う箱根の詳細へ
+- [Nikko Day Trip from Tokyo](/blog/nikko-day-trip-from-tokyo) — 東武 vs JR日光線の選択肢へ
+- [Kawaguchiko vs Hakone for Mt Fuji](/blog/kawaguchiko-vs-hakone-for-mt-fuji) — 富士山方面のアクセス比較へ
+- [Japan Rail Pass: Worth It?](/blog/japan-rail-pass-worth-it) — 長距離旅行者向けの既存記事へ（相互補完）
+- [Best Day Trips from Tokyo](/blog/best-day-trips-from-tokyo) — 日帰り先の全体概観へ
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["kamakura-day-trip", "hakone-day-trip", "nikko-day-trip"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: 鎌倉・箱根・日光の既存ツアー写真（既存記事と共用可）。路線図/比較表はテキストベースのCSSテーブルで対応
+- **不足分（Wikimedia/Unsplash提案）**: 東京駅の新幹線ホームの写真（JRパスを使うシーンの視覚化）、Suicaカードの写真
+
+## Risk notes
+
+- **AI Overview ゼロクリック化のリスク** — 「japan rail pass price 2026」は価格情報型クエリ。ただし「東京日帰り旅行に必要か」という判断型slantにすることでAI Overviewが答えにくい領域へシフト。コスト比較表とManabuの判断軸（プライベートツアー視点）が差別化要因
+- **カニバリゼーションリスク** — 既存 `/blog/japan-rail-pass-worth-it` との重複度は推定50%以下（スコープ：全国旅行 vs 東京発日帰り）。内部リンクで両記事を補完関係にする
+- **競合過密** — JRパス一般論はLonely Planet・Japan Guide（DR80+）が独占。「東京日帰り限定コスト計算」の角度はニッチが確保できる
+- **ファクト変動リスク** — JRパス価格・運賃は年次変動あり。Last updated 更新を必須化し、Required factsセクションで執筆時に全数値を検証する
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `templates/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/JapanRailPassForDayTripsFromTokyo.tsx` を作成
+2. `src/pages/es/blog/EsJrPassExcursionesDesdeTokio.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/japan-rail-pass-for-day-trips-from-tokyo` および `/es/blog/jr-pass-excursiones-desde-tokio`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. tsc で型チェック
+7. feature ブランチ作成 + commit
+
+---
+
+## 生成メモ（Routine自動追記）
+
+- **生成日**: 2026-06-08
+- **使用データ**: seo-pipeline/data/daily/2026-05-22.json（注: 2026-06-08のAPI取得が `google-api-python-client` 未インストールで失敗。直近の実データ2026-05-22を使用）
+- **分析クエリ数**: GSC 2,556クエリ、ゼロクリック機会8件、near-page-one 1件
+- **競合check**: JRパス一般 → Lonely Planet, Japan-guide.com (DR80+)。「東京日帰り限定」角度は未占拠と判断

--- a/seo-pipeline/data/daily/2026-06-08.json
+++ b/seo-pipeline/data/daily/2026-06-08.json
@@ -1,0 +1,12 @@
+{
+  "generated_at": "2026-06-08",
+  "window_days": 28,
+  "fetch_status": "error_fallback",
+  "fetch_note": "google-api-python-client not installed in this environment. Analysis performed using 2026-05-22.json as fallback. Install dependencies with: pip3 install google-api-python-client google-auth",
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Japan Rail Pass for Tokyo Day Trips 2026: Do You Actually Need It?
- **slug**: `japan-rail-pass-for-day-trips-from-tokyo` (EN), `jr-pass-excursiones-desde-tokio` (ES)
- **category**: Decision Helpers
- **priority**: high

## データシグナル（なぜこの案か）

JR Pass関連のゼロクリック機会が今回最大の機会クラスター：

| クエリ | 表示数 | クリック | 順位 |
|--------|--------|---------|------|
| jr pass price increase 2026 | 1,121 | 0 | 5.45 |
| japan rail pass prices 2026 official | 558 | 0 | 7.68 |
| japan rail pass price 2026 | 400 | 0 | **11.92（near page 1）** |

既存 `/blog/japan-rail-pass-worth-it` は **38,565 表示・15 クリック・CTR 0.04%**。
既存記事が全国旅行（東京→京都→大阪）向けなのに対し、本記事は「東京発日帰り旅行限定のコスト比較」に特化 → カニバリゼーションリスク低（推定重複度 ~50%）。

**CV影響**: JRパスの費用対効果を検討している読者は、プライベートツアーという代替手段に最もオープンな段階 → form_submit への直接経路。

## ⚠️ 技術メモ

`google-api-python-client` が未インストールのため、2026-06-08 のGSC/GA4 取得に失敗。
分析は直近実データ `seo-pipeline/data/daily/2026-05-22.json` をフォールバックとして使用。

依存パッケージのインストール（ローカルまたはRoutine環境）:
```
pip3 install google-api-python-client google-auth
```

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む（`/build-article` で記事生成）
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] **Manabu独自エピソード**（プレースホルダー3箇所）に実体験を追記
  - 500回超のツアーで「JRパスは必要？」と聞かれた時の実例
  - 各ルート（鎌倉・箱根・日光）の「ガイドだから知っている裏技」
  - プライベートツアー同行時の交通費の扱い方
- [ ] Required facts のチェックリスト（価格・運賃・対象路線）を執筆前に全検証
- [ ] H2 アウトラインが論理的か
- [ ] competitor_difficulty, ai_overview_risk の評価が妥当か

## ブリーフ本体

`seo-pipeline/briefs/2026-06-08-japan-rail-pass-for-day-trips-from-tokyo.md`

---
🤖 Generated by Daily SEO Brief Routine · 2026-06-08

---
_Generated by [Claude Code](https://claude.ai/code/session_01REw3zc5zgnK11nCzms7ps3)_