### PR TITLE
brief: 2026-06-12 — Is Nikko Worth Visiting? Honest Guide from Tokyo (2026)

### DIFF
--- a/seo-pipeline/briefs/2026-06-12-is-nikko-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-06-12-is-nikko-worth-visiting.md
@@ -1,0 +1,129 @@
+---
+date: 2026-06-12
+slug: is-nikko-worth-visiting
+slug_es: vale-la-pena-visitar-nikko
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Is Nikko Worth Visiting? An Honest Day Trip Guide from Tokyo (2026)
+
+**Spanish Title**: ¿Vale la Pena Visitar Nikko desde Tokio? Guía Honesta 2026
+
+## Why this article (data-driven rationale)
+
+- **GSC signal — page**: `/blog/nikko-day-trip-from-tokyo` 直近28日で 表示667回、クリック0回、順位23.8位（高インプレッションにもかかわらずCTRは実質ゼロ → 情報提供記事のままでは判断できない読者をとりこぼしている）
+- **GSC signal — queries**: `hakone or nikko` 直近28日で 表示45回、クリック1回、順位8.56 / `hakone vs nikko` 表示48回、クリック1回、順位8.92 → 「NikkoかHakoneか」比較判断フェーズの読者が実在する
+- **GSC signal — pattern**: `is kamakura worth visiting` 表示27回、クリック1回、順位3.11 → 「行く価値があるか」フォーマットが既存Kamakura/Hakoneクラスターで機能していることを確認
+- **既存記事ギャップ**: `/blog/nikko-day-trip-from-tokyo`（情報提供型）・`/blog/nikko-day-trip-guide-vs-solo`（比較型）・`/blog/hakone-vs-nikko-day-trip`（並列比較）は存在するが、「そもそもNikkoに行く価値があるか」という判断支援フォーマットの記事がない。`/blog/is-hakone-worth-visiting` でこのフォーマットが成立したため、並列展開が有効
+- **想定CV影響**: HIGH — 「行く価値があるか」で検索するユーザーは旅程の最終決定段階にあり、Manabuのガイド推薦→問い合わせフォームへの動線が最も短い
+- **競合状況**: 上位はLonely Planet, TripAdvisor, japan-guide.com（いずれもDR70+）。ただし「政府公認ガイドとしての正直な評価」という体験ベースのslantは未開拓。ニッチ差別化余地あり
+
+## Target keyword cluster
+
+- **Primary**: "is nikko worth visiting"
+- **Secondary**: "nikko day trip worth it", "nikko one day itinerary 2026", "should i visit nikko or hakone", "nikko worth it from tokyo"
+- **Search intent**: commercial investigation（行く価値があるかを判断し、次の予約行動に移る段階）
+
+## Differentiation slant (Manabuならでは)
+
+**[MANABU EPISODE PLACEHOLDER 1]**
+Nikkoのツアーで、ゲストが陽明門・奥社・杉並木のどの瞬間に「来てよかった」と感じたか、実際のエピソードを1つ書いてください。「世界遺産なのに日本人でも知らない人が多いのはなぜ？」という質問に、Manabuとしてどう答えているかも添えてください。（例：「東照宮の彫刻の数を全部数えたら一生かかる、と説明したら皆さん笑いながら写真を撮り続けてくれました」など）
+
+**[MANABU EPISODE PLACEHOLDER 2]**
+「NikkoとKamakura/Hakone、どちらがおすすめですか？」と聞かれたとき、Manabuはどのような基準で答えているか書いてください。「自然が好きな人はHakone、歴史に興味がある人はNikko」という以上の、ガイドとして観察してきた「Nikkoで感動するゲストのタイプ」「Nikkoに向かないゲストのタイプ」を具体的に。
+
+**[MANABU EPISODE PLACEHOLDER 3]**
+全国通訳案内士として日本史の試験に合格しているManabuだからこそ語れる、日光東照宮に纏わる歴史的背景を1つ選んでください。（例：徳川家康が「死後に神になった」経緯、東照宮の建設に携わった職人の数や期間、陽明門の「魔除けに1本だけ逆向きにした柱」の意味など）一般の旅行ブログでは読めない深さで。
+
+**Claudeが提案する3つの差別化軸（プレースホルダー以外）:**
+
+1. **"The licensed guide's honest verdict"構造**: 記事冒頭に `quick-decision` ブロックで「行く価値がある人」「行かなくていい人」をズバリ明言する。読者の時間を尊重し、答えを最初に渡す構成は、情報を並べるだけの他記事と決定的に異なる。
+
+2. **"1 day is enough — here's exactly why" セクション**: 多くのブログが「できれば2日」と書く中、「1日で十分な理由と、その時の動き方」を具体ルート付きで断言する。逆に「1日では物足りないケース」も正直に書く。このアンビバレントな誠実さがCV前の信頼を生む。
+
+3. **混雑回避の現地情報**: 2024-2026年に実際にツアーで訪れた経験から、「観光バスが来る前に奥社を回る」「杉並木は朝7時台が別世界」といった、ウェブ検索では出てこない時間帯・ルート情報を含める。
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Nikko Worth Visiting? Honest Guide from Tokyo (2026)`
+- **Meta description (EN)** (155字以内): `Is Nikko worth a day trip from Tokyo? Licensed guide Manabu gives an honest verdict — who should go, who can skip it, and how to make the most of one day in Nikko in 2026.`
+- **Title (ES)** (60字以内): `¿Vale la Pena Visitar Nikko desde Tokio? Guía 2026`
+- **Meta description (ES)** (155字以内): `¿Merece la pena visitar Nikko en un día desde Tokio? El guía oficial Manabu da su veredicto honesto: quién debería ir, quién puede saltárselo y cómo aprovechar el día al máximo.`
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Honest Verdict** — `quick-decision` ブロックで冒頭に結論を提示。「歴史・建築・自然を一度に体験したい人 → YES / 海・砂浜・リラックス重視 → Hakoneへ」という明快な振り分け。Manabuの個人的な評価を一言で。
+
+2. **Section 02 · What Makes Nikko Special** — 日光東照宮・輪王寺・二荒山神社（「二社一寺」）の世界遺産としての価値をManabuの歴史知識で解説。陽明門の彫刻、奥社の静寂、杉並木の規模感など、写真では伝わらない体験の質を伝える。[MANABU EPISODE PLACEHOLDER 3] を配置。
+
+3. **Section 03 · Is One Day in Nikko Enough?** — `choice-grid` ブロックで「1日で十分なケース」vs「もう1泊したいケース」を整理。具体的な1日ルート（推奨スタート時刻・見学順序・終了時刻）を示す。混雑回避の時間帯情報を含める。
+
+4. **Section 04 · Nikko vs Hakone vs Kamakura — Choosing Your Day Trip** — `cost-table` + `bar-cell` で3択を「歴史性・自然度・移動コスト・混雑度・Manabu推薦度」の軸で比較。既存記事への内部リンクを自然に配置。[MANABU EPISODE PLACEHOLDER 2] を配置。
+
+5. **Section 05 · Practical Info for 2026** — アクセス方法（東武特急/新幹線+乗り換え）の所要時間・運賃感の概要（具体的数値はRequired Factsで確認後記入）。best season・混雑シーズン・服装・拝観料の目安を記載。[MANABU EPISODE PLACEHOLDER 1] を配置。
+
+6. **Section 06 · Should You Go with a Guide?** — `guide-note-callout` でManabuのポートレート付きコメント。Nikkoでガイドを雇う価値（歴史解説の深さ・移動ルート最適化・言語サポート）を具体的に。CVへの直接導線（問い合わせCTA）。
+
+7. **Section 07 · FAQ** — `faq-block` でラップ
+   - Is Nikko safe for solo travelers?
+   - How far is Nikko from Tokyo?
+   - Do I need to book Nikko attractions in advance?
+   - Is Nikko open year-round?
+   - How does Nikko compare to Hakone for first-timers?
+
+## Required facts (web search before writing)
+
+執筆前に web search で必ず検証：
+
+- [ ] 日光東照宮の拝観料（円建て・税込）と営業時間・定休日（2026年版）
+- [ ] 輪王寺・二荒山神社の拝観料と時間（2026年版）
+- [ ] 東京〜日光のアクセス：東武特急きぬ/けごん（浅草〜東武日光）の所要時間・2026年運賃
+- [ ] 新幹線+東武乗り換え（宇都宮/那須塩原）ルートの所要時間と費用
+- [ ] 日光・足尾フリーパス等の周遊パスの種類・価格（2026年版）
+- [ ] 世界遺産「日光の社寺」の登録年・登録対象の正式範囲
+
+## Internal link plan (既存記事への参照)
+
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — 同フォーマットの比較対象。Hakoneを検討していた読者へのクロスリンク
+- [Hakone vs Nikko Day Trip](/blog/hakone-vs-nikko-day-trip) — 両方を比較している読者への詳細比較記事
+- [Nikko Day Trip: Guide vs Solo](/blog/nikko-day-trip-guide-vs-solo) — ガイド同行の価値検討記事へ
+- [Kamakura vs Hakone vs Nikko](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 3択比較の上位記事
+- [Best Day Trips from Tokyo](/blog/best-day-trips-from-tokyo) — ピラー記事への上位接続（Nikkoセクションに双方向リンク）
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["nikko-day-trip"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: `/tours/nikko-day-trip` ページ内の既存ツアー写真素材を確認
+- **不足分（Wikimedia Commons / CC候補）**: 陽明門（Yomeimon Gate）正面構図、奥社（Okusha）杉並木参道、華厳の滝（Kegon Falls）、輪王寺三仏堂外観
+
+## Risk notes
+
+- 「1 day itinerary nikko」系は競合多数（Lonely Planet, TripAdvisor）。「行く価値があるか」の判断支援フレームで差別化すること
+- AI Overview対応: 「行く価値があるか」は体験・判断・意見の領域のため、価格や時刻のような純粋情報クエリよりAI Overview吸収リスクは低い ✅
+- 日光東照宮の拝観料・開館時間は季節によって変動あり。Required Facts確認必須。"Last updated: June 2026" を記事内に明記すること
+- 既存クラスター（nikko-day-trip-from-tokyo, nikko-day-trip-guide-vs-solo, hakone-vs-nikko）との内部リンク構造を確認し、重複表現は避けつつクラスター強化になる構成にすること
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsNikkoWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValelapenaVisitarNikko.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加:
+   - `<Route path="/blog/is-nikko-worth-visiting" element={<IsNikkoWorthVisiting />} />`
+   - `<Route path="/es/blog/vale-la-pena-visitar-nikko" element={<EsValelapenaVisitarNikko />} />`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. `tsc` で型チェック
+7. feature ブランチ `feature/is-nikko-worth-visiting` で commit

--- a/seo-pipeline/data/daily/2026-06-12.json
+++ b/seo-pipeline/data/daily/2026-06-12.json
@@ -1,0 +1,113 @@
+{
+  "generated_at": "2026-06-12",
+  "window_days": 28,
+  "_note": "API credentials unavailable in this execution environment. Data carried forward from 2026-05-22 (most recent successful pull). GSC/GA4 figures reflect window 2026-04-24 to 2026-05-22. Brief analysis is based on this reference data.",
+  "gsc": {
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "clicks": 275,
+      "impressions": 101626,
+      "page_count": 154,
+      "query_count": 2556
+    },
+    "top_queries_by_impression": [
+      { "query": "kamakura", "clicks": 2, "impressions": 403, "ctr": 0.4963, "position": 4.37 },
+      { "query": "tsukiji outer market opening hours 2026", "clicks": 1, "impressions": 505, "ctr": 0.198, "position": 3.12 },
+      { "query": "tsukiji fish market opening hours", "clicks": 2, "impressions": 264, "ctr": 0.7576, "position": 11.36 },
+      { "query": "tsukiji market opening hours", "clicks": 1, "impressions": 256, "ctr": 0.3906, "position": 9.72 },
+      { "query": "japan private tour guide cost", "clicks": 1, "impressions": 107, "ctr": 0.9346, "position": 9.37 },
+      { "query": "kamakura vs hakone", "clicks": 2, "impressions": 86, "ctr": 2.3256, "position": 6.14 },
+      { "query": "hakone or kamakura", "clicks": 1, "impressions": 74, "ctr": 1.3514, "position": 6.95 },
+      { "query": "hakone vs nikko", "clicks": 1, "impressions": 48, "ctr": 2.0833, "position": 8.92 },
+      { "query": "hakone or nikko", "clicks": 1, "impressions": 45, "ctr": 2.2222, "position": 8.56 },
+      { "query": "is tsukiji market open on sunday", "clicks": 1, "impressions": 45, "ctr": 2.2222, "position": 9.42 },
+      { "query": "japan rail pass 2026 price", "clicks": 1, "impressions": 42, "ctr": 2.381, "position": 4.86 },
+      { "query": "tsukiji outer market", "clicks": 1, "impressions": 55, "ctr": 1.8182, "position": 16.85 },
+      { "query": "is kamakura worth visiting", "clicks": 1, "impressions": 27, "ctr": 3.7037, "position": 3.11 },
+      { "query": "tsukiji hours", "clicks": 1, "impressions": 23, "ctr": 4.3478, "position": 8.39 },
+      { "query": "nikko o kamakura", "clicks": 1, "impressions": 10, "ctr": 10.0, "position": 13.0 }
+    ],
+    "top_pages_by_impression": [
+      { "page": "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it", "clicks": 15, "impressions": 38565, "ctr": 0.0389, "position": 8.18 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide", "clicks": 92, "impressions": 26845, "ctr": 0.3427, "position": 6.52 },
+      { "page": "https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette", "clicks": 1, "impressions": 4498, "ctr": 0.0222, "position": 10.82 },
+      { "page": "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip", "clicks": 37, "impressions": 3292, "ctr": 1.1239, "position": 6.23 },
+      { "page": "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio", "clicks": 9, "impressions": 2699, "ctr": 0.3335, "position": 8.13 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost", "clicks": 11, "impressions": 2564, "ctr": 0.429, "position": 7.38 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu", "clicks": 10, "impressions": 2197, "ctr": 0.4552, "position": 8.1 },
+      { "page": "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide", "clicks": 9, "impressions": 1698, "ctr": 0.53, "position": 7.23 },
+      { "page": "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "clicks": 10, "impressions": 1414, "ctr": 0.7072, "position": 9.73 },
+      { "page": "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple", "clicks": 5, "impressions": 1319, "ctr": 0.3791, "position": 7.14 },
+      { "page": "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route", "clicks": 6, "impressions": 813, "ctr": 0.738, "position": 6.02 },
+      { "page": "https://tanuki-tabi-travel.com/blog/yokohama-day-trip-from-tokyo", "clicks": 4, "impressions": 682, "ctr": 0.5865, "position": 7.82 },
+      { "page": "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo", "clicks": 0, "impressions": 667, "ctr": 0.0, "position": 23.8 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tokyo-3-day-itinerary", "clicks": 1, "impressions": 664, "ctr": 0.1506, "position": 9.21 },
+      { "page": "https://tanuki-tabi-travel.com/blog/old-tokyo-shitamachi", "clicks": 2, "impressions": 624, "ctr": 0.3205, "position": 8.06 },
+      { "page": "https://tanuki-tabi-travel.com/blog/shinjuku-guide", "clicks": 0, "impressions": 482, "ctr": 0.0, "position": 13.33 },
+      { "page": "https://tanuki-tabi-travel.com/blog/mount-fuji-from-tokyo", "clicks": 0, "impressions": 441, "ctr": 0.0, "position": 10.47 },
+      { "page": "https://tanuki-tabi-travel.com/blog/hakone-day-trip-guide-vs-solo", "clicks": 9, "impressions": 404, "ctr": 2.2277, "position": 21.2 }
+    ],
+    "zero_click_opportunities": [
+      { "query": "jr pass price increase 2026", "clicks": 0, "impressions": 1121, "ctr": 0, "position": 5.45 },
+      { "query": "japan rail pass prices 2026 official", "clicks": 0, "impressions": 558, "ctr": 0, "position": 7.68 },
+      { "query": "japan rail pass current prices 2026", "clicks": 0, "impressions": 531, "ctr": 0, "position": 9.71 },
+      { "query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92 },
+      { "query": "japan rail pass price 2026 official", "clicks": 0, "impressions": 262, "ctr": 0, "position": 8.59 },
+      { "query": "japan rail pass official prices 2026", "clicks": 0, "impressions": 254, "ctr": 0, "position": 8.63 },
+      { "query": "tsukiji outer market official hours 2026", "clicks": 0, "impressions": 252, "ctr": 0, "position": 3.4 }
+    ],
+    "near_page_one_pushup": [
+      { "query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92 }
+    ],
+    "new_queries_last7": [
+      { "query": "is hakone worth visiting", "clicks": 0, "impressions": 6, "ctr": 0, "position": 40.83 },
+      { "query": "nonbei yokocho walking time from shibuya station", "clicks": 0, "impressions": 5, "ctr": 0, "position": 10.0 },
+      { "query": "best places to see mount fuji from tokyo 2026", "clicks": 0, "impressions": 4, "ctr": 0, "position": 5.75 },
+      { "query": "early morning breakfast tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 1.0 },
+      { "query": "hire a guide in tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 23.0 }
+    ]
+  },
+  "ga4": {
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "sessions": 749.0,
+      "totalUsers": 623.0,
+      "screenPageViews": 938.0,
+      "engagementRate": 0.3925,
+      "averageSessionDuration": 306.08
+    },
+    "events": [
+      { "eventName": "page_view", "eventCount": 938.0, "totalUsers": 623.0 },
+      { "eventName": "form_submit", "eventCount": 8.0, "totalUsers": 8.0 },
+      { "eventName": "book_now_click", "eventCount": 20.0, "totalUsers": 16.0 },
+      { "eventName": "contact_page_view", "eventCount": 32.0, "totalUsers": 27.0 },
+      { "eventName": "tour_page_view", "eventCount": 101.0, "totalUsers": 52.0 },
+      { "eventName": "form_start", "eventCount": 11.0, "totalUsers": 10.0 }
+    ],
+    "organic_landing_pages": [
+      { "landingPagePlusQueryString": "/blog/tsukiji-market-guide", "sessions": 135.0, "engagementRate": 0.5333, "averageSessionDuration": 245.95 },
+      { "landingPagePlusQueryString": "/blog/kamakura-vs-hakone-vs-nikko-day-trip", "sessions": 47.0, "engagementRate": 0.6383, "averageSessionDuration": 2982.62 },
+      { "landingPagePlusQueryString": "/blog/japan-rail-pass-worth-it", "sessions": 17.0, "engagementRate": 0.4118, "averageSessionDuration": 166.83 },
+      { "landingPagePlusQueryString": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "sessions": 14.0, "engagementRate": 0.4286, "averageSessionDuration": 124.77 },
+      { "landingPagePlusQueryString": "/blog/tokyo-private-tour-guide-cost", "sessions": 12.0, "engagementRate": 0.8333, "averageSessionDuration": 311.57 },
+      { "landingPagePlusQueryString": "/blog/nikko-day-trip-guide-vs-solo", "sessions": 2.0, "engagementRate": 0.5, "averageSessionDuration": 373.52 },
+      { "landingPagePlusQueryString": "/blog/yanaka-tokyo-walking-route", "sessions": 7.0, "engagementRate": 0.7143, "averageSessionDuration": 757.88 }
+    ],
+    "sources": [
+      { "sessionSource": "google", "sessionMedium": "organic", "sessions": 372.0, "engagementRate": 0.5134 },
+      { "sessionSource": "(direct)", "sessionMedium": "(none)", "sessions": 239.0, "engagementRate": 0.205 },
+      { "sessionSource": "chatgpt.com", "sessionMedium": "(not set)", "sessions": 46.0, "engagementRate": 0.2609 }
+    ],
+    "countries": [
+      { "country": "United States", "sessions": 214.0, "engagementRate": 0.3411 },
+      { "country": "Japan", "sessions": 162.0, "engagementRate": 0.4321 },
+      { "country": "Spain", "sessions": 59.0, "engagementRate": 0.6102 }
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Nikko Worth Visiting? Honest Guide from Tokyo (2026)
- **slug**: `is-nikko-worth-visiting` (EN), `vale-la-pena-visitar-nikko` (ES)
- **category**: Decision Helpers
- **priority**: high

## データ根拠（なぜこの案か）

- `/blog/nikko-day-trip-from-tokyo` が**表示667回・クリック0回・順位23.8位**という異常な乖離 → 情報提供型では判断できない読者がとりこぼされている
- `hakone or nikko`（表示45回、順位8.56）・`hakone vs nikko`（表示48回、順位8.92）の比較クエリが実在 → Nikkoの判断支援コンテンツへの需要が確認できる
- `/blog/is-hakone-worth-visiting` で「行く価値があるか」フォーマットが成立 → 同フォーマットをNikkoに展開する明確なギャップ
- Decision Helpers カテゴリ（weight 30%）で form_submit 影響度が最高、CVへの動線が最短

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして `build-article` スキルで記事化へ
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（3つのプレースホルダー）に実体験を追記
- [ ] H2 outlineが論理的か確認（特にSection 03の1日ルート詳細）
- [ ] Required facts（拝観料・アクセス・パス費用）をweb searchで検証
- [ ] competitor_difficulty: medium、ai_overview_risk: low の評価が妥当か確認

## ファイル

- ブリーフ本体: [seo-pipeline/briefs/2026-06-12-is-nikko-worth-visiting.md](seo-pipeline/briefs/2026-06-12-is-nikko-worth-visiting.md)
- データ参照: [seo-pipeline/data/daily/2026-06-12.json](seo-pipeline/data/daily/2026-06-12.json)（2026-05-22キャッシュ使用 — API認証はRoutine環境のみ有効）

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_018qWSbFjSmBGjyaiQaLPaU8)_