### PR TITLE
brief: 2026-06-16 — Is Kamakura Worth Visiting? A Private Guide's Honest Answer (2026)

### DIFF
--- a/seo-pipeline/briefs/2026-06-16-is-kamakura-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-06-16-is-kamakura-worth-visiting.md
@@ -1,0 +1,124 @@
+---
+date: 2026-06-16
+slug: is-kamakura-worth-visiting
+slug_es: vale-la-pena-visitar-kamakura
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Is Kamakura Worth Visiting? A Private Guide's Honest Answer (2026)
+
+**Spanish Title**: ¿Vale la pena visitar Kamakura? La opinión sincera de un guía privado (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (28日間 / 2026-04-24〜05-22)**: 「is kamakura worth visiting」直近28日で表示 27、クリック 1、順位 3.11（→ `/blog/kamakura-vs-hakone-vs-nikko-day-trip` が偶発的に捕捉中。専用記事があれば1位狙いで CTR 5-10倍を狙える）
+- **クラスター実績**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` は表示3,292回・クリック37回（CTR 1.12%）、平均セッション時間**49分超**（2,982秒）— サイト全体で最高エンゲージメント。クラスター追加の ROI は非常に高い
+- **関連クエリ**: 「kamakura vs hakone」86 imp / pos 6.14、「hakone or kamakura」74 imp / pos 6.95、「is kamakura worth visiting」27 imp / pos 3.11、「kamakura」403 imp / pos 4.37
+- **既存記事ギャップ**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` は「どの目的地か」の比較軸、`/blog/kamakura-day-trip-from-tokyo` は「どう行くか」のHow-to軸。「行く価値があるか（Go / No-Go 判断）」に特化した Decision Helper が不在
+- **想定CV影響**: HIGH — 「行く価値があるか」を調べるユーザーは旅程最終決定フェーズ。「Yes、かつガイドと行くと劇的に違う」という結論への着地でbook_now_clickに直結
+- **競合状況**: TripAdvisor（DR90+）、Lonely Planet（DR92）、The Broke Backpacker（DR65）が上位。ただし全て「観光地紹介」軸。「政府公認ガイドが答える判断基準」という一次情報スラントで差別化余地あり
+
+## Target keyword cluster
+
+- **Primary**: "is kamakura worth visiting"
+- **Secondary**: "kamakura day trip worth it", "kamakura worth visiting 2026", "is kamakura worth a day trip", "kamakura or hakone which is better"
+- **Search intent**: commercial（Go/No-Go の判断段階 → 次の行動 = ツアー予約または旅程決定）
+
+## Differentiation slant (Manabuならでは)
+
+**[ここにManabuさんの実体験エピソードを挿入 — 必須]**
+
+以下の3軸で「ガイドにしか書けない」コンテンツにする：
+
+1. **[エピソード枠A: 「2時間で後悔したお客様 vs. 1日使った方の違い」]**
+   → 実際に案内した中で「Kamakuraは大仏だけ見て終わり」と言っていたお客様と、地元路地を含めた1日コースを回ったお客様の反応の違い。具体的な場所名・会話・感情を含めてください（例: 「◯◯寺の◯◯で、お客様が突然立ち止まって…」）
+
+2. **[エピソード枠B: 「政府公認ガイドの混雑回避ルート」]**
+   → 高徳院（大仏）・長谷寺・鎌倉宮の"観光客の流れ"を知り尽くした立場から、「この順序で回ると列に並ばずに済む」という非公開知識。ガイド歴・ツアー回数から来る具体的なノウハウ
+
+3. **「行く価値がある人 / ない人」の判断軸（Manabu基準）**
+   → 「歴史・侘び寂び・日本の精神性に興味がある人は絶対に行くべき。純粋なショッピング目当てなら銀座でいい。」といった、ガイドの率直な意見（対象ユーザーを絞り込む内容で CV 精度を上げる）
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Kamakura Worth Visiting? A Guide's Honest Answer (2026)`
+- **Meta description (EN)** (155字以内): `Licensed Tokyo guide Manabu shares his honest verdict: who should visit Kamakura, what most tourists get wrong, and whether a day trip is worth your time in 2026.`
+- **Title (ES)** (60字以内): `¿Vale la pena visitar Kamakura? La opinión de un guía (2026)`
+- **Meta description (ES)** (155字以内): `El guía oficial Manabu comparte su veredicto honesto: quién debería visitar Kamakura, qué errores evitar y si realmente vale la pena el viaje de un día en 2026.`
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Short Answer** — クイック判断ボックス（"Yes, if… / No, if…"）。読者がスキップしないための結論ファースト。`quick-decision` モジュール使用
+2. **Section 02 · What Kamakura Really Is (And Isn't)** — よくある誤解（「東京近郊の小さな観光地」）を解体。実際は鎌倉幕府700年の歴史都市という文脈を簡潔に。`guide-note-callout` でManabuコメント挿入
+3. **Section 03 · Who Should Go — And Who Should Skip** — `choice-grid` モジュール使用。「歴史・精神性・自然が好きな人 → GO / ショッピング・クラブ・近未来Tokyo体験が目的 → SKIP」という明確な対比で CV 精度を上げる
+4. **Section 04 · The Best Time to Visit** — 季節別・時間帯別の正直なアドバイス。混雑のピークと穴場タイミング。[Manabuエピソード枠B: 混雑回避ルート] をここに配置
+5. **Section 05 · How Long Do You Actually Need?** — 「2時間・半日・1日」の違いをManabu視点で正直に解説。[Manabuエピソード枠A] をここに配置。`bar-cell` で「時間 × 満足度」を視覚化
+6. **Section 06 · Going Solo vs. With a Private Guide: Does It Matter?** — 本記事から `/blog/kamakura-day-trip-guide-vs-solo` への導線。判断材料を提示しつつ「ガイドを選ぶ価値」を体験ベースで語る。`pull-quote` でManabuの一言
+7. **Section 07 · FAQ** — 4-5問（下記参照）
+
+**FAQ候補**:
+- Is Kamakura better than Nikko or Hakone for a day trip?
+- Can you do Kamakura in half a day?
+- Is Kamakura too crowded in 2026?
+- What's the best way to get to Kamakura from Tokyo?
+- Do I need a guide for Kamakura, or can I go solo?
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 高徳院（鎌倉大仏）2026年の入場料・営業時間（公式サイト確認）
+- [ ] 長谷寺2026年の入場料・営業時間・混雑情報（公式サイト確認）
+- [ ] 鎌倉〜東京（新宿・品川・渋谷）のアクセス時間・運賃（JR/江ノ電、2026年現在）
+- [ ] 2026年の鎌倉市の混雑対策・規制（鎌倉市公式、またはニュースソース）
+- [ ] 鎌倉市の混雑ピーク時期（桜・紅葉・連休）の公式情報
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura vs. Hakone vs. Nikko: Which Day Trip Is Best?](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 比較決断が必要な読者への橋渡し（目的地選定段階のユーザーに対して）
+- [Kamakura Day Trip from Tokyo: Complete Guide](/blog/kamakura-day-trip-from-tokyo) — 「行くと決めた」読者への実務ガイドへの自然な導線
+- [Should You Hire a Private Guide for Kamakura?](/blog/kamakura-day-trip-guide-vs-solo) — Section 06 での CV 導線として必須
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — 「ガイドの価値」を説明する補足記事として
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["kamakura-day-trip", "kamakura-nikko-combo"]} />`
+
+※ 実際のtour IDはManabuさんの既存ツアー設定に合わせて調整してください
+
+## Image candidates
+
+- **Project内（最優先）**: 既存のKamakura関連記事で使用中の画像を確認（`/src/assets/` または `/public/images/`）
+- **不足分（Wikimedia/Unsplash提案）**: 
+  - 高徳院の大仏（朝の光・人が少ないタイミング）
+  - 小町通り以外の路地（Manabuが案内する非観光ルート）
+  - 長谷寺のあじさい（季節性アピール用）
+
+## Risk notes
+
+- **カニバリリスク**: LOW — 既存3記事（比較・アクセス・ガイドvs.ソロ）とのH2重複は30%以下。「Go/No-Go判断」フォーカスで差別化済み
+- **AI Overview リスク**: LOW — 「is it worth visiting」は判断・体験型クエリ。AIが答えにくい「ガイドの率直な意見」スラントで、ゼロクリック化リスクを回避
+- **競合難易度**: MEDIUM — TripAdvisor・Lonely Planetが上位だが、「政府公認ガイドの一次情報」で差別化可能。DR20でも「私が500回以上案内して気づいたこと」コンテンツは勝てる余地あり
+- **ファクト変動リスク**: 入場料・交通運賃は年次変動あり。Last updated の更新が必須。「Required facts」の検証を執筆前に必ず実施
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsKamakuraWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValelapenaVisitarKamakura.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加:
+   - EN: `<Route path="/blog/is-kamakura-worth-visiting" element={<IsKamakuraWorthVisiting />} />`
+   - ES: `<Route path="/es/blog/vale-la-pena-visitar-kamakura" element={<EsValelapenaVisitarKamakura />} />`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. `tsc` で型チェック
+7. feature ブランチ `claude/article-is-kamakura-worth-visiting` 作成 + commit

--- a/seo-pipeline/data/daily/2026-06-16.json
+++ b/seo-pipeline/data/daily/2026-06-16.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-16",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Kamakura Worth Visiting? A Private Guide's Honest Answer (2026)
- **slug**: `is-kamakura-worth-visiting` (EN), `vale-la-pena-visitar-kamakura` (ES)
- **category**: Decision Helpers
- **priority**: high

## なぜこの案か（データ根拠）

- 「is kamakura worth visiting」が **表示27回・順位3.11** で既存比較記事が偶発的に捕捉中 → 専用 Decision Helper 記事で1位狙い＋CTR大幅改善が見込める
- `/blog/kamakura-vs-hakone-vs-nikko-day-trip` の平均セッション時間が **49分超（2,982秒）** — サイト全体で最高エンゲージメント。Kamakuraクラスター追加のROIは非常に高い
- 既存3記事（比較・アクセス・ガイドvs.ソロ）にない「Go/No-Go 判断」軸が空白 → カニバリリスク: LOW
- AI Overview リスク: LOW（「worth it?」判断型クエリは体験情報が優位）

## GSC/GA4 APIについて

本日（2026-06-16）の `fetch_daily.py` 実行時に `No module named 'googleapiclient'` エラーが発生したため、2026-05-22のデータを分析に使用しています。
`pip install google-api-python-client google-auth` を実行環境に追加することで次回から正常に取得できます。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（3つのプレースホルダー）に実体験を追記
  - エピソードA: 2時間で後悔したお客様 vs. 1日使った方の違い（Section 05）
  - エピソードB: 混雑回避の非公開ルート（Section 04）
  - 「行く価値がある人 / ない人」Manabu基準（Section 03）
- [ ] Required facts（入場料・交通・混雑規制）のweb検証
- [ ] H2 outlineが論理的か（7セクション + FAQ構成）
- [ ] competitor_difficulty: medium、ai_overview_risk: low が妥当か

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-16-is-kamakura-worth-visiting.md](seo-pipeline/briefs/2026-06-16-is-kamakura-worth-visiting.md)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_014hpUGJtWQQXLrmcPWbhvXN)_