### PR TITLE
brief: 2026-06-10 — Ueno vs Asakusa Tokyo 2026: Which to Visit First?

### DIFF
--- a/seo-pipeline/briefs/2026-06-10-ueno-vs-asakusa-tokyo.md
+++ b/seo-pipeline/briefs/2026-06-10-ueno-vs-asakusa-tokyo.md
@@ -1,0 +1,117 @@
+---
+date: 2026-06-10
+slug: ueno-vs-asakusa-tokyo
+slug_es: ueno-vs-asakusa-tokio
+status: pending  # pending | approved | rejected | needs-changes
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Ueno vs Asakusa Tokyo 2026: Which to Visit First?
+
+**Spanish Title**: Ueno vs Asakusa en Tokio 2026: ¿Cuál visitar primero?
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (2026-05-22 dataset)**: `/blog/old-tokyo-shitamachi`（Ueno隣接エリア）は直近28日で表示 624、クリック 2、順位 8.06。Ueno 自体の記事はゼロで、需要を取りこぼしている状態。
+- **比較フォーマットの実績**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` は表示 3,292・クリック 37・順位 6.23、GA4の平均セッション時間 **2,982秒**（サイト最高値）。「どっちにすべき？」型記事の高エンゲージが証明済み。
+- **近接記事の好パフォーマンス**: `/blog/yanaka-tokyo-walking-route` は GA4 平均 757秒・engagement rate 71%。下町エリアのウォーキング＆比較コンテンツへの関心が高い。
+- **既存記事ギャップ**: `/blog/asakusa-guide` は存在するが Ueno 専記事がゼロ。"ueno vs asakusa" "ueno tokyo guide" は現時点で表示取得なし → 競合より先にクラスターを取る先行者メリットあり。
+- **想定CV影響**: high — 「どちらから行くか」という計画フェーズの旅行者が対象。結論として「2エリアをスムーズに回るならプライベートガイドが最適」の文脈が自然に生まれ、form_submit へ直結。
+- **競合状況**: Japan Guide・Tokyo Cheapo・Lonely Planet は個別のエリアガイドを持つが、"Ueno vs Asakusa" というvs比較記事は見当たらない。DR は高いが、ニッチ slant（ガイド視点の一日ルート）で差別化できる余地あり。
+
+## Target keyword cluster
+
+- **Primary**: "ueno vs asakusa"
+- **Secondary**: "ueno tokyo guide", "asakusa or ueno which is better", "ueno asakusa same day"
+- **Long-tail**: "ueno or asakusa first", "ueno asakusa one day itinerary", "best neighborhoods to visit in tokyo"
+- **Search intent**: commercial investigational — 旅行計画中の読者が比較して行動を決める段階
+
+## Differentiation slant (Manabuならでは)
+
+**[プレースホルダー 1 — Manabuさん記入欄]**
+500回以上このエリアを案内してきた経験から「Ueno と Asakusa どっちから行くべき？」という質問に即答できるはず。実際にゲストに尋ねられた中で最も印象的だったエピソード（例：60代アメリカ人夫妻が最初 Asakusa を選んで人混みで疲弊し、午後の Ueno で満足した体験 → 逆順を勧めるようになった理由）を挿入してください。
+
+**[プレースホルダー 2 — Manabuさん記入欄]**
+政府公認ガイド（全国通訳案内士）として、Ueno 東照宮のどこに立てば見晴らしがよいか、Ameyoko 市場の何時頃が混雑のピークを過ぎるか、など「観光客がほぼ素通りするポイント」を1〜2個、実際のガイド中に活用している具体例で挿入してください。
+
+- 時刻付きの推奨ルート（朝9時Ueno国立博物館→11時Ameyoko→昼食→午後Asakusa）はManabuガイドだから言える「最適解」として提示。他のサイトにない具体性を出す。
+- シニア・ファミリー向けに Ueno が Asakusa より石畳が少なく疲れにくいという実体験アドバイスを追加できると差別化になる。
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Ueno vs Asakusa Tokyo 2026: Which to Visit First?`（50文字）
+- **Meta description (EN)** (155字以内): `Private guide Manabu compares Ueno and Asakusa — crowds, highlights, and hidden spots — so you visit both in the right order. Updated June 2026.`（150文字）
+- **Title (ES)** (60字以内): `Ueno vs Asakusa en Tokio 2026: ¿Cuál visitar primero?`（54文字）
+- **Meta description (ES)** (155字以内): `Manabu, guía privado certificado, compara Ueno y Asakusa: cuándo ir, qué ver y cómo combinar ambos barrios en un día perfecto en Tokio.`（138文字）
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · Quick Verdict** — Quick Decision ボックスで「午前: Ueno → 午後: Asakusa」か「1日それぞれ集中」か状況別に即答。ファーストビューで離脱防止。
+2. **Section 02 · Ueno: Museums, Market, Morning Magic** — 東京国立博物館・上野動物園・Ameyoko 市場の見どころを「ガイド視点で何を重視するか」で解説。一般的なリスト記事との差別化。
+3. **Section 03 · Asakusa: Temple, Crafts, Retro Atmosphere** — 浅草寺・仲見世・浅草六区の歩き方。混雑ピーク時間帯と回避策をManabu経験から記述。
+4. **Section 04 · Head-to-Head: Crowds, Walking Distance, Kid/Senior-Friendliness** — 比較表（cost-table フォーマット）で2エリアを5軸スコアリング。ファクトより体感ベースで評価。
+5. **Section 05 · The Perfect One-Day Route: Ueno → Yanaka → Asakusa** — 時刻付きの具体的ルート。Yanaka を経由することで両エリアをつなぐ独自視点。既存 `yanaka-walking-route` との内部リンク起点。
+6. **Section 06 · When a Private Guide Adds Value (and When You Don't Need One)** — 正直に「一人でも回れる」と認めつつ、ガイドがいると解説が深まるポイントを提示。form_submit 誘導。
+7. **Section 07 · FAQ** — 4-5問（以下 Required facts から派生させる）
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 東京国立博物館の入館料（2026年時点、円建て税込）と開館時間・休館日
+- [ ] 上野動物園の入園料（2026年時点）と開園時間
+- [ ] Ameyoko 市場の営業時間帯と主な定休日（目安）
+- [ ] 浅草寺の公式拝観時間（無料エリアと有料エリアの区別）
+- [ ] Ueno駅〜浅草駅の移動時間（東京メトロ銀座線、徒歩それぞれ）
+- [ ] Yanaka Ginza の最寄り駅と徒歩時間
+
+## Internal link plan (既存記事への参照)
+
+- [Asakusa Guide: What to See & Do](/blog/asakusa-guide) — Section 03 で「より詳しいAsakusa情報はこちら」と誘導
+- [Old Tokyo Shitamachi Guide](/blog/old-tokyo-shitamachi) — Section 05 のルート説明で下町エリアの歴史的文脈として引用
+- [Yanaka Tokyo Walking Route](/blog/yanaka-tokyo-walking-route) — Section 05 でUeno→Yanaka→Asakusaルートの中継点として強くリンク
+- [Kamakura vs Hakone vs Nikko Day Trip](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — Section 06 末尾で「都外日帰りを検討するなら」としてサイドリンク
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — Section 06（ガイドの価値）から自然に誘導
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["tokyo-highlights", "asakusa-private-tour"]} />`
+
+> ※ tour ID は実際の AppRoutes/tours ページの ID に合わせてください。
+
+## Image candidates
+
+- **Project内（最優先）**: Senso-ji Kaminarimon の既存写真（`/blog/asakusa-guide` で使用のもの）
+- **不足分（Wikimedia/Unsplash提案）**: 東京国立博物館の正面ファサード（Wikimedia Commons に CC0 が複数あり）、Ameyoko の市場風景（Unsplash "ameyoko" で検索）
+
+## Risk notes
+
+- **競合記事**: Japan Guide・Tokyo Cheapo の既存 Ueno/Asakusa 記事はそれぞれ単独エリアガイド。"vs" 比較の直接競合は現時点でほぼなし。ただし DR 差があるので、ニッチ slant（ガイド視点の時刻付きルート）を必ず維持する。
+- **AI Overview リスク**: 「どちらが良いか」という判断型クエリは AI Overview が答えにくい。ガイドの実体験と時刻付きルートを前面に出すことでゼロクリック化を回避できる。
+- **ファクト変動リスク**: 博物館料金・開館時間は年次変更の可能性あり。執筆時に公式サイトで確認し、「Last updated: June 2026」を記事冒頭に表示。
+- **カニバリゼーション**: `/blog/asakusa-guide` との重複チェック済み（Ueno vs Asakusa 比較は存在しない。Asakusa 単独深掘りと補完関係）。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/UenoVsAsakusaTokyo.tsx` を作成
+2. `src/pages/es/blog/EsUenoVsAsakusaTokio.tsx` も作成（hreflang 対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/ueno-vs-asakusa-tokyo` および `/es/blog/ueno-vs-asakusa-tokio`）
+4. `src/pages/blog/BlogIndex.tsx` に2 entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. `tsc` で型チェック
+7. feature ブランチ `feature/ueno-vs-asakusa` 作成 + commit
+
+---
+
+## Data note
+
+2026-06-10 の fetch_daily.py 実行時に `googleapiclient` モジュール未インストールのため API 取得失敗。本 brief は 2026-05-22 の直近有効データをベースに分析。次回の Routine 実行前に `pip install google-api-python-client google-auth-httplib2` を実施するか、環境設定を確認してください。

--- a/seo-pipeline/data/daily/2026-06-10.json
+++ b/seo-pipeline/data/daily/2026-06-10.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-10",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Ueno vs Asakusa Tokyo 2026: Which to Visit First?
- **slug**: `ueno-vs-asakusa-tokyo` (EN), `ueno-vs-asakusa-tokio` (ES)
- **category**: Decision Helpers
- **priority**: high
- **duplicate_risk**: low / **competitor_difficulty**: medium / **ai_overview_risk**: low

## なぜこの案か（要約）

比較型コンテンツ（kamakura-vs-hakone-vs-nikko）がサイト最高の平均セッション時間 **2,982秒** を記録しており、同フォーマットの高ROIが実証済み。Ueno 専記事がゼロにもかかわらず近接する `old-tokyo-shitamachi` が GSC 624 impressions を獲得しており、先行者メリットを取れるタイミング。「どちらに行くべき？」という判断フェーズの読者は form_submit への距離が近く、CV インパクトが高い。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → merge して記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus 指示を書いて commit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] プレースホルダー2箇所（ゲストエピソード・ガイド現場の tips）に実体験を追記
- [ ] H2 outline が論理的か（Section 05 の Yanaka 経由ルートは実際の案内ルートと合っているか確認）
- [ ] Required facts（博物館料金・開館時間・アクセス時間）を執筆前に web search で検証
- [ ] competitor_difficulty、ai_overview_risk の評価が妥当か

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-10-ueno-vs-asakusa-tokyo.md](seo-pipeline/briefs/2026-06-10-ueno-vs-asakusa-tokyo.md)

## 補足: API 接続エラー

`fetch_daily.py` 実行時に `googleapiclient` モジュール未インストールのため GSC/GA4 API 取得失敗。分析は 2026-05-22 の直近有効データをベースにしています。環境に `pip install google-api-python-client google-auth-httplib2` を追加することで次回から自動取得が可能になります。

---
🤖 Generated by Daily SEO Brief Routine

https://claude.ai/code/session_01ERgrVYDdDUQHsLgybqsQKB

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgrVYDdDUQHsLgybqsQKB)_