### PR TITLE
brief: 2026-06-17 — Is Nikko Worth Visiting from Tokyo? (2026 Guide)

### DIFF
--- a/seo-pipeline/briefs/2026-06-17-is-nikko-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-06-17-is-nikko-worth-visiting.md
@@ -1,0 +1,111 @@
+---
+date: 2026-06-17
+slug: is-nikko-worth-visiting
+slug_es: vale-la-pena-visitar-nikko
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Is Nikko Worth Visiting from Tokyo? A Guide's Honest Take (2026)
+
+**Spanish Title**: ¿Vale la pena visitar Nikko desde Tokio? La opinión honesta de un guía (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (28日間: 2026-04-24 〜 2026-05-22)**: `/blog/nikko-day-trip-from-tokyo` — 0 クリック、667 impressions、position 23.8（ページ3に完全埋没）。`/tours/nikko-day-trip` も 0 クリック、443 impressions、position 24.63。Nikko クラスター合計 **1,110+ impressions でほぼゼロクリック**。一方 `kamakura-vs-hakone-vs-nikko-day-trip` は 37 クリック、3,292 impressions、CTR 1.12%、平均滞在 2,982 秒（GA4）と突出したパフォーマンスを示す。意思決定フェーズのコンテンツが Nikko に不在という構造的ギャップが明確
+- **既存記事ギャップ**: `/blog/nikko-day-trip-from-tokyo`（how-to logistics）と `/blog/nikko-day-trip-guide-vs-solo`（guide vs solo 比較）は存在するが、「そもそも Nikko に行く価値があるか」という**決断フェーズのクエリをカバーするページがない**。`/blog/is-hakone-worth-visiting` が Hakone クラスターで担っている役割が Nikko に完全に空白
+- **想定CV影響**: high — "is nikko worth visiting" / "is nikko worth the trip" は旅行プランの確定直前クエリ。肯定的な判断を与えたユーザーが次に見るのが `/tours/nikko-day-trip` のツアーページ。内部リンクを通じた form_submit への寄与が高い
+- **競合状況**: TripAdvisor (DR93)、Lonely Planet (DR91)、TimeOut Tokyo (DR85) が "nikko guide" 一般クエリを支配。ただし "is nikko worth visiting" / "nikko worth it" というオピニオン系クエリは、ライセンスガイドの一次体験記事が DR 差を覆せる余地あり（`is-hakone-worth-visiting` の先行実績に基づく判断）
+
+## Target keyword cluster
+
+- **Primary**: "is nikko worth visiting"
+- **Secondary**: "nikko day trip from tokyo worth it", "is nikko worth the trip", "nikko worth visiting 2026", "nikko worth it"
+- **Search intent**: commercial / decision-making（行くか行かないかを判断する段階）
+
+## Differentiation slant (Manabuならでは)
+
+[ここにManabuさんの実体験エピソードを挿入]
+
+- **[Placeholder A — 「行って良かった」の具体的な瞬間]**: 500本以上のツアーで日光に同行した中で、特定のゲスト（年齢層・旅のタイプを明示。例：「初来日の60代アメリカ人夫妻を案内した時、陽明門の彫刻を説明した瞬間に…」）が見せた反応や感動のエピソードを1〜2文で。「Nikkoに連れてきて本当に良かった」と実感した体験
+- **[Placeholder B — ガイドでないと気づけない「隠れた読み方」]**: 全国通訳案内士として東照宮を案内する際、看板や案内板だけでは絶対に伝わらない装飾や建築の意味・象徴を1つ具体的に（例：眠り猫の向き、三猿の順番の意味、陽明門に意図的に未完成の柱がある理由など）。これが「ガイドと行く価値」の核心的証拠になる
+- **[Placeholder C — Nikkoをすすめなかったケース]**: 「正直、今回は日光より別の選択肢の方が良いと思います」と伝えたことがある具体的な状況（例：秋の紅葉ピーク週末に問い合わせてきたゲストに混雑リスクを説明した、体力的に階段が難しいシニアに別ルートを提案した等）。honest なアドバイスが信頼構築の核
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): "Is Nikko Worth Visiting from Tokyo? (2026 Guide)" — 49文字 ✓
+- **Meta description (EN)** (155字以内): "Licensed Tokyo guide Manabu gives an honest answer: is Nikko worth the trip? Who should go, best seasons, what you'd miss going solo—and when to skip it." — 152文字 ✓
+- **Title (ES)** (60字以内): "¿Vale la pena Nikko desde Tokio? Opinión de un guía (2026)" — 58文字 ✓
+- **Meta description (ES)** (155字以内): "Guía con licencia oficial responde: ¿vale la pena visitar Nikko desde Tokio? Para quién es ideal, cuándo ir y qué te perderías yendo solo." — 139文字 ✓
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Short Answer** — Quick-decision box: "Yes—if you match this profile" / "You might skip it—if this sounds like you" の2列カード形式。判断フェーズの読者をスクロール前に掴む。Manabu の verdict を1段落で。
+2. **Section 02 · What Makes Nikko Genuinely Special** — 東照宮の UNESCO 世界遺産指定の背景、陽明門・眠り猫・三猿の象徴的意味（Placeholder B の素材）、華厳の滝・中禅寺湖・杉並木の自然美。「東京近郊でこれほど歴史と自然が凝縮された場所は他にない」という論点で 300〜400 語。
+3. **Section 03 · Who Gets the Most Out of Nikko** — 歴史・建築好き、紅葉撮影目的、リピーター旅行者、「日本らしさ」を深く体験したいゲスト。Placeholder A のエピソードをここに配置。家族連れ・シニア層は条件付き推奨（Section 04 へ誘導）。
+4. **Section 04 · The Honest Downsides** — ピーク混雑（紅葉10〜11月・GW・正月）、往復 2.5h+ の所要時間、東照宮の長い石段（シニア・車椅子には要注意）、神社周辺の食事選択肢の限界。Placeholder C のエピソードをここに配置。正直さで信頼構築。
+5. **Section 05 · Best Time to Visit Nikko** — 季節別 breakdown：新緑（5月）、夏の涼（7月）、紅葉（10月下旬〜11月上旬）、雪景色（冬）。「最も避けるべき時期」も明記。Manabu のインサイダー Tips（早朝到着推奨、平日 vs 休日等）。
+6. **Section 06 · With a Guide vs. Going Solo: What Changes** — `/blog/nikko-day-trip-guide-vs-solo` への誘導。東照宮の解説品質の差、御朱印や隠れスポットへのアクセス、昼食手配。ライセンスガイドの価値を具体的に示す。末尾に tour CTA。
+7. **Section 07 · FAQ** — 4〜5問（faq-block ラップ）
+
+### FAQ questions（提案）:
+- Is Nikko worth visiting if I've already been to Kyoto?
+- How many hours do you really need in Nikko?
+- Is Nikko accessible for elderly travelers or those with limited mobility?
+- Can I use a JR Pass to get to Nikko?
+- Nikko vs Kamakura vs Hakone: which day trip for first-timers?
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 東照宮の拝観料（2026年最新、円建て税込。奥社セット・拝観券の種類も確認）
+- [ ] 東武日光線 / JR 日光線の所要時間・運賃（浅草発 or 新宿発、特急料金含む）
+- [ ] JR Pass が日光線（JR）に適用されるか（東武には適用外）
+- [ ] 東照宮・二荒山神社・輪王寺の開門時間・定休日（2026年版、祭事・特別閉門日含む）
+- [ ] 華厳の滝エレベーター料金と中禅寺湖エリアのアクセス時間
+- [ ] 紅葉の見頃時期（気候変動で年々変化しているため最新トレンドを確認）
+
+## Internal link plan (既存記事への参照)
+
+- [Nikko Day Trip Guide: With a Guide vs. Solo](/blog/nikko-day-trip-guide-vs-solo) — Section 06「ガイドと行く意味」の詳細へ誘導
+- [Nikko Day Trip from Tokyo](/blog/nikko-day-trip-from-tokyo) — Section 05「実際のプランニング・アクセス詳細」へ誘導
+- [Kamakura vs Hakone vs Nikko Day Trip](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — FAQ「どのデイトリップが一番か」で比較記事へ誘導
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — Section 01 または FAQ で自然なクロスリンク（Hakone と迷っている読者向け）
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["nikko-day-trip"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: `/public/images/` 配下の `nikko/` または `day-trips/` フォルダに東照宮・陽明門・華厳滝の写真があるか確認
+- **不足分（Wikimedia/Unsplash提案）**: 陽明門クローズアップ（彫刻のディテール）、紅葉期の中禅寺湖俯瞰、日光杉並木（世界遺産碑と杉並木の並び）
+
+## Risk notes
+
+- **AI Overview リスク: LOW** — "is nikko worth visiting" は opinion / experience-based クエリ。Google AI Overview はファクト系（価格・時刻・アクセス）に出やすく、「価値があるか」という判断系オピニオンクエリには出づらい。ただしセクション内に "nikko opening hours" "nikko price" 等の純情報型コンテンツを入れすぎると AI Overview のターゲットになりやすい → 判断・体験・一次情報フォーカスを維持し、ファクト情報は「執筆時に確認」として控えめに留める
+- **カニバリリスク: LOW** — 既存 Nikko 記事（`/blog/nikko-day-trip-from-tokyo` は logistics、`/blog/nikko-day-trip-guide-vs-solo` は比較）と検索意図が明確に異なる（decision-making vs. how-to）。`/blog/kamakura-vs-hakone-vs-nikko-day-trip` との重複も20%未満と判断
+- **競合過密リスク: MEDIUM** — TripAdvisor・Lonely Planet・TimeOut が "nikko guide" 系を支配。"is nikko worth visiting" の opinion slant と `is-hakone-worth-visiting` の先行実績を根拠に、ニッチ 1st-person ガイド記事として PAGE 1 を狙える判断。ただし guarantee できるものではなく Manabu の体験密度が決め手
+- **ファクト変動リスク: MEDIUM** — 東照宮拝観料・東武特急料金は年次変動あり。Last updated 必須。執筆後も年1回の更新を推奨
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsNikkoWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValelapenaVisitarNikko.tsx` も作成（hreflang 対応）
+3. `src/AppRoutes.tsx` に import + Route 追加
+   - EN: `<Route path="/blog/is-nikko-worth-visiting" element={<IsNikkoWorthVisiting />} />`
+   - ES: `<Route path="/es/blog/vale-la-pena-visitar-nikko" element={<EsValelapenaVisitarNikko />} />`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. `tsc` で型チェック
+7. feature ブランチ作成 + commit

--- a/seo-pipeline/data/daily/2026-06-17.json
+++ b/seo-pipeline/data/daily/2026-06-17.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-17",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要
本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Nikko Worth Visiting from Tokyo? A Guide's Honest Take (2026)
- **slug**: `is-nikko-worth-visiting` (EN), `vale-la-pena-visitar-nikko` (ES)
- **category**: Decision Helpers
- **priority**: high

## なぜこの案か

Nikkoクラスター（`/blog/nikko-day-trip-from-tokyo` + `/tours/nikko-day-trip`）は合計1,110+ impressionsを獲得しながらほぼゼロクリック（pos 23〜24）。`/blog/is-hakone-worth-visiting` が Hakone クラスターで担っている「意思決定フェーズ」の記事が Nikko に完全に空白。Decision Helper カテゴリ（CV直結・重み30%）として最優先。AI Overview リスクが低い opinion クエリで、競合 DR80+ サイトとも差別化できる。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → 記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus 指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Placeholder A（「行って良かった」の具体的エピソード）に実体験を追記
- [ ] Placeholder B（ガイドでないと気づけない東照宮の「隠れた読み方」）に実体験を追記
- [ ] Placeholder C（Nikkoをすすめなかったケース）に実体験を追記
- [ ] Required facts のチェックリスト（拝観料・アクセス・営業時間）を執筆前に検証
- [ ] competitor_difficulty: medium、ai_overview_risk: low が妥当か確認

## データサマリー

| 指標 | 値 |
|---|---|
| 参照データ | 2026-05-22.json（28日間 GSC+GA4）|
| GSC エラー | API 未設定（googleapiclient module 不在）→ 前回データで代替 |
| Nikkoクラスター合計 | 1,110+ impressions / ~0 clicks |
| 比較: Kamakura 3比較記事 | 3,292 impr / 37 clicks / CTR 1.12% / avg 2,982秒 |
| form_submit (28日) | 8 events |

## 詳細
ブリーフ本体: [seo-pipeline/briefs/2026-06-17-is-nikko-worth-visiting.md](seo-pipeline/briefs/2026-06-17-is-nikko-worth-visiting.md)

---
⚠️ **GSC/GA4 API 注意**: `googleapiclient` モジュール未インストールのため本日のリアルタイムデータが取得できませんでした。Routine 環境に `google-api-python-client` と `google-auth` のインストールが必要です。

🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5YU24XLCQHi6vgy7ZAM2J)_