### PR TITLE
brief: 2026-06-14 — Ueno, Tokyo: A Private Guide's Neighborhood Handbook

### DIFF
--- a/seo-pipeline/briefs/2026-06-14-ueno-tokyo-guide.md
+++ b/seo-pipeline/briefs/2026-06-14-ueno-tokyo-guide.md
@@ -1,0 +1,170 @@
+---
+date: 2026-06-14
+slug: ueno-tokyo-guide
+slug_es: guia-barrio-ueno-tokio
+status: pending  # pending | approved | rejected | needs-changes
+priority: high
+category: Neighborhoods
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: medium
+---
+
+# Ueno, Tokyo: A Private Guide's Neighborhood Handbook
+
+**Spanish Title**: Ueno, Tokio: la guía del barrio según un guía privado
+
+---
+
+## Why this article (data-driven rationale)
+
+- **GSC signal**: 直近28日（2026-04-24〜2026-05-22）サイト全体 101,626 impressions / 275 clicks。Neighborhoods カテゴリでは `/blog/shinjuku-guide` が 482 impressions・0 clicks・position 13.33、`/blog/senso-ji-most-visited-temple` が 1,319 impressions・5 clicks。これらの隣接エリアに需要があるにもかかわらず、**上野 slug が完全に空白**。
+- **既存記事ギャップ**: `/blog/asakusa-guide`（上野から徒歩15分北）、`/blog/senso-ji-most-visited-temple`、`/blog/old-tokyo-shitamachi` はすべて下町文化圏を扱うが、**上野公園・博物館群・アメ横・不忍池のエリアは 1 記事も存在しない**。内部リンク網に大きな空白。
+- **想定CV影響**: medium-high — 上野はファミリー・シニア層の定番ルート。`/blog/tokyo-with-kids-family-tour`（既存）と `/blog/tokyo-with-elderly-parents`（既存）の読者が「次の行先」として検索する段階に合致。ツアーCTAへの誘導距離が短い。
+- **競合状況**: 上位は Time Out Tokyo (DR79)・Japan Guide (DR73)・Tripadvisor (DR90)。ただし全て汎用リスト型。「政府公認ガイドが実際にツアーで案内してきた上野の見方」という体験型スラントは未開拓。config.yml Neighborhoods weight=15 に合致。
+
+---
+
+## Target keyword cluster
+
+- **Primary**: "ueno tokyo guide"
+- **Secondary**: "things to do in ueno tokyo", "ueno park museums tokyo", "ueno tokyo with kids"
+- **Long-tail**: "best museum in ueno tokyo", "ueno ameyoko market guide", "how much time do you need in ueno"
+- **Search intent**: informational → commercial（ツアー検討の情報収集段階）
+
+---
+
+## Differentiation slant (Manabuならでは)
+
+**[ここにManabuさんの実体験エピソードを挿入してください]**
+
+1. **博物館選びのガイド体験**: 「上野公園でご家族（[年代・構成をご記入ください]）をご案内した時、[どのルートが最も喜ばれたか、具体的な館名と理由]。全国通訳案内士として館内の展示背景を英語で解説できる強みを活かした体験」 — 観光客が「どれに入るべきか」で時間を無駄にする典型的な失敗を回避する判断軸を提供。
+
+2. **アメ横の現場知識**: 「アメ横で外国人観光客が[よくやってしまう誤解・行動]を何度も目撃してきた。ガイドとして伝えているポイントは[具体的なアドバイス — 時間帯/値段交渉の有無/狙い目の店など]」 — 雑誌には書けないローカル視点。
+
+3. **混雑と体力管理のリアル**: 「500回以上のツアー経験から見た上野の正直な評価: [桜シーズン/平日/雨天/それぞれのメリットとデメリット]。シニアや小さなお子さんを連れたゲストには特に[どのプランを推奨しているか]」 — 旅行者が不安に感じるフィジカル面の判断材料。
+
+---
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Ueno, Tokyo: What to See, Do & Eat — Local Guide 2026`
+- **Meta description (EN)** (155字以内): `From Tokyo National Museum to Ameyoko Market, a licensed private guide shares Ueno's best spots, ideal timing, and how to see it all in one day without the overwhelm.`
+- **Title (ES)** (60字以内): `Ueno, Tokio: qué ver, hacer y comer — guía local 2026`
+- **Meta description (ES)** (155字以内): `Del Museo Nacional de Tokio al mercado Ameyoko, un guía privado oficial revela los mejores rincones de Ueno, el horario ideal y cómo aprovecharlo en un día sin agobiarse.`
+
+---
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · What Makes Ueno Worth Your Time** — 上野を一言で定義（東京最古の公立公園、5つの国立文化施設が並ぶ唯一のエリア）。「観光客が多い＝避けるべき」という誤解を崩し、「知って行くと全然違う」理由を示す冒頭フック。Manabuの視点で "why I keep bringing clients here" を語る。
+
+2. **Section 02 · The Museum Cluster: Which One Is Right for You?** — 東京国立博物館・国立科学博物館・国立西洋美術館・東京都美術館の4館を「誰に向いているか」で比較。ファミリー向け（科博）/ 歴史好き（TNM）/ 西洋美術ファン（西洋美術館）/ 特別展狙い（都美術館）の判断フレームを提供。Manabu体験エピソード [プレースホルダー] を Section 02 末尾に挿入。
+
+3. **Section 03 · Ueno Park & Shinobazu Pond** — 公園そのものの楽しみ方。不忍池（蓮の季節、ボート、渡り鳥）、清水観音堂、上野東照宮、花見スポット（桜の時期は別記事リンク）。「博物館疲れ」のリフレッシュとして使う導線。
+
+4. **Section 04 · Ameyoko Market: The Street Food & Shopping Reality Check** — アメ横の正直ガイド。何が買えるか、混雑ピーク時間帯、外国人が期待しがちな「市場感」と実際のギャップ、ガイドが密かに連れて行く店 [プレースホルダー]。食べ歩きで試すべき1〜2品の提案。
+
+5. **Section 05 · Ueno with Kids, Seniors, and First-Timers** — ターゲット別プランの提示（2〜3時間コース vs. 5時間フルコース）。上野動物園のポジショニング（ファミリー向け優先度）。シニアへの体力的配慮（エレベーター・ベンチの場所、ランチ候補）。初訪問者へのミニマムプラン提案。Manabu体験エピソード [プレースホルダー]。
+
+6. **Section 06 · Getting There, Getting Around & Combining Nearby Areas** — アクセス（JR上野駅 / 東京メトロ銀座線・日比谷線の出口案内）、コインロッカー場所、エリア内移動の距離感（博物館 → アメ横 → 不忍池の所要時間）。浅草・秋葉原との組み合わせ提案（ツアーでよく使うルート [プレースホルダー]）。
+
+7. **Section 07 · FAQ**
+   - 上野だけで何時間見ればいい？
+   - 上野動物園と博物館、どちらを優先すべきか？
+   - 雨の日に上野は楽しめるか？
+   - 浅草と上野、同じ日に回れるか？
+   - プライベートツアーで上野を案内してもらえるか？
+
+---
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 東京国立博物館の常設展入館料（大人・大学生・高校生以下）と定休日（2026年最新）
+- [ ] 国立科学博物館の入館料と定休日（2026年最新）
+- [ ] 国立西洋美術館の入館料と定休日（2026年最新）
+- [ ] 上野動物園の入園料（大人・中学生・小学生・シニア）と定休日（2026年最新）
+- [ ] アメ横商店街の一般的な営業時間帯と定休日の傾向（元日等の例外）
+- [ ] JR上野駅から各博物館・不忍池への徒歩分数（公園口・公園改札からの距離）
+- [ ] 上野公園内のコインロッカー設置場所と料金（最新情報）
+
+---
+
+## Internal link plan (既存記事への参照)
+
+- [Asakusa Guide](/blog/asakusa-guide) — 上野から徒歩15分・組み合わせプランで必ず言及
+- [Senso-ji: Tokyo's Most Visited Temple](/blog/senso-ji-most-visited-temple) — 浅草スポットとの連携セクション
+- [Old Tokyo: Shitamachi](/blog/old-tokyo-shitamachi) — 下町エリアの文化的背景・コンテキストリンク
+- [Tokyo with Kids: Family Tour](/blog/tokyo-with-kids-family-tour) — 上野動物園・科博ファミリー向けセクション
+- [Tokyo with Elderly Parents](/blog/tokyo-with-elderly-parents) — シニア配慮プランの参照元
+- [Japan Temple & Shrine Etiquette](/blog/japan-temple-shrine-etiquette) — 上野東照宮・清水観音堂訪問前の礼儀作法
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — Section 05 末尾のCTA強化
+
+---
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["tokyo-private-tour", "asakusa-private-tour"]} />`
+
+（上野エリア専用ツアーページが存在する場合はそちらを優先。Manabuさんに確認。）
+
+---
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/` に上野公園・博物館・アメ横の写真があれば使用（Manabuさんが撮影したツアー写真が最適）
+- **不足分（Wikimedia/Unsplash提案）**:
+  - 東京国立博物館の正門・表慶館（Wikimedia Commons、CC BY-SA利用可）
+  - 不忍池の蓮（夏）または桜（春）の全景
+  - アメ横商店街の屋台/看板列（Unsplash）
+  - 博物館内展示（著作権に注意、Manabuの現地撮影があれば差別化大）
+
+---
+
+## Risk notes
+
+- **AI Overview ゼロクリックリスク — medium**: "things to do in ueno tokyo" は純情報型クエリでAI Overviewに取られやすい。Section 02-03 を「判断フレーム」「比較」「ガイドの体験的推薦」にして情報密度を上げ、ゼロクリック化を抑制。リスト型記事にしない。
+- **競合過密 — medium**: Time Out (DR79) / Tripadvisor (DR90) が上位。差別化は「政府公認ガイドのツアー視点」に徹する。汎用「何をすべきか」リストは避け、「なぜManabuがそれを勧めるか」の理由を全セクションに入れる。
+- **ファクト変動リスク**: 博物館入館料・動物園入場料は年次改定あり。Required facts を必ず執筆直前に確認。記事に "Last updated: June 2026" を表示。
+- **Helpful Content System**: Neighborhoods 記事は体験に基づく一次情報が必須。Manabu体験プレースホルダーを空欄のまま公開しない。
+
+---
+
+## Candidate analysis (選定ロジック)
+
+| 候補 | カニバリ | AI Overview リスク | CV影響 | 選定 |
+|------|---------|-------------------|--------|------|
+| JR Pass price 2026 | 高（既存記事あり） | 高（価格情報型） | low | 除外 |
+| Tsukiji hours 派生 | 高（記事群多数） | 高 | low | 除外 |
+| Temple etiquette push-up | 中（既存あり） | 高（情報型） | low | 除外（既存記事改善案件） |
+| **Ueno neighborhood** | **低（空白）** | **medium → 判断slantで軽減** | **medium-high** | **✅ 採用** |
+| Shinjuku guide (push-up) | 高（既存あり） | medium | medium | 除外 |
+| Mount Fuji viewing spots | 中（英語版あり） | medium | medium | 次点 |
+
+---
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/UenoTokyoGuide.tsx` を作成
+2. `src/pages/es/blog/EsGuiaBarrioUenoTokio.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に以下を追加:
+   ```tsx
+   import UenoTokyoGuide from "./pages/blog/UenoTokyoGuide";
+   import EsGuiaBarrioUenoTokio from "./pages/es/blog/EsGuiaBarrioUenoTokio";
+   // ...
+   <Route path="/blog/ueno-tokyo-guide" element={<UenoTokyoGuide />} />
+   <Route path="/es/blog/guia-barrio-ueno-tokio" element={<EsGuiaBarrioUenoTokio />} />
+   ```
+4. `src/pages/blog/BlogIndex.tsx` に EN・ES エントリを追加
+5. `public/sitemap.xml` に以下 2 URL を追加:
+   - `https://tanuki-tabi-travel.com/blog/ueno-tokyo-guide`
+   - `https://tanuki-tabi-travel.com/es/blog/guia-barrio-ueno-tokio`
+6. `tsc --noEmit` で型チェック（エラーゼロを確認）
+7. feature ブランチ `article/ueno-tokyo-guide` を作成 + commit + push

--- a/seo-pipeline/data/daily/2026-06-14.json
+++ b/seo-pipeline/data/daily/2026-06-14.json
@@ -1,0 +1,427 @@
+{
+  "generated_at": "2026-06-14",
+  "window_days": 28,
+  "data_source_note": "google-api-python-client not installed in this environment; analysis uses latest available snapshot (2026-05-22). Install with: pip install google-api-python-client google-auth for live fetching.",
+  "analysis_based_on": "2026-05-22",
+  "gsc": {
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "clicks": 275,
+      "impressions": 101626,
+      "page_count": 154,
+      "query_count": 2556
+    },
+    "top_queries_by_impression": [
+      {
+        "query": "kamakura",
+        "clicks": 2,
+        "impressions": 403,
+        "ctr": 0.4963,
+        "position": 4.37
+      },
+      {
+        "query": "tsukiji fish market opening hours",
+        "clicks": 2,
+        "impressions": 264,
+        "ctr": 0.7576,
+        "position": 11.36
+      },
+      {
+        "query": "tsukiji market opening hours",
+        "clicks": 1,
+        "impressions": 256,
+        "ctr": 0.3906,
+        "position": 9.72
+      },
+      {
+        "query": "kamakura vs hakone",
+        "clicks": 2,
+        "impressions": 86,
+        "ctr": 2.3256,
+        "position": 6.14
+      },
+      {
+        "query": "hakone or kamakura",
+        "clicks": 1,
+        "impressions": 74,
+        "ctr": 1.3514,
+        "position": 6.95
+      },
+      {
+        "query": "tsukiji outer market",
+        "clicks": 1,
+        "impressions": 55,
+        "ctr": 1.8182,
+        "position": 16.85
+      },
+      {
+        "query": "hakone vs nikko",
+        "clicks": 1,
+        "impressions": 48,
+        "ctr": 2.0833,
+        "position": 8.92
+      },
+      {
+        "query": "hakone or nikko",
+        "clicks": 1,
+        "impressions": 45,
+        "ctr": 2.2222,
+        "position": 8.56
+      },
+      {
+        "query": "is tsukiji market open on sunday",
+        "clicks": 1,
+        "impressions": 45,
+        "ctr": 2.2222,
+        "position": 9.42
+      },
+      {
+        "query": "japan rail pass",
+        "clicks": 2,
+        "impressions": 11,
+        "ctr": 18.1818,
+        "position": 5.09
+      },
+      {
+        "query": "japan private tour guide cost",
+        "clicks": 1,
+        "impressions": 107,
+        "ctr": 0.9346,
+        "position": 9.37
+      },
+      {
+        "query": "tsukiji outer market opening hours 2026",
+        "clicks": 1,
+        "impressions": 505,
+        "ctr": 0.198,
+        "position": 3.12
+      }
+    ],
+    "top_pages_by_impression": [
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it",
+        "clicks": 15,
+        "impressions": 38565,
+        "ctr": 0.0389,
+        "position": 8.18
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide",
+        "clicks": 92,
+        "impressions": 26845,
+        "ctr": 0.3427,
+        "position": 6.52
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette",
+        "clicks": 1,
+        "impressions": 4498,
+        "ctr": 0.0222,
+        "position": 10.82
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip",
+        "clicks": 37,
+        "impressions": 3292,
+        "ctr": 1.1239,
+        "position": 6.23
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio",
+        "clicks": 9,
+        "impressions": 2699,
+        "ctr": 0.3335,
+        "position": 8.13
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost",
+        "clicks": 11,
+        "impressions": 2564,
+        "ctr": 0.429,
+        "position": 7.38
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu",
+        "clicks": 10,
+        "impressions": 2197,
+        "ctr": 0.4552,
+        "position": 8.1
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide",
+        "clicks": 9,
+        "impressions": 1698,
+        "ctr": 0.53,
+        "position": 7.23
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo",
+        "clicks": 10,
+        "impressions": 1414,
+        "ctr": 0.7072,
+        "position": 9.73
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple",
+        "clicks": 5,
+        "impressions": 1319,
+        "ctr": 0.3791,
+        "position": 7.14
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/shinjuku-guide",
+        "clicks": 0,
+        "impressions": 482,
+        "ctr": 0,
+        "position": 13.33
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/mount-fuji-from-tokyo",
+        "clicks": 0,
+        "impressions": 441,
+        "ctr": 0,
+        "position": 10.47
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo",
+        "clicks": 0,
+        "impressions": 667,
+        "ctr": 0,
+        "position": 23.8
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route",
+        "clicks": 6,
+        "impressions": 813,
+        "ctr": 0.738,
+        "position": 6.02
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/yokohama-day-trip-from-tokyo",
+        "clicks": 4,
+        "impressions": 682,
+        "ctr": 0.5865,
+        "position": 7.82
+      }
+    ],
+    "new_queries_last7": [
+      {
+        "query": "best places to see mount fuji from tokyo 2026",
+        "clicks": 0,
+        "impressions": 4,
+        "ctr": 0,
+        "position": 5.75
+      },
+      {
+        "query": "nonbei yokocho walking time from shibuya station",
+        "clicks": 0,
+        "impressions": 5,
+        "ctr": 0,
+        "position": 10
+      },
+      {
+        "query": "early morning breakfast tokyo",
+        "clicks": 0,
+        "impressions": 2,
+        "ctr": 0,
+        "position": 1
+      },
+      {
+        "query": "hire a guide in tokyo",
+        "clicks": 0,
+        "impressions": 2,
+        "ctr": 0,
+        "position": 23
+      },
+      {
+        "query": "is hakone worth visiting",
+        "clicks": 0,
+        "impressions": 6,
+        "ctr": 0,
+        "position": 40.83
+      },
+      {
+        "query": "tsukiji outer market opening hours sunday",
+        "clicks": 0,
+        "impressions": 6,
+        "ctr": 0,
+        "position": 10.33
+      }
+    ],
+    "zero_click_opportunities": [
+      {
+        "query": "jr pass price increase 2026",
+        "clicks": 0,
+        "impressions": 1121,
+        "ctr": 0,
+        "position": 5.45
+      },
+      {
+        "query": "japan rail pass prices 2026 official",
+        "clicks": 0,
+        "impressions": 558,
+        "ctr": 0,
+        "position": 7.68
+      },
+      {
+        "query": "japan rail pass current prices 2026",
+        "clicks": 0,
+        "impressions": 531,
+        "ctr": 0,
+        "position": 9.71
+      },
+      {
+        "query": "japan rail pass price 2026",
+        "clicks": 0,
+        "impressions": 400,
+        "ctr": 0,
+        "position": 11.92
+      },
+      {
+        "query": "japan rail pass price 2026 official",
+        "clicks": 0,
+        "impressions": 262,
+        "ctr": 0,
+        "position": 8.59
+      },
+      {
+        "query": "japan rail pass official price 7 day ordinary 2026",
+        "clicks": 0,
+        "impressions": 255,
+        "ctr": 0,
+        "position": 9.73
+      },
+      {
+        "query": "japan rail pass official prices 2026",
+        "clicks": 0,
+        "impressions": 254,
+        "ctr": 0,
+        "position": 8.63
+      },
+      {
+        "query": "tsukiji outer market official hours 2026",
+        "clicks": 0,
+        "impressions": 252,
+        "ctr": 0,
+        "position": 3.4
+      }
+    ],
+    "near_page_one_pushup": [
+      {
+        "query": "japan rail pass price 2026",
+        "clicks": 0,
+        "impressions": 400,
+        "ctr": 0,
+        "position": 11.92
+      }
+    ]
+  },
+  "ga4": {
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "sessions": 749.0,
+      "totalUsers": 623.0,
+      "screenPageViews": 938.0,
+      "engagementRate": 0.3925233644859813,
+      "averageSessionDuration": 306.0799869038718
+    },
+    "events": [
+      {
+        "eventName": "page_view",
+        "eventCount": 938.0,
+        "totalUsers": 623.0
+      },
+      {
+        "eventName": "session_start",
+        "eventCount": 752.0,
+        "totalUsers": 623.0
+      },
+      {
+        "eventName": "user_engagement",
+        "eventCount": 316.0,
+        "totalUsers": 272.0
+      },
+      {
+        "eventName": "tour_page_view",
+        "eventCount": 101.0,
+        "totalUsers": 52.0
+      },
+      {
+        "eventName": "contact_page_view",
+        "eventCount": 32.0,
+        "totalUsers": 27.0
+      },
+      {
+        "eventName": "book_now_click",
+        "eventCount": 20.0,
+        "totalUsers": 16.0
+      },
+      {
+        "eventName": "form_start",
+        "eventCount": 11.0,
+        "totalUsers": 10.0
+      },
+      {
+        "eventName": "form_submit",
+        "eventCount": 8.0,
+        "totalUsers": 8.0
+      }
+    ],
+    "organic_landing_pages": [
+      {
+        "landingPagePlusQueryString": "/blog/tsukiji-market-guide",
+        "sessions": 135.0,
+        "engagementRate": 0.5333333333333333,
+        "averageSessionDuration": 245.94640525185181
+      },
+      {
+        "landingPagePlusQueryString": "/blog/kamakura-vs-hakone-vs-nikko-day-trip",
+        "sessions": 47.0,
+        "engagementRate": 0.6382978723404256,
+        "averageSessionDuration": 2982.624405851064
+      },
+      {
+        "landingPagePlusQueryString": "/blog/japan-rail-pass-worth-it",
+        "sessions": 17.0,
+        "engagementRate": 0.4117647058823529,
+        "averageSessionDuration": 166.8300424117647
+      },
+      {
+        "landingPagePlusQueryString": "/es/blog/comparativa-excursiones",
+        "sessions": 17.0,
+        "engagementRate": 0.5882352941176471,
+        "averageSessionDuration": 274.90668411764705
+      },
+      {
+        "landingPagePlusQueryString": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo",
+        "sessions": 14.0,
+        "engagementRate": 0.42857142857142855,
+        "averageSessionDuration": 124.77351257142857
+      },
+      {
+        "landingPagePlusQueryString": "/blog/tokyo-private-tour-guide-cost",
+        "sessions": 12.0,
+        "engagementRate": 0.8333333333333334,
+        "averageSessionDuration": 311.56787275
+      },
+      {
+        "landingPagePlusQueryString": "/blog/tsukiji-vs-toyosu",
+        "sessions": 11.0,
+        "engagementRate": 0.5454545454545454,
+        "averageSessionDuration": 183.90271609090908
+      },
+      {
+        "landingPagePlusQueryString": "/blog/yanaka-tokyo-walking-route",
+        "sessions": 7.0,
+        "engagementRate": 0.7142857142857143,
+        "averageSessionDuration": 757.8761270000001
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Ueno, Tokyo: A Private Guide's Neighborhood Handbook
- **slug**: `ueno-tokyo-guide` (EN), `guia-barrio-ueno-tokio` (ES)
- **category**: Neighborhoods
- **priority**: high
- **duplicate_risk**: low | **competitor_difficulty**: medium | **ai_overview_risk**: medium

## なぜこの案か

上野エリアのスラグが既存記事リスト（60+記事）に**完全に存在しない**ことが最大の根拠。隣接する asakusa-guide・senso-ji-most-visited-temple・old-tokyo-shitamachi が計2,000+ impressions を獲得しているにもかかわらず、上野の単独記事がゼロ。ファミリー・シニア向けツアー（Manabuの強み）との親和性も高く、既存 tokyo-with-kids・tokyo-with-elderly-parents 記事から自然な内部リンク強化が見込める。

## データ根拠（2026-04-24〜2026-05-22）

| ページ | Impressions | Clicks | CTR | Position |
|--------|------------|--------|-----|----------|
| `/blog/senso-ji-most-visited-temple` | 1,319 | 5 | 0.38% | 7.14 |
| `/blog/shinjuku-guide` (Neighborhoods 類似) | 482 | 0 | 0% | 13.33 |
| `/blog/asakusa-guide` (上野隣接) | 280+ | — | — | 10.53 |
| **上野 (slug 空白)** | — | — | — | **未着手** |

サイト全体: 101,626 impressions / 275 clicks（28日間）

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → `main` へ merge して記事化 (`/build-article`) に進む
- [ ] **却下** → PR を Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus 指示を書いて commit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] **Manabu独自エピソード（プレースホルダー3箇所）に実体験を追記**
  1. Section 02: 博物館選びでご案内したファミリーの体験
  2. Section 04: アメ横での外国人観光客あるある + こっそり教える穴場
  3. Section 05/06: シニア・子連れへの体力配慮プランの実体験
- [ ] H2 outline（7セクション + FAQ）の流れが論理的か
- [ ] Required facts（博物館入館料・動物園入場料・アクセス）を執筆前に web search で検証
- [ ] competitor_difficulty: medium、ai_overview_risk: medium の評価が妥当か

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-14-ueno-tokyo-guide.md](seo-pipeline/briefs/2026-06-14-ueno-tokyo-guide.md)

### 付記: データ取得について
`google-api-python-client` ライブラリが未インストールのため、本日の GSC/GA4 はライブ取得できず、最新スナップショット（2026-05-22）を使用。ライブ取得を有効にするには Routine 環境で `pip install google-api-python-client google-auth` を実行してください。

---

🤖 Generated by Daily SEO Brief Routine — 2026-06-14

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbaJrfumRHfQPkPNmJcRgc)_