### PR TITLE
brief: 2026-06-11 — Is Nikko Worth Visiting From Tokyo? (Decision Helper)

### DIFF
--- a/seo-pipeline/briefs/2026-06-11-is-nikko-worth-visiting-from-tokyo.md
+++ b/seo-pipeline/briefs/2026-06-11-is-nikko-worth-visiting-from-tokyo.md
@@ -1,0 +1,122 @@
+---
+date: 2026-06-11
+slug: is-nikko-worth-visiting-from-tokyo
+slug_es: merece-la-pena-visitar-nikko
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: medium
+---
+
+# Is Nikko Worth Visiting From Tokyo? A Licensed Guide's Honest Take (2026)
+
+**Spanish Title**: ¿Vale la Pena Visitar Nikko desde Tokio? La Opinión Honesta de un Guía Licenciado (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal — comparison cluster**: 「hakone or nikko」直近28日で 表示 45、クリック 1、順位 8.56。「hakone vs nikko」同期間 impressions 48、クリック 1、順位 8.92。どちらも page 1 手前で止まっており、比較インテントを受け皿にする Decision Helper が不在。
+- **GSC signal — Nikko 単体**: 既存の `/blog/nikko-day-trip-from-tokyo` が 667 impressions・0 クリック・順位 23.8 という異常に沈んだパフォーマンス。クラスター記事を追加してドメイン内リンクを整備することで、グループ全体の順位を押し上げる余地が大きい。
+- **既存記事ギャップ**: `/blog/is-hakone-worth-visiting`（最近追加）の Nikko 対応版が不在。「is it worth visiting」インテントに正面から答える記事がゼロ。
+- **参照インテント**: 「nikko o kamakura」10 impressions / pos 13、「hakone or nikko」「hakone vs nikko」のパターンから、**Nikko を他の日帰りと比較して判断したい読者**が確実に存在する。
+- **想定CV影響**: high — 「Nikko は行く価値がある？」を解決した読者は日帰りツアー予約フェーズに直結。`/blog/tokyo-private-tour-guide-cost`（83.3% engagement rate、311s avg session）と同様の高エンゲージ×高コンバージョン型記事になり得る。
+- **競合状況**: Lonely Planet・Japan Guide が Nikko general 記事で上位占拠。ただし「is it worth / licensed guide opinion / honest take」スラントのある記事は DR80+ サイトの管轄外。ニッチ slant でエントリー可能。
+
+## Target keyword cluster
+
+- **Primary**: "is nikko worth visiting from tokyo"
+- **Secondary**: "nikko day trip worth it", "nikko vs hakone day trip", "how long to spend in nikko"
+- **Search intent**: commercial investigation（日帰り旅行を計画中 → ガイド予約判断の直前段階）
+
+## Differentiation slant (Manabuならでは)
+
+政府公認ガイドが「正直に」答えることがこの記事の核心。以下のプレースホルダーに Manabu さんの実体験を入れてください：
+
+1. **[MANABU EPISODE 1 — Nikko で実際に困った・印象に残ったこと]**
+   例: 500回以上ツアーを案内した中で、日光東照宮の装飾を前にしたゲストが「なぜこんなに豪華なのか」という歴史背景の質問に詰まったこと、徳川家康の一次資料と試験勉強で得た深い知識がある → 一般ガイドとの差別化を具体的に書く
+
+2. **[MANABU EPISODE 2 — Nikko が「向いていないゲスト」の実例]**
+   例: 体力に不安があるシニアのゲストを案内したとき、坂や石畳が多いルートで困った経験。または「半日で回れると思って来たけど全然足りなかった」という声。 → これが正直な「向いている人/向いていない人」セクションの根拠になる
+
+3. **[MANABU EPISODE 3 — Nikko を最大限楽しむ「地元ガイドだけが知る」ポイント]**
+   例: 観光客が素通りするが実は重要な場所、混雑を避ける時間帯、地元で食べるべき湯葉料理の店など → 体験ベースのニッチ情報
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Nikko Worth Visiting From Tokyo? Guide's Honest Take 2026`
+  → 57文字 ✓
+- **Meta description (EN)** (155字以内): `Licensed Tokyo guide Manabu answers: Is Nikko worth a day trip from Tokyo in 2026? Crowd levels, what to see, honest pros and cons — plus who should skip it.`
+  → 156文字 → 短縮版: `Licensed guide Manabu answers: Is Nikko worth a day trip from Tokyo in 2026? Crowd levels, honest pros and cons, and who should skip it.`
+  → 136文字 ✓
+- **Title (ES)** (60字以内): `¿Vale la Pena Visitar Nikko desde Tokio? Guía 2026`
+  → 51文字 ✓
+- **Meta description (ES)** (155字以内): `Manabu, guía oficial licenciado, responde con honestidad: ¿merece la pena Nikko en un día desde Tokio en 2026? Ventajas, desventajas y a quién no le recomendaría ir.`
+  → 165文字 → 短縮: `Guía oficial licenciado responde: ¿merece la pena Nikko en un día desde Tokio? Ventajas, desventajas reales y para quién NO recomendaría la excursión.`
+  → 152文字 ✓
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · My Honest Verdict** — 「行く価値はあるか？」に冒頭で直接答える（Quick Decision ボックス推奨）。条件付きYES + どんな人向きかを一行で。
+2. **Section 02 · What Makes Nikko Worth It** — 日光東照宮の世界遺産としての価値、自然（鬼怒川・中禅寺湖）、江戸期の歴史的文脈。Manabu が案内で必ず伝える「なぜここは他の神社と違うか」エピソード。[MANABU EPISODE 1]
+3. **Section 03 · Who Should Skip Nikko** — 正直な「向いていない人」の議論。体力・時間・興味（装飾過多が好みでない人）・紅葉シーズンの混雑問題。[MANABU EPISODE 2]
+4. **Section 04 · Nikko vs Hakone vs Kamakura — Which Day Trip?** — コンパクトな比較表（nature/history/crowd/ease）。内部リンク: `/blog/kamakura-vs-hakone-vs-nikko-day-trip`、`/blog/is-hakone-worth-visiting`
+5. **Section 05 · How to Get the Most Out of One Day** — 時系列モデルルート（早起き必須、混雑ピーク回避）。[MANABU EPISODE 3] + 湯葉・温泉など。
+6. **Section 06 · With a Guide vs Solo** — 内部リンク先: `/blog/nikko-day-trip-guide-vs-solo`。この記事では「ガイドと行くと何が変わるか」を重点的に。
+7. **Section 07 · FAQ** — 4-5問
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 日光東照宮の入場料（円建て税込、2026年最新）
+- [ ] 輪王寺・二荒山神社を含む「二社一寺」共通拝観券の価格と含まれる施設
+- [ ] 東武日光・JR日光それぞれの所要時間と運賃（新宿・上野・浅草基点）
+- [ ] 鬼怒川温泉エリアへのアクセスと日帰り温泉施設（代表例の価格）
+- [ ] 混雑シーズン（紅葉：10-11月）の入場制限・事前予約要否
+- [ ] 世界遺産「日光の社寺」の登録範囲と含まれる建造物
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura vs Hakone vs Nikko Day Trip](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 三択比較でこの記事への橋渡し、クラスター強化
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — "Nikko vs Hakone" セクションで並置
+- [Nikko Day Trip: With a Guide vs Solo](/blog/nikko-day-trip-guide-vs-solo) — Section 06 で詳細を委譲
+- [Nikko Day Trip From Tokyo](/blog/nikko-day-trip-from-tokyo) — 「実際の行き方」情報を委譲（pos 23.8 をクラスターリンクで引き上げる）
+- [How to Choose a Private Tokyo Guide](/blog/how-to-choose-private-tokyo-guide) — CTAセクション
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["nikko-day-trip"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: `/public/images/` 内の nikko 関連画像があれば使用
+- **不足分（Wikimedia推奨）**: 日光東照宮・陽明門の外観、中禅寺湖と男体山、いろは坂の紅葉
+
+## Risk notes
+
+- **AI Overview リスク（MEDIUM）**: 「is it worth visiting」系クエリは AI が直接回答する傾向。ただし「licensed guide's honest take」という一人称視点 + 体験ベース情報は AI では代替不可。Manabu エピソードの充実でリスク低減。
+- **カニバリリスク（LOW）**: 既存 3 本の Nikko 記事（`nikko-day-trip-from-tokyo`、`nikko-day-trip-guide-vs-solo`、`kamakura-vs-hakone-vs-nikko-day-trip`）は切り口が異なる。「is it worth」インテントは現状どの記事も正面から答えていない。
+- **競合難易度（MEDIUM）**: Lonely Planet・Fodor's・Japan Guide が汎用 Nikko 記事で上位。ただし「is it worth / should I go / guide opinion」スラントへの DR80+ 記事は少ない。ニッチ slant で勝負可能。
+- **ファクト変動リスク**: 入場料・交通費は年次変動。`Last updated: June 2026` を記事に明記し、次回更新時に再チェック。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsNikkoWorthVisitingFromTokyo.tsx` を作成
+2. `src/pages/es/blog/EsMerecelapenaVisitarNikko.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（EN: `/blog/is-nikko-worth-visiting-from-tokyo`、ES: `/es/blog/merece-la-pena-visitar-nikko`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. `tsc` で型チェック
+7. feature ブランチ `claude/blog-is-nikko-worth-visiting` 作成 + commit
+
+---
+
+## データソース注記（Routine向け）
+
+> **フェッチ状況**: 2026-06-11 の GSC/GA4 フェッチは `google-auth` 依存ライブラリ（cffi/cryptography）の不備により失敗。本ブリーフは 2026-05-22 の直近データを参照データとして使用。Routine 本番環境で `GOOGLE_APPLICATION_CREDENTIALS_JSON` secret と Python 依存関係が正しく設定されれば、次回実行から最新データが使用される。

--- a/seo-pipeline/data/daily/2026-06-11.json
+++ b/seo-pipeline/data/daily/2026-06-11.json
@@ -1,0 +1,14 @@
+{
+  "generated_at": "2026-06-11",
+  "window_days": 28,
+  "fetch_status": "partial_failure",
+  "fetch_note": "google-auth dependencies unavailable in this environment (cffi/cryptography missing). Analysis uses reference data from 2026-05-22. Set GOOGLE_APPLICATION_CREDENTIALS_JSON secret for live fetches.",
+  "gsc": {
+    "error": "No module named 'googleapiclient' / cffi backend unavailable",
+    "reference_data_used": "2026-05-22"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient' / cffi backend unavailable",
+    "reference_data_used": "2026-05-22"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Nikko Worth Visiting From Tokyo? A Licensed Guide's Honest Take (2026)
- **slug**: `is-nikko-worth-visiting-from-tokyo` (EN), `merece-la-pena-visitar-nikko` (ES)
- **category**: Decision Helpers
- **priority**: high

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → 家でmergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（3か所のプレースホルダー）に実体験を追記
- [ ] H2 outline（7セクション）が論理的か確認
- [ ] Required facts（入場料・アクセス・共通拝観券）を執筆前にweb検索で検証
- [ ] competitor_difficulty: medium、ai_overview_risk: medium の評価に同意するか

## なぜこの案か

GSCデータより「hakone or nikko」が45 impressions / pos 8.56、「hakone vs nikko」が48 impressions / pos 8.92 で比較インテントが確認。既存の `/blog/is-hakone-worth-visiting`（最近追加）に対応する Nikko 版が空白。既存 Nikko ページ（`nikko-day-trip-from-tokyo`）が667 impressions・0クリック・pos 23.8 と異常に沈んでおり、クラスター強化が急務。Decision Helper カテゴリ（最高 weight 30%）でCV直結。

## ⚠️ フェッチ状況

`fetch_daily.py` は `google-auth` 依存（cffi/cryptography）の不備により 2026-06-11 のリアルタイムデータ取得に失敗。分析は 2026-05-22 の参照データを使用。Routine 本番環境で `GOOGLE_APPLICATION_CREDENTIALS_JSON` secret と Python 依存関係が正しく設定されれば次回から自動解決します。

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-11-is-nikko-worth-visiting-from-tokyo.md](seo-pipeline/briefs/2026-06-11-is-nikko-worth-visiting-from-tokyo.md)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_0152fzCKMXHEJU7zGHaEKieU)_