### PR TITLE
brief: 2026-06-15 — Is a Private Tokyo Tour Guide Worth It for Solo Travelers?

### DIFF
--- a/seo-pipeline/briefs/2026-06-15-private-tour-tokyo-solo-traveler.md
+++ b/seo-pipeline/briefs/2026-06-15-private-tour-tokyo-solo-traveler.md
@@ -1,0 +1,109 @@
+---
+date: 2026-06-15
+slug: private-tour-tokyo-solo-traveler
+slug_es: tour-privado-tokio-viajero-solo
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: low
+ai_overview_risk: low
+---
+
+# Is a Private Tokyo Tour Guide Worth It for Solo Travelers?
+
+**Spanish Title**: ¿Vale la Pena un Tour Privado en Tokio si Viajas Solo?
+
+## Why this article (data-driven rationale)
+
+- **GSC signal**: ⚠️ GSC API データ取得不可（2026-06-15 実行時に `googleapiclient` モジュール未インストール）。コンテンツギャップ分析による代替評価：「private tour tokyo solo traveler」「solo traveler private guide tokyo」クエリに対応する既存記事なし（cannibalization スコア < 30%）。隣接 Decision Helper `/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` は config 記載 CTR 0.72%（サイトのトップパフォーマー）。同カテゴリの追加記事は form_submit への高い波及効果が見込まれる。
+- **既存記事ギャップ**: `/blog/group-vs-private-tour-tokyo` はグループ vs プライベートの一般比較を扱うが、**ひとり旅読者特有の懸念**（「ひとりのために高い？」「ガイドと1対1で気まずい？」「何でも自分のペースにできる？」）は不在。`/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` は雇用価値の一般論で、ソロトラベラー文脈に特化していない。既存53記事中、「ひとり旅 × プライベートガイド」の直接カバーはゼロ。
+- **想定CV影響**: HIGH — ひとり旅でガイド雇用を検討している読者はファネル最下部（採用直前の意思決定フェーズ）。form_submit 転換率が最も高いセグメント。
+- **競合状況**: 上位は Viator・GetYourGuide・TripAdvisor などの予約プラットフォームと一般 Tokyo travel blog（DR 70-85）。「ひとり旅の迷い」に一人称で答えるコンテンツは現状ゼロ。ガイド自身の視点が圧倒的差別化になる。
+- **タイミング**: 2026年6月（夏旅行計画ピーク）。ひとりでの日本旅行はポストコロナ以降トレンド継続中。インデックス後 2-4 週でピーク需要に間に合う。
+
+## Target keyword cluster
+
+- **Primary**: "private tour tokyo solo traveler"
+- **Secondary**: "solo traveler private guide tokyo", "private guide tokyo worth it solo", "hiring a tour guide in tokyo alone", "private tour japan solo"
+- **Search intent**: commercial（採用 vs 不採用を判断しようとしている意思決定段階）
+
+## Differentiation slant (Manabuならでは)
+
+[以下はエピソード挿入の具体的な指針。Manabuさんが実体験を書き加える領域です]
+
+1. **「ひとり旅クライアントで印象的だった体験」エピソード**: ガイドとしてひとり旅客を案内した具体的な1事例を書いてください（例：「50代のアメリカ人女性が最初はひとりでガイドを雇うのを躊躇っていたが、ツアー後にこう言った…」「グループでは立ち寄れなかった◯◯で、ひとりだからこそできた体験」など）。国籍・年齢層・旅の目的の組み合わせで読者が自分を重ねやすいエピソードが理想的です。
+2. **「1対1だから実現したカスタマイズ」の具体例**: グループツアーでは絶対にできなかったことをひとつ明記（例：「疲れたのでカフェで30分休憩してからルート変更した」「本来予定になかった路地の和菓子屋に急遽立ち寄れた」「クライアントの食の好みに合わせてランチスポットを当日変更した」）。
+3. **「旅の相棒」としてのガイドの役割**: ひとり旅の読者が一番求めているのは情報だけでなく「誰かと体験・驚き・感動を共有できる安心感」。政府公認ガイド（全国通訳案内士）として、ひとり旅客に対してどんな存在になっているかをManabu視点で書いてください。
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Private Tour Tokyo for Solo Travelers: Worth It? 2026`
+- **Meta description (EN)** (155字以内): `Solo in Tokyo and wondering if a private guide is worth it? Licensed guide Manabu breaks down real costs, what you get, and who benefits most from solo private tours.`
+- **Title (ES)** (60字以内): `Tour Privado Tokio Viajero Solo: ¿Vale la Pena? 2026`
+- **Meta description (ES)** (155字以内): `¿Viajas solo a Tokio y dudas si vale contratar un guía privado? Manabu, guía oficial certificado, explica costes reales y para quién es la mejor opción.`
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Solo Traveler's Dilemma** — 「ひとりのためにプライベートガイドは大げさ？」という読者の率直な疑問からスタート。quick-decision ボックス：「3項目チェックリストで向いているか即判断」を冒頭に置く。「ひとり旅こそプライベートガイドが最も力を発揮する」という逆説的テーゼを提示。
+2. **Section 02 · What a Solo Private Tour Actually Looks Like** — ガイドとのひとり旅1日の実際の流れを描写。[Manabuエピソード①挿入]。グループツアーとの体験差を3つの軸で比較。「旅の相棒」感についての[Manabuエピソード③挿入]。
+3. **Section 03 · The Cost Reality: Is It Worth It Solo?** — ひとり旅でプライベートガイドを頼む費用感の考え方（割り勘なしのコスト、グループツアーとの比較軸、隠れたコスパ）。価格は Required facts で検証後に記載。cost-table コンポーネント使用推奨。
+4. **Section 04 · Who Gets the Most Out of Solo Private Tours** — ひとり旅の中でも「特に向いている人」vs「向いていない人」を明確化（choice-grid コンポーネント使用推奨）。"Choose solo private tour if…" / "Choose group tour if…" の二択フレーム。
+5. **Section 05 · How to Book as a Solo Traveler** — いつ・どこで予約するか・何を準備するか。直接予約 vs プラットフォームの違い。[Manabuエピソード②：ひとり旅クライアントのカスタマイズ例挿入]。
+6. **Section 06 · FAQ** — 4-5問（faq-block ラップ必須）
+
+   候補FAQ：
+   - "Is it weird to hire a private guide just for myself?"
+   - "Will Manabu adjust the pace for a solo traveler?"
+   - "How much does a solo private Tokyo tour cost?"
+   - "Should I book in advance or is last-minute OK?"
+   - "Can I do half a day instead of a full day?"
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] Manabuの現行プライベートツアー料金（半日・全日・ひとり旅料金。公式サイト tanuki-tabi-travel.com に記載の最新価格と整合させる）
+- [ ] Viator・GetYourGuide 上の東京ひとり旅向けプライベートツアーの相場価格帯（2026年最新）
+- [ ] 全国通訳案内士の資格概要（読者向けの信頼性の根拠として引用する際の正確な情報）
+- [ ] 予約方法・キャンセルポリシー（公式サイト記載内容）
+
+## Internal link plan (既存記事への参照)
+
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — 本記事のひとり旅特化スピンオフとして定義。Section 01 に「一般的な議論はこちら」の参照リンク。
+- [Private Tour Guide Cost Tokyo](/blog/tokyo-private-tour-guide-cost) — Section 03 の「費用の現実」から自然なリンク。
+- [Group vs Private Tour Tokyo](/blog/group-vs-private-tour-tokyo) — Section 04 の choice-grid「向いていない人→グループツアーはこちら」から誘導。
+- [What to Expect on a Private Tour Tokyo](/blog/what-to-expect-private-tour-tokyo) — Section 02 の「実際の流れ」から「もっと詳しく」へのリンク。
+- [How to Choose a Private Tokyo Guide](/blog/how-to-choose-private-tokyo-guide) — Section 05 の「予約のヒント」から誘導。
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["private-full-day", "private-half-day"]} />`
+（※ 実際の tour ID は Manabuさんが公式サイトのツアーページと照合して修正してください）
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/` 内の Manabu とゲストの2ショット（特に1対1の場面が望ましい）
+- **不足分（Unsplash/Wikimedia提案）**: 東京の路地をひとりで歩く旅行者の写真（観光気分が伝わるもの）、縦構図のガイドとゲストの対話シーン
+
+## Risk notes
+
+- **Helpful Content System リスク**: Decision Helper 系の量産は注意。本記事は「ひとり旅読者に特化した独立した意思決定ガイド」として既存記事と明確に差別化が必須。Manabuの一人称エピソードが薄いと量産コンテンツと判定されるリスクあり。エピソードセクション（Section 01, 02）の充実度が鍵。
+- **AI Overview ゼロクリック化リスク**: LOW。「private tour tokyo worth it solo」は意見・判断型クエリのため AI Overview 化リスク低い。ただし価格・施設情報の羅列型構成にした場合はリスク上昇 → 体験・比較・判断軸の記述を中心に維持すること。
+- **カニバリゼーションリスク**: LOW（`/blog/group-vs-private-tour-tokyo` との重複 < 30%、`/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` との重複 < 40%）。「ひとり旅特化」のスラントを全セクションで一貫して維持すること。
+- **ファクト変動リスク**: 価格・予約ポリシーは変動するため、Last updated を記事公開時に明記し定期更新が必要。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `templates/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/PrivateTourTokyoSoloTraveler.tsx` を作成
+2. `src/pages/es/blog/EsTourPrivadoTokioViajeroSolo.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/private-tour-tokyo-solo-traveler` と `/es/blog/tour-privado-tokio-viajero-solo`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. tsc で型チェック
+7. feature ブランチ作成 + commit

--- a/seo-pipeline/data/daily/2026-06-15.json
+++ b/seo-pipeline/data/daily/2026-06-15.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-15",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is a Private Tokyo Tour Guide Worth It for Solo Travelers?
- **slug**: `private-tour-tokyo-solo-traveler` (EN), `tour-privado-tokio-viajero-solo` (ES)
- **category**: Decision Helpers
- **priority**: high
- **duplicate_risk**: low / **competitor_difficulty**: low / **ai_overview_risk**: low

### なぜこの案か

既存53記事中「ひとり旅 × プライベートガイド」に特化した記事がゼロ。Decision Helpers カテゴリ（config.yml 最高優先度 weight:30）で、form_submit への直接影響が最も高い記事タイプ。隣接記事 `is-it-worth-hiring-a-tour-guide-in-tokyo` がサイト最高 CTR（0.72%）を記録しており、同カテゴリの追加記事は高い波及効果が見込まれる。

⚠️ **Note**: 2026-06-15 の実行で GSC API が `googleapiclient` モジュール未インストールのためデータ取得不可。コンテンツギャップ分析 + config.yml ベースラインによる代替評価を使用。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む（`/build-article` コマンドを使用）
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（Section 02, 05 のプレースホルダー）に実体験を追記
- [ ] H2 outline（6セクション + FAQ）が論理的か確認
- [ ] Required facts（料金・資格情報・相場）を執筆前に web search で検証
- [ ] RelatedTourCards の tourIds を実際のツアーIDに修正

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-15-private-tour-tokyo-solo-traveler.md](seo-pipeline/briefs/2026-06-15-private-tour-tokyo-solo-traveler.md)

---
🤖 Generated by Daily SEO Brief Routine · tanuki-tabi-travel.com

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdYNvRD4WQ9yFnNZPobJY2)_