### PR TITLE
brief: 2026-06-20 — Viator Tokyo Tours vs. Booking a Licensed Guide Directly (2026)

### DIFF
--- a/seo-pipeline/briefs/2026-06-20-viator-vs-private-guide-tokyo.md
+++ b/seo-pipeline/briefs/2026-06-20-viator-vs-private-guide-tokyo.md
@@ -1,0 +1,115 @@
+---
+date: 2026-06-20
+slug: viator-vs-private-guide-tokyo
+slug_es: viator-vs-guia-privado-tokio
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Viator Tokyo Tours vs. Booking a Licensed Guide Directly (2026)
+
+**Spanish Title**: Tours de Viator en Tokio vs. Contratar un Guía Privado con Licencia Directamente (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (proxy: 2026-05-22 window)**: `/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` — 直近28日で表示 1,414、クリック 10、CTR 0.71%、順位 9.73。このDecision Helpers記事が9位台に停滞しており、「具体的にどこで予約すべきか」という次の判断ステップをカバーする記事が存在しない
+- **GSC signal**: `/blog/tokyo-private-tour-guide-cost` — 表示 2,564、クリック 11、CTR 0.43%、順位 7.38。GA4で **エンゲージメント率 83.3%・平均セッション312秒** という高品質シグナルを示しており、コスト感を調べた読者が次に「どこで予約するか」に進む導線が未整備
+- **既存記事ギャップ**: `/blog/free-walking-tour-vs-private-tokyo`（無料 vs 有料）と `/blog/licensed-vs-unlicensed-tour-guides-japan`（資格の有無）は存在するが、**「Viatorなどの仲介プラットフォーム経由 vs ガイドへ直接予約」**という購買決断の最終段階をカバーする記事がない。config.yml の Decision Helpers 例に `viator-vs-direct` が明記されているにもかかわらず未作成
+- **想定CV影響**: HIGH — すでにプライベートツアーを検討し、Viatorを知っている読者が対象。この比較記事を読んでManabuへの直接予約ページに誘導できれば、form_submit CVに最も近い
+- **競合状況**: 上位はViator公式ページとTripAdvisor系。しかし「viator vs book direct tokyo guide」「should i book viator or private guide japan」型のクエリでは決定的な勝者がいない。ライセンスガイドとしての一次情報ポジション（全国通訳案内士）で差別化可能
+
+## Target keyword cluster
+
+- **Primary**: "viator tokyo private tour"
+- **Secondary**: "book private guide tokyo directly", "viator vs private guide japan", "is viator good for tokyo tours", "best way to book private tour tokyo 2026"
+- **Search intent**: commercial / transactional（比較・購買決定フェーズ）
+
+## Differentiation slant (Manabuならでは)
+
+> **[ここにManabuさんの実体験エピソードを挿入]**
+
+以下の3つを具体的なエピソードで肉付けしてください（Claudeには代筆できない一次情報）：
+
+1. **Viator手数料の実態（ガイド側の視点）**: Viatorは通常ガイド報酬から20〜30%のコミッションを差し引く。これが料金設定や対応品質にどう影響するか、Manabuが実際に比較・検討した経験を書いてください。例：「私自身、Viatorへの登録を検討して断念した理由は…」
+
+2. **お客さんが予約後に感じた落差（実例）**: 実際にVIATOR経由で別のガイドを使い、後からManabuへ問い合わせてきた旅行者のエピソードがあれば。例：「◯◯の時期、事前にViatorで1日ツアーを申し込んだご夫婦が当日ガイドの英語力に困り…」（個人特定情報は除く）
+
+3. **直接予約だから可能だったカスタマイズ事例**: 「3週間前にメールで相談して、嫁の食物アレルギーに合わせた昼食スポットに変更した」「雨予報で出発前日に行程を丸ごと室内中心に組み替えた」など、プラットフォーム経由では不可能な体験を具体的に
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Viator Tokyo Tours vs. Private Guide Direct: Which to Book (2026)`
+- **Meta description (EN)** (155字以内): `Viator or book a licensed Tokyo guide directly? A Japan-certified guide breaks down commissions, flexibility, and what Viator doesn't tell you. Make the right call for 2026.`
+- **Title (ES)** (60字以内): `Viator Tokio vs. Guía Privado Directo: ¿Cuál Reservar? (2026)`
+- **Meta description (ES)** (155字以内): `¿Reservar en Viator o directamente con un guía con licencia en Tokio? Un guía oficial de Japón explica comisiones, flexibilidad y lo que Viator no te dice.`
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · What Viator Actually Is (and Isn't)** — プラットフォームとしての仕組みをフラットに説明。Viatorはガイドのマーケットプレイスであり、ガイド品質を保証するわけではないことを中立的に伝える
+2. **Section 02 · Who Guides Viator Tokyo Tours?** — 日本の観光ガイドに国家資格（全国通訳案内士）が存在すること、Viator上では資格の有無が見えにくいことを解説。既存記事 `/blog/licensed-vs-unlicensed-tour-guides-japan` へのリンクポイント
+3. **Section 03 · The Commission Math: What You're Really Paying For** — Viatorの手数料モデルがガイドの手取りと料金設定に与える影響を透明に示す（ガイド視点）。断定的な数字は Required facts で検証後に記載
+4. **Section 04 · Flexibility & Customization — The Real Difference** — 直接予約でのみ実現できる事前カスタマイズ、行程変更、アレルギー対応、当日フレキシビリティをManabuの実体験ベースで語る
+5. **Section 05 · How to Vet Any Private Guide in Tokyo** — Viatorで探すにしても直接予約するにしても、良いガイドの見極め方チェックリスト（資格確認、レビューの読み方、問い合わせ時の質問例）
+6. **Section 06 · FAQ** — 4-5問（下記参照）
+
+**FAQ案（faq-block）:**
+- Q: Is Viator reliable for Tokyo tours? A: プラットフォーム自体は信頼できるが、ガイドの質はピンキリ。確認すべき点を箇条書きで
+- Q: Are Viator guides in Tokyo licensed? A: 必ずしもそうではない。全国通訳案内士の確認方法
+- Q: Is it cheaper to book a private guide directly? A: 仲介手数料分のコスト構造を説明
+- Q: How far in advance should I book a private Tokyo tour? A: 混雑シーズン別の推奨リードタイム
+- Q: Can I customize a Viator tour? A: 通常はできない/限定的。直接予約との比較
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] Viatorのガイド向けコミッション率（現行：公式発表または業界レポートで確認）
+- [ ] Viatorで東京プライベートツアーの平均掲載価格（1日、半日）
+- [ ] 全国通訳案内士の資格要件・試験概要（外国語観光案内業の業法規制含む）
+- [ ] 2006年改正観光立国推進基本法以降のガイド資格制度の現状（無資格ガイドの法的位置づけ）
+- [ ] GetYourGuide、Klookなど他のプラットフォームのコミッション構造（参考比較）
+
+## Internal link plan (既存記事への参照)
+
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — 「そもそもプライベートツアーが必要か」迷っている読者への入口記事として冒頭でリンク
+- [How Much Does a Private Tour Guide in Tokyo Cost?](/blog/tokyo-private-tour-guide-cost) — Section 03（コスト比較）でリンク。「Viator掲載価格 vs 直接予約価格」の文脈で
+- [Licensed vs. Unlicensed Tour Guides in Japan](/blog/licensed-vs-unlicensed-tour-guides-japan) — Section 02（誰がガイドするか）でリンク
+- [Free Walking Tour vs. Private Tour in Tokyo](/blog/free-walking-tour-vs-private-tokyo) — FAQ最終問「予算が限られている場合は？」でリンク
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["tokyo-half-day", "tokyo-full-day", "custom-private-tour"]} />`
+
+（実際のtour IDはManabuさんのツアーページIDに合わせて調整）
+
+## Image candidates
+
+- **Project内（最優先）**: ツアー中の写真（ガイドと旅行者が地図を見ているシーン、下町散策シーンなど）
+- **不足分**: スマートフォンでViatorアプリ画面を見ているシーン（ライセンスに注意）、ガイド証明書/バッジのクローズアップ写真（Manabuの実物があればベスト）
+
+## Risk notes
+
+- **AI Overview リスク: LOW** — 「どちらが良いか」という比較・判断記事はAI Overviewに吸収されにくい。一次情報（ガイド当事者の視点）が含まれることでさらにリスク低減
+- **カニバリゼーション**: LOW — `/blog/free-walking-tour-vs-private-tokyo`（無料ツアー比較）・`/blog/licensed-vs-unlicensed-tour-guides-japan`（資格比較）とは切り口が明確に異なる（予約チャネル比較）
+- **競合過密リスク**: MEDIUM — Viator自身、GetYourGuide、Tripadvisorが「viator tokyo」クエリを支配。ただし「viator vs direct booking」「should I use viator or book directly」型のcomparison queriesはニッチ
+- **Viatorとの関係**: Manabuが現在Viatorに登録していない場合は明記してよい。登録している場合は利益相反を透明に開示すること
+- **ファクト変動リスク**: Viatorのコミッション率・掲載条件は変更されることがある。Last updated 更新を必須とする
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/ViatorVsPrivateGuideTokyo.tsx` を作成
+2. `src/pages/es/blog/EsViatorVsGuiaPrivadoTokio.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/viator-vs-private-guide-tokyo` および `/es/blog/viator-vs-guia-privado-tokio`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. tsc で型チェック
+7. feature ブランチ作成 + commit + push

--- a/seo-pipeline/data/daily/2026-06-20.json
+++ b/seo-pipeline/data/daily/2026-06-20.json
@@ -1,0 +1,13 @@
+{
+  "generated_at": "2026-06-20",
+  "window_days": 28,
+  "data_note": "Live GSC/GA4 fetch failed: GOOGLE_APPLICATION_CREDENTIALS_JSON secret not configured in this environment. Analysis uses 2026-05-22 dataset as proxy. To fix: add the ADC service account JSON as the GOOGLE_APPLICATION_CREDENTIALS_JSON secret in Routine Environment settings.",
+  "gsc": {
+    "error": "credentials not available",
+    "proxy_from": "seo-pipeline/data/daily/2026-05-22.json"
+  },
+  "ga4": {
+    "error": "credentials not available",
+    "proxy_from": "seo-pipeline/data/daily/2026-05-22.json"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Viator Tokyo Tours vs. Booking a Licensed Guide Directly (2026)
- **slug**: `viator-vs-private-guide-tokyo` (EN), `viator-vs-guia-privado-tokio` (ES)
- **category**: Decision Helpers
- **priority**: high

## なぜこの案か

- `/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` が 直近28日で **表示1,414・クリック10・CTR 0.71%・順位9.73** と好調だが、「具体的にどこで予約するか」という次の判断ステップをカバーする記事が未作成
- `/blog/tokyo-private-tour-guide-cost` が GA4で **エンゲージメント率83.3%・平均312秒** — コスト感を調べた読者が次に「どこで予約するか」に進む導線が整備できる
- config.yml の Decision Helpers 例に `viator-vs-direct` が明記されているにもかかわらず、そのテーマの記事がサイトに存在しない（gap確認済み）
- AI Overview リスクが低い（判断・比較型コンテンツ）、カニバリリスクも低い

> ⚠️ **注意**: 本日のGSC/GA4ライブデータ取得は `GOOGLE_APPLICATION_CREDENTIALS_JSON` シークレット未設定のため失敗しました。分析は `seo-pipeline/data/daily/2026-05-22.json` をプロキシとして使用しています。シークレット設定後は翌日から正確なデータで生成されます。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → ローカルでmergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] **Manabu独自エピソード（3箇所のプレースホルダー）に実体験を追記**
  - Viatorへの登録を検討して断念した（またはしなかった）経緯
  - Viator経由ガイドに困った旅行者からの問い合わせ実例（あれば）
  - 直接予約だから実現できたカスタマイズ事例
- [ ] H2 outlineが論理的か（Section 01〜06 + FAQ）
- [ ] `competitor_difficulty: medium` が妥当か（Viator公式・TripAdvisor系が上位）
- [ ] Required factsのチェックリスト（Viatorコミッション率、全国通訳案内士の資格要件）を執筆前に検証

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-20-viator-vs-private-guide-tokyo.md](seo-pipeline/briefs/2026-06-20-viator-vs-private-guide-tokyo.md)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_014RPnE2MGNzx7NrKGLgLcbF)_