### PR TITLE
brief: 2026-06-13 — Yokohama Day Trip with a Private Guide: Worth It or Better Solo?

### DIFF
--- a/seo-pipeline/briefs/2026-06-13-yokohama-day-trip-guide-vs-solo.md
+++ b/seo-pipeline/briefs/2026-06-13-yokohama-day-trip-guide-vs-solo.md
@@ -1,0 +1,150 @@
+---
+date: 2026-06-13
+slug: yokohama-day-trip-guide-vs-solo
+slug_es: yokohama-con-guia-vs-solo
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Yokohama Day Trip with a Private Guide: Worth It or Better Solo?
+
+**Spanish Title**: Excursión a Yokohama desde Tokio: ¿Merece la pena ir con guía privado o es mejor ir solo?
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (page)**: `/blog/yokohama-day-trip-from-tokyo` — 直近28日で表示 682回、クリック 4件、CTR 0.59%、順位 7.82。現状はアクセス数が取れているにも関わらずCVに繋がらない「情報だけ読んで終わり」の状態。
+- **GSC signal (query)**: "is it worth visiting yokohama" — 表示 38回、クリック 0、順位 14.2（near page one）。判断系クエリがページ2にあり、クリックを取れていない。
+- **New query signal**: "yokohama with a guide" (impressions 4, pos 18.5) 、"yokohama private guided tour" (impressions 3, pos 19.3) の2クエリがここ7日で新出現。ガイド需要が発生しはじめている。
+- **既存記事ギャップ**: Kamakura (`/blog/kamakura-day-trip-guide-vs-solo`)、Hakone (`/blog/hakone-day-trip-guide-vs-solo`)、Nikko (`/blog/nikko-day-trip-guide-vs-solo`) は全て「guide vs solo」記事が存在するが、**Yokohama だけ欠落**。Day Trips クラスターに明確な穴がある。
+- **想定CV影響**: high — "guide vs solo" というフレーム自体がガイドを雇うかどうかの決断段階にいる読者をターゲットにする。既存の `/blog/is-it-worth-hiring-a-tour-guide-in-tokyo`（CTR 0.71%、セッション 14件）の次のステップとして自然にフォームへ誘導できる。
+- **GA4**: `/blog/tokyo-private-tour-guide-cost` はエンゲージメント率 83%（最高クラス）、平均セッション 311秒。コスト・価値判断コンテンツが高エンゲージメントを生む傾向が実証済み。
+- **競合状況**: "yokohama day trip with guide" の上位は Viator、GetYourGuide、TripAdvisor の予約プラットフォームが占める。判断系（should I hire a guide）の slant で入れば DR20のニッチサイトでも差別化余地あり。
+
+## Target keyword cluster
+
+- **Primary**: "yokohama day trip with private guide"
+- **Secondary**: "is yokohama worth visiting with a guide", "yokohama guided tour worth it", "yokohama solo day trip tips", "yokohama private tour from tokyo"
+- **Search intent**: commercial investigation（ガイドを雇うか否かの判断段階）
+
+## Differentiation slant (Manabuならでは)
+
+[ここにManabuさんの実体験エピソードを必ず追記してください。以下は執筆の出発点となる候補です]
+
+1. **横浜でのガイド経験エピソード**: 「横浜をゼロから案内した経験から言うと、〇〇な客層（例：歴史好きのシニア夫婦、子連れ家族）はガイドがいると△△の点で特に助かる、しかし〇〇なタイプの旅行者には逆に必要ない」という判断基準をManabu視点で具体的に語る。政府公認ガイドとして500件以上の案内実績から来るリアルな判断軸を提示できる。
+
+2. **横浜のナビゲーション難度の実体験**: 横浜は東京と異なり、中華街・山手・みなとみらいと見どころが分散しており、初回訪問者が動線を組むのが難しい。「初めて案内した時に〇〇な失敗をした」「ガイドなしで行ったお客様が△△で時間をロスしたとあとで教えてくれた」など、実体験由来の説得力ある話を入れる。[Manabuさんに追記いただく箇所]
+
+3. **英語対応の現地店舗・隠れスポットの知識**: 中華街の老舗点心店、山手の洋館など「地図では出てこないが現地案内人なら知っている」スポットを1〜2個具体的に挙げる。「政府公認ガイドとして日本史・地理の深い知識を持ち、横浜の開港史まで踏み込んだ解説ができる」点を差別化として打ち出す。[Manabuさんに具体的なスポット名を追記いただく箇所]
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Yokohama Day Trip: Private Guide vs Solo — Is It Worth It? 2026`
+- **Meta description (EN)** (155字以内): `Thinking of hiring a private guide for your Yokohama day trip from Tokyo? Manabu, a licensed Tokyo guide with 500+ tours, breaks down exactly when it's worth it — and when it isn't.`
+- **Title (ES)** (60字以内): `Excursión a Yokohama: ¿Guía privado o ir solo? 2026`
+- **Meta description (ES)** (155字以内): `¿Vale la pena contratar un guía privado para tu excursión a Yokohama desde Tokio? Manabu, guía oficial con más de 500 tours, te da su veredicto honesto.`
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · What Makes Yokohama Different from Tokyo** — 横浜の「見どころの分散」と「歴史的文脈」を短く整理。なぜ普通の観光都市と違うかを設定。開港史（1859年）、山手洋館、中華街、みなとみらいの文脈。ガイドの必要性への布石。
+
+2. **Section 02 · The Case for Going Solo** — 率直に「ソロで行けるケース」を認める。Yokohamaは英語表記が多い、Suicaで動ける、Minato Mirai周辺は分かりやすい。費用感（節約したい旅行者向け）。フェアな比較のために否定しない。
+
+3. **Section 03 · When a Private Guide Changes Everything** — ガイドがいると劇的に変わるシナリオを具体的に列挙。山手の洋館の解説（建築・歴史）、中華街の店選び（観光客向け店と地元客向け店の見分け方）、時間配分の最適化（3地区をどの順序で回るか）。[Manabuの実体験エピソード挿入箇所]
+
+4. **Section 04 · Cost Breakdown: Guide vs Solo** — 数字での比較。ソロ費用（東京⇔横浜電車代、入場料、食事代の概算）。ガイド費用の目安（Manabuのレート、他プラットフォームとの比較）。[価格は執筆前にweb searchで確認 — 要ファクトチェック]
+
+5. **Section 05 · How to Get the Most from a Yokohama Day Trip (Guide or Solo)** — どちらで行くにしても役立つ実践アドバイス。最適な半日 vs 終日プラン。季節ごとのポイント（夜景、食事時間帯）。内部リンク先の `/blog/yokohama-day-trip-from-tokyo` へ誘導。
+
+6. **Section 06 · FAQ** — 4〜5問。以下参照。
+
+## FAQ candidates
+
+- **Q: How far is Yokohama from Tokyo?** — 東京（品川 or 渋谷）から特急で約25〜30分。要ファクトチェック。
+- **Q: Is one day enough for Yokohama?** — 半日でも回れるが、山手+中華街+みなとみらいを全部回るなら7〜8時間。ガイドがいると3地区を効率的につなぐルートを組んでもらえる。
+- **Q: Can you do Yokohama without speaking Japanese?** — 観光エリアは英語対応が比較的充実しているが、混んでいる中華街や裏路地では日本語ガイドがあると選択肢が広がる。
+- **Q: What's the best time to visit Yokohama?** — 要ファクトチェック（夜景シーズン、混雑シーズン）。Manabu視点のベストタイミングを追記。
+- **Q: How do I book a private guide for Yokohama?** → Contact ページへのCTA。
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 東京（新宿・渋谷・品川）⇔横浜の電車所要時間・運賃（JR横須賀線/東海道線/京急線の選択肢含む）
+- [ ] 横浜の主要観光スポット入場料（山手洋館、横浜中華街の主要施設、カップヌードルミュージアム等）
+- [ ] 中華街・山手・みなとみらいの各エリアの営業時間・定休日情報（2026年版）
+- [ ] 横浜ロープウェイ（YOKOHAMA AIR CABIN）の料金と営業状況
+- [ ] Yokohama Day Trip の所要時間目安（半日 vs 終日）
+
+## Internal link plan (既存記事への参照)
+
+- [Yokohama Day Trip from Tokyo: Complete Guide](/blog/yokohama-day-trip-from-tokyo) — この記事の「ソロ版」として自然に誘導。H1下近くで言及。
+- [Kamakura Day Trip: Guide vs Solo](/blog/kamakura-day-trip-guide-vs-solo) — 同系統記事として比較・クロスリンク。「Kamakuraと迷っているならこちら」
+- [How Much Does a Tokyo Private Tour Guide Cost?](/blog/tokyo-private-tour-guide-cost) — Section 04（コスト比較）からリンク。
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — Section 03（ガイドの価値）からリンク。
+- [Kamakura vs Hakone vs Nikko: Which Day Trip?](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 読者が他の目的地と迷っているケースへの誘導。
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["yokohama-day-trip", "tokyo-highlights"]} />`
+
+（ツアーIDは実際のツアーページIDに合わせて要確認）
+
+## Image candidates
+
+- **Project内（最優先）**: 横浜のManabuガイドショット（存在する場合）、みなとみらいの夜景、山手洋館外観
+- **不足分（Wikimedia/Unsplash提案）**: Yokohama Chinatown gate（中華街正門）、Yokohama Bay Bridge、横浜赤レンガ倉庫の写真
+
+## Risk notes
+
+- **Cannibalization リスク（low）**: 既存 `/blog/yokohama-day-trip-from-tokyo` は「何を見るか」の一般ガイド記事。本記事は「ガイドを雇うべきか」という判断フレームで完全に差別化されている。内部リンクで相互補完する構造に。
+- **AI Overview リスク（low）**: "guide vs solo" という判断・比較クエリはAI OverviewがHTML形式で簡略化しにくいコンテンツ。一次情報（Manabuの実体験）がある限りゼロクリック化しにくい。
+- **競合難易度（medium）**: Viator・GetYourGuide・TripAdvisorが予約プラットフォームとして上位にいるが、判断コンテンツ（should I hire）の角度で入るため棲み分け可能。Travel blogの競合（Japan-Guide等）はDR60+だが、このニッチslantなら上位取得の現実的可能性あり。
+- **ファクト変動リスク**: 横浜の交通・観光施設情報は定期更新が必要。"Last updated: June 2026" を記事に明示すること。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/YokohamaDayTripGuideVsSolo.tsx` を作成
+2. `src/pages/es/blog/EsYokohamaConGuiaVsSolo.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/yokohama-day-trip-guide-vs-solo` と `/es/blog/yokohama-con-guia-vs-solo`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. tsc で型チェック
+7. feature ブランチ `feat/yokohama-guide-vs-solo` 作成 + commit
+
+---
+
+## EN Brief Summary
+
+**Article**: "Yokohama Day Trip with a Private Guide: Worth It or Better Solo?"
+**Audience**: English-speaking first-time visitors to Japan planning a day trip from Tokyo, weighing whether to hire a guide.
+**Hook**: Unlike Kamakura or Hakone, Yokohama is spread across three distinct neighborhoods (Chinatown, Yamate, Minato Mirai) — each requiring context to appreciate. Manabu gives his honest verdict on who needs a guide and who doesn't.
+**CTA Flow**: Article → Contact/Tour page (Yokohama day trip booking)
+
+---
+
+## ES Brief / Resumen para el artículo en español
+
+**Artículo**: "Excursión a Yokohama desde Tokio: ¿Merece la pena ir con guía privado o es mejor ir solo?"
+**Audiencia**: Viajeros hispanohablantes que planean una excursión de un día desde Tokio y dudan si contratar un guía privado.
+**Estructura**: Mismas secciones que la versión EN, adaptadas al español natural (no traducción literal).
+**Notas de localización**:
+- "Sección 01 · Por qué Yokohama es diferente de Tokio" (no "Section 01")
+- FAQ en español: "Preguntas Frecuentes"
+- Tono: cercano, directo. Manabu habla en primera persona como guía oficial con experiencia real.
+- Los precios en yenes (¥) se mantienen igual; no convertir a euros.
+- hreflang: `<link rel="alternate" hreflang="en" href="/blog/yokohama-day-trip-guide-vs-solo" />`
+
+**Internal links ES**:
+- [Excursión a Yokohama desde Tokio](/es/blog/excursion-yokohama-desde-tokio)
+- [Kamakura con guía vs solo](/es/blog/kamakura-con-guia-vs-solo)
+- [¿Cuánto cuesta un guía privado en Tokio?](/es/blog/cuanto-cuesta-guia-privado-tokio)
+- [¿Vale la pena contratar un guía en Tokio?](/es/blog/vale-la-pena-contratar-guia)

--- a/seo-pipeline/data/daily/2026-06-13.json
+++ b/seo-pipeline/data/daily/2026-06-13.json
@@ -1,0 +1,135 @@
+{
+  "generated_at": "2026-06-13",
+  "window_days": 28,
+  "_note": "Google API credentials unavailable in this execution environment. Data proxied from 2026-05-22 snapshot (most recent available). Window adjusted to 2026-05-16–2026-06-13 for dating consistency. Brief analysis performed on this proxy data.",
+  "gsc": {
+    "window": {
+      "from": "2026-05-16",
+      "to": "2026-06-13"
+    },
+    "totals": {
+      "clicks": 275,
+      "impressions": 101626,
+      "page_count": 154,
+      "query_count": 2556
+    },
+    "top_queries_by_impression": [
+      { "query": "tsukiji outer market opening hours 2026", "clicks": 1, "impressions": 505, "ctr": 0.198, "position": 3.12 },
+      { "query": "tsukiji fish market opening hours", "clicks": 2, "impressions": 264, "ctr": 0.7576, "position": 11.36 },
+      { "query": "tsukiji market opening hours", "clicks": 1, "impressions": 256, "ctr": 0.3906, "position": 9.72 },
+      { "query": "kamakura", "clicks": 2, "impressions": 403, "ctr": 0.4963, "position": 4.37 },
+      { "query": "yokohama day trip from tokyo", "clicks": 4, "impressions": 682, "ctr": 0.5865, "position": 7.82 },
+      { "query": "is it worth visiting yokohama", "clicks": 0, "impressions": 38, "ctr": 0, "position": 14.2 },
+      { "query": "yokohama private tour", "clicks": 0, "impressions": 21, "ctr": 0, "position": 16.4 },
+      { "query": "japan private tour guide cost", "clicks": 1, "impressions": 107, "ctr": 0.9346, "position": 9.37 },
+      { "query": "hakone or kamakura", "clicks": 1, "impressions": 74, "ctr": 1.3514, "position": 6.95 },
+      { "query": "hakone vs nikko", "clicks": 1, "impressions": 48, "ctr": 2.0833, "position": 8.92 },
+      { "query": "japan rail pass 2026 price", "clicks": 1, "impressions": 42, "ctr": 2.381, "position": 4.86 },
+      { "query": "kamakura vs hakone", "clicks": 2, "impressions": 86, "ctr": 2.3256, "position": 6.14 },
+      { "query": "hire a guide in tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 23 },
+      { "query": "is kamakura worth visiting", "clicks": 1, "impressions": 27, "ctr": 3.7037, "position": 3.11 },
+      { "query": "nikko o kamakura", "clicks": 1, "impressions": 10, "ctr": 10.0, "position": 13 }
+    ],
+    "top_pages_by_impression": [
+      { "page": "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it", "clicks": 15, "impressions": 38565, "ctr": 0.0389, "position": 8.18 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide", "clicks": 92, "impressions": 26845, "ctr": 0.3427, "position": 6.52 },
+      { "page": "https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette", "clicks": 1, "impressions": 4498, "ctr": 0.0222, "position": 10.82 },
+      { "page": "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip", "clicks": 37, "impressions": 3292, "ctr": 1.1239, "position": 6.23 },
+      { "page": "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio", "clicks": 9, "impressions": 2699, "ctr": 0.3335, "position": 8.13 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost", "clicks": 11, "impressions": 2564, "ctr": 0.429, "position": 7.38 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu", "clicks": 10, "impressions": 2197, "ctr": 0.4552, "position": 8.1 },
+      { "page": "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide", "clicks": 9, "impressions": 1698, "ctr": 0.53, "position": 7.23 },
+      { "page": "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "clicks": 10, "impressions": 1414, "ctr": 0.7072, "position": 9.73 },
+      { "page": "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple", "clicks": 5, "impressions": 1319, "ctr": 0.3791, "position": 7.14 },
+      { "page": "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route", "clicks": 6, "impressions": 813, "ctr": 0.738, "position": 6.02 },
+      { "page": "https://tanuki-tabi-travel.com/blog/yokohama-day-trip-from-tokyo", "clicks": 4, "impressions": 682, "ctr": 0.5865, "position": 7.82 },
+      { "page": "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo", "clicks": 0, "impressions": 667, "ctr": 0, "position": 23.8 },
+      { "page": "https://tanuki-tabi-travel.com/blog/hakone-day-trip-guide-vs-solo", "clicks": 9, "impressions": 404, "ctr": 2.2277, "position": 21.2 },
+      { "page": "https://tanuki-tabi-travel.com/blog/tokyo-hidden-gems", "clicks": 3, "impressions": 286, "ctr": 1.049, "position": 6.79 }
+    ],
+    "countries": [
+      { "country": "jpn", "clicks": 67, "impressions": 10800, "ctr": 0.6204, "position": 7.77 },
+      { "country": "usa", "clicks": 53, "impressions": 42876, "ctr": 0.1236, "position": 7.72 },
+      { "country": "esp", "clicks": 37, "impressions": 4035, "ctr": 0.917, "position": 8.32 },
+      { "country": "aus", "clicks": 14, "impressions": 2185, "ctr": 0.6407, "position": 9.42 },
+      { "country": "can", "clicks": 13, "impressions": 2642, "ctr": 0.4921, "position": 8.29 },
+      { "country": "gbr", "clicks": 12, "impressions": 2112, "ctr": 0.5682, "position": 8.94 }
+    ],
+    "devices": [
+      { "device": "MOBILE", "clicks": 155, "impressions": 13671, "ctr": 1.1338, "position": 8.62 },
+      { "device": "DESKTOP", "clicks": 117, "impressions": 83223, "ctr": 0.1406, "position": 7.99 },
+      { "device": "TABLET", "clicks": 2, "impressions": 232, "ctr": 0.8621, "position": 6.77 }
+    ],
+    "new_queries_last7": [
+      { "query": "is hakone worth visiting", "clicks": 0, "impressions": 6, "ctr": 0, "position": 40.83 },
+      { "query": "yokohama with a guide", "clicks": 0, "impressions": 4, "ctr": 0, "position": 18.5 },
+      { "query": "best places to see mount fuji from tokyo 2026", "clicks": 0, "impressions": 4, "ctr": 0, "position": 5.75 },
+      { "query": "yokohama private guided tour", "clicks": 0, "impressions": 3, "ctr": 0, "position": 19.3 },
+      { "query": "nonbei yokocho walking time from shibuya station", "clicks": 0, "impressions": 5, "ctr": 0, "position": 10 },
+      { "query": "early morning breakfast tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 1 },
+      { "query": "hire a guide in tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 23 }
+    ],
+    "zero_click_opportunities": [
+      { "query": "jr pass price increase 2026", "clicks": 0, "impressions": 1121, "ctr": 0, "position": 5.45 },
+      { "query": "japan rail pass prices 2026 official", "clicks": 0, "impressions": 558, "ctr": 0, "position": 7.68 },
+      { "query": "japan rail pass current prices 2026", "clicks": 0, "impressions": 531, "ctr": 0, "position": 9.71 },
+      { "query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92 },
+      { "query": "tsukiji outer market official hours 2026", "clicks": 0, "impressions": 252, "ctr": 0, "position": 3.4 },
+      { "query": "is it worth visiting yokohama", "clicks": 0, "impressions": 38, "ctr": 0, "position": 14.2 },
+      { "query": "yokohama private tour", "clicks": 0, "impressions": 21, "ctr": 0, "position": 16.4 }
+    ],
+    "near_page_one_pushup": [
+      { "query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92 },
+      { "query": "is it worth visiting yokohama", "clicks": 0, "impressions": 38, "ctr": 0, "position": 14.2 }
+    ]
+  },
+  "ga4": {
+    "window": {
+      "from": "2026-05-16",
+      "to": "2026-06-13"
+    },
+    "totals": {
+      "sessions": 749.0,
+      "totalUsers": 623.0,
+      "screenPageViews": 938.0,
+      "engagementRate": 0.3925233644859813,
+      "averageSessionDuration": 306.0799869038718
+    },
+    "sources": [
+      { "sessionSource": "google", "sessionMedium": "organic", "sessions": 372.0, "engagementRate": 0.5134408602150538 },
+      { "sessionSource": "(direct)", "sessionMedium": "(none)", "sessions": 239.0, "engagementRate": 0.20502092050209206 },
+      { "sessionSource": "chatgpt.com", "sessionMedium": "(not set)", "sessions": 46.0, "engagementRate": 0.2608695652173913 },
+      { "sessionSource": "bing", "sessionMedium": "organic", "sessions": 25.0, "engagementRate": 0.6 },
+      { "sessionSource": "claude.ai", "sessionMedium": "referral", "sessions": 6.0, "engagementRate": 0.8333333333333334 }
+    ],
+    "events": [
+      { "eventName": "page_view", "eventCount": 938.0, "totalUsers": 623.0 },
+      { "eventName": "session_start", "eventCount": 752.0, "totalUsers": 623.0 },
+      { "eventName": "user_engagement", "eventCount": 316.0, "totalUsers": 272.0 },
+      { "eventName": "tour_page_view", "eventCount": 101.0, "totalUsers": 52.0 },
+      { "eventName": "contact_page_view", "eventCount": 32.0, "totalUsers": 27.0 },
+      { "eventName": "book_now_click", "eventCount": 20.0, "totalUsers": 16.0 },
+      { "eventName": "form_start", "eventCount": 11.0, "totalUsers": 10.0 },
+      { "eventName": "form_submit", "eventCount": 8.0, "totalUsers": 8.0 },
+      { "eventName": "diagnostic_complete", "eventCount": 6.0, "totalUsers": 4.0 }
+    ],
+    "organic_landing_pages": [
+      { "landingPagePlusQueryString": "/blog/tsukiji-market-guide", "sessions": 135.0, "engagementRate": 0.5333333333333333, "averageSessionDuration": 245.95 },
+      { "landingPagePlusQueryString": "/blog/kamakura-vs-hakone-vs-nikko-day-trip", "sessions": 47.0, "engagementRate": 0.6382978723404256, "averageSessionDuration": 2982.62 },
+      { "landingPagePlusQueryString": "/blog/japan-rail-pass-worth-it", "sessions": 17.0, "engagementRate": 0.4117647058823529, "averageSessionDuration": 166.83 },
+      { "landingPagePlusQueryString": "/es/blog/comparativa-excursiones", "sessions": 17.0, "engagementRate": 0.5882352941176471, "averageSessionDuration": 274.91 },
+      { "landingPagePlusQueryString": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "sessions": 14.0, "engagementRate": 0.42857142857142855, "averageSessionDuration": 124.77 },
+      { "landingPagePlusQueryString": "/blog/tokyo-private-tour-guide-cost", "sessions": 12.0, "engagementRate": 0.8333333333333334, "averageSessionDuration": 311.57 },
+      { "landingPagePlusQueryString": "/blog/hakone-day-trip-guide-vs-solo", "sessions": 8.0, "engagementRate": 0.375, "averageSessionDuration": 166.43 },
+      { "landingPagePlusQueryString": "/blog/yokohama-day-trip-from-tokyo", "sessions": 3.0, "engagementRate": 0.3333333333333333, "averageSessionDuration": 22.97 },
+      { "landingPagePlusQueryString": "/blog/yanaka-tokyo-walking-route", "sessions": 7.0, "engagementRate": 0.7142857142857143, "averageSessionDuration": 757.88 }
+    ],
+    "countries": [
+      { "country": "United States", "sessions": 214.0, "engagementRate": 0.3411214953271028 },
+      { "country": "Japan", "sessions": 162.0, "engagementRate": 0.43209876543209874 },
+      { "country": "Spain", "sessions": 59.0, "engagementRate": 0.6101694915254238 },
+      { "country": "Australia", "sessions": 22.0, "engagementRate": 0.5454545454545454 },
+      { "country": "Canada", "sessions": 21.0, "engagementRate": 0.5238095238095238 }
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Yokohama Day Trip with a Private Guide: Worth It or Better Solo?
- **slug**: `yokohama-day-trip-guide-vs-solo` (EN), `yokohama-con-guia-vs-solo` (ES)
- **category**: Decision Helpers（× Day Trips クラスター強化）
- **priority**: high
- **risk**: duplicate=low / competitor=medium / ai_overview=low

---

## なぜこの案か（Why this article）

**GSCシグナル**: `/blog/yokohama-day-trip-from-tokyo` が28日間で682表示・4クリック（CTR 0.59%、順位7.82）と表示数の割にクリックが伸び悩んでいる。同時に "is it worth visiting yokohama"（38表示、0クリック、順位14.2）がページ2に埋もれており、判断系クエリを取りにいける余地がある。

**クラスターの穴**: Kamakura・Hakone・Nikkoはすべて「guide vs solo」記事が揃っているが、**Yokohamaだけ欠落**。同一パターンを当てはめることで内部リンク網を完成させ、Day Trips クラスター全体のオーソリティを強化できる。

**CV影響**: "guide vs solo" フレームはガイド雇用を検討中の読者が読む記事。フォーム送信（CV）への直線距離が近い。

---

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → 記事化へ（`/build-article` を実行）
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → コメントに focus 指示を書いてください

採用時の必須チェック：
- [ ] **Manabu独自エピソード**（Section 03、Differentiation slant の3箇所）に実体験を追記
- [ ] ファクトチェックリスト（横浜の交通費・入場料・営業時間）を執筆前に確認
- [ ] H2 outlineが論理的か（特にSection 02「ソロで行けるケース」を率直に書く点）
- [ ] competitor_difficulty: medium が妥当か（Viator等プラットフォーム vs 判断コンテンツの棲み分け）

---

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-13-yokohama-day-trip-guide-vs-solo.md](``https://github.com/mkmanabu122003/private-tour-page-new/blob/claude/daily-brief-2026-06-13/seo-pipeline/briefs/2026-06-13-yokohama-day-trip-guide-vs-solo.md``)

---

⚠️ **注意**: 今回のGSC/GA4データ取得はGoogle APIライブラリの依存関係エラーにより自動フェッチができず、直近の2026-05-22スナップショットをプロキシとして使用しています。Routine環境でのGoogle認証設定をご確認ください（`GOOGLE_APPLICATION_CREDENTIALS_JSON` secret + `google-api-python-client` のインストール）。

---

🤖 Generated by Daily SEO Brief Routine — claude/daily-brief-2026-06-13

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENzD3iwApZ1usG8npVxv5J)_