### PR TITLE
brief: 2026-06-21 — Asakusa vs Ueno: Which Tokyo Neighborhood First? (2026)

### DIFF
--- a/seo-pipeline/briefs/2026-06-21-asakusa-vs-ueno-tokyo.md
+++ b/seo-pipeline/briefs/2026-06-21-asakusa-vs-ueno-tokyo.md
@@ -1,0 +1,141 @@
+---
+date: 2026-06-21
+slug: asakusa-vs-ueno-tokyo
+slug_es: asakusa-vs-ueno-tokio
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Asakusa vs Ueno: Which Tokyo Neighborhood Should You Explore First? (2026)
+
+**Spanish Title**: Asakusa vs Ueno: ¿Cuál Barrio de Tokio Visitar Primero? (2026)
+
+## Why this article (data-driven rationale)
+
+> **Note**: GSC/GA4 API data for 2026-06-21 is unavailable (missing `google-api-python-client` module in this environment). The following analysis is based on the most recent available dataset: **2026-05-22** (28-day window: 2026-04-24 → 2026-05-22).
+
+- **GSC signal — Asakusa cluster**: `/blog/old-tokyo-shitamachi` (nearest GSC proxy for Asakusa/Shitamachi neighborhood content) — 直近28日で 表示 624、クリック 2、順位 8.06。GA4オーガニック経由: 3セッション、エンゲージメント率 66.7%、平均滞在99秒。`/blog/asakusa-guide` はオーガニック経由2セッション、エンゲージ率50%。  
+- **Comparison format benchmark**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` — 直近28日で 表示 3,292、クリック 37、CTR 1.12%、順位 6.23。GA4: 47セッション、エンゲージ率 63.8%、**平均滞在2,982秒（約50分）**。比較形式は断然ハイパフォーマー。  
+- **Neighborhood gap**: config.yml の priority_categories.Neighborhoods に `ueno` が明記されているが、Ueno単体またはAsakusaとの比較記事がゼロ。`/blog/harajuku-vs-shibuya-vs-shinjuku` が比較フォーマットで最近追加されており、本記事はその東東京版。  
+- **既存記事ギャップ**: `/blog/asakusa-guide` はAsakusa単体の情報記事。「どちらに行けばいいか」という**判断型クエリ**には未対応。  
+- **想定CV影響**: high — 「どちらの街を選ぶか」を考えている読者は旅程の核を決める段階 = プライベートガイド依頼の直前フェーズ。Section 06「Should You Hire a Private Guide?」でCTAへ自然接続。  
+- **競合状況**: 上位は Lonely Planet, Japan-Guide.com, Time Out Tokyo など DR65-80。ただし「比較 × 現地ガイドの判断軸」という切り口を持つ記事は不在。Manabuの一次情報スラントで差別化可能。
+
+## Target keyword cluster
+
+- **Primary**: "asakusa vs ueno tokyo"
+- **Secondary**: "asakusa or ueno tokyo", "ueno neighborhood guide tokyo", "asakusa ueno same day", "best neighborhood tokyo first time"
+- **Search intent**: informational → navigational（旅程決定フェーズ）
+
+## Differentiation slant (Manabuならでは)
+
+> **[ここにManabuさんの実体験エピソードを挿入 — 以下は方向性の提案]**
+
+- **提案1 — 朝一番の体験差**: 「私がゲストを案内するとき、Asakusaへ行くなら早朝7時着を強く推奨します。理由は…」→ [Manabuさんが実際にゲストと訪れた早朝のAsakusaの体験談を入れてください。Uenoの朝は？動物園が開く前の上野公園の雰囲気は？]
+
+- **提案2 — ゲストタイプ別の反応の違い**: 「500回以上のツアーで気づいたこと：歴史好きのシニアカップルはほぼ必ずAsakusa → Yanaka → Ueno の順を喜ぶ。一方、アート・食好きの20-30代にはUenoのアメ横→上野公園→浅草逆順が刺さる。」→ [実際のゲスト反応を具体的に追記してください]
+
+- **提案3 — ガイド不要な部分・必要な部分の正直な評価**: 「Ueno公園の散歩は一人でも楽しめる。でも上野の東博（東京国立博物館）の常設展は解説なしだと宝の持ち腐れになる理由：展示の文脈とストーリーが…」→ [Manabuさんが実際に博物館で解説した体験から教えてください]
+
+## Meta tags (SEO)
+
+- **Title (EN)** (56文字): "Asakusa vs Ueno: Which Tokyo Neighborhood First? (2026)"
+- **Meta description (EN)** (138文字): "Can't decide between Asakusa and Ueno? Licensed private guide Manabu breaks down both neighborhoods so you can plan the perfect Tokyo day."
+- **Title (ES)** (62文字): "Asakusa vs Ueno: ¿Qué Barrio de Tokio Visitar Primero? (2026)"
+- **Meta description (ES)** (133文字): "¿Asakusa o Ueno? El guía privado con licencia Manabu compara ambos barrios para que planifiques tu día perfecto en Tokio con confianza."
+
+## H2 outline (7 sections + FAQ)
+
+1. **Section 01 · The Quick Answer** — Quick Decision ボックスで2行回答。「歴史・下町文化重視 → Asakusa、博物館・自然・市場重視 → Ueno。両方行けるなら午前Ueno + 午後Asakusa」。冒頭でページを離脱させない。
+
+2. **Section 02 · Asakusa at a Glance** — Sensō-ji、仲見世通り、浅草花屋敷、隅田川。「何が見られるか」より「どんな感情になるか」で書く。朝・昼・夕方の時間帯別おすすめを短く。
+
+3. **Section 03 · Ueno at a Glance** — 上野公園、東京国立博物館、アメヤ横丁、上野動物園。桜シーズンの人口密度も正直に書く。「博物館は1館に絞って」など実用アドバイス。
+
+4. **Section 04 · Head-to-Head Comparison** — cost-table スタイルで6項目比較: 文化深度 / 混雑度 / 歩きやすさ / ガイド付加価値 / アクセス / ベストシーズン。判断軸ごとに勝者を明示。
+
+5. **Section 05 · How to Combine Both in One Day** — 半日コース × 2案（Asakusa朝型 / Ueno朝型）。実際の移動時間（メトロ Ginza線 Asakusa → Ueno 5分）、ランチスポット候補。Manabuエピソードで実際のゲスト体験談。[**エピソードプレースホルダー**]
+
+6. **Section 06 · Should You Hire a Private Guide for Either Neighborhood?** — ガイドが特に効くシーン vs 不要なシーン。正直に「Asakusa仲見世は一人でも楽しめる」と書いたうえで、「でも浅草寺の建築背景・祭りの意味・隠れた裏通りは…」へ。CTA: Manabuのツアーへ。
+
+7. **Section 07 · FAQ** — 4-5問（faq-block ラップ）
+   - Is Asakusa or Ueno better for first-time visitors?
+   - Can I visit both Asakusa and Ueno in one day?
+   - Which neighborhood is less crowded?
+   - Is the Tokyo National Museum worth it without a guide?
+   - How far is Asakusa from Ueno?
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 東京国立博物館: 入館料（一般・学生・無料日）、開館時間、休館日（2026年版公式サイト）
+- [ ] 上野動物園: 入園料（2026年現在）、開園時間、休園日
+- [ ] アメヤ横丁: 一般的な営業時間帯（店舗により異なるが平均的な目安）
+- [ ] 浅草寺境内: 参拝自由時間、仲見世通り一般的な開店時間（早朝vs通常）
+- [ ] AsakusaからUenoへの移動: 東京メトロ銀座線所要時間・料金（2026年版）
+- [ ] 上野公園の桜: 例年のピーク時期と混雑状況（正確な日付は気象依存と注記）
+
+## Internal link plan (既存記事への参照)
+
+- [Sensō-ji: Tokyo's Most Visited Temple](/blog/senso-ji-most-visited-temple) — Asakusaセクションで自然にリンク
+- [Old Tokyo & Shitamachi Guide](/blog/old-tokyo-shitamachi) — Asakusaの下町文化の深掘りとして
+- [Asakusa Guide](/blog/asakusa-guide) — Section 02の詳細情報源として
+- [Yanaka Tokyo Walking Route](/blog/yanaka-tokyo-walking-route) — 「Ueno帰りにYanaka散歩」オプションとして
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — Section 06のCTA前リンク
+- [Where to Stay in Tokyo](/blog/where-to-stay-in-tokyo-area-guide) — Asakusa/Ueno周辺宿泊の文脈
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["asakusa-private-tour", "shitamachi-walking-tour"]} />`
+
+> **Manabuさんへ**: 実際のツアーIDを確認してから差し替えてください。Asakusa/Ueno周辺のツアーIDが異なる場合は修正をお願いします。
+
+## Image candidates
+
+- **Project内（最優先）**: `/public/images/asakusa/` 以下の既存写真（Sensō-ji、仲見世、隅田川）
+- **Ueno不足分**: 上野公園（噴水広場、不忍池）、東京国立博物館正面、アメヤ横丁の賑わい → Wikimedia Commons または Unsplashで「Ueno Park Tokyo」「Ameyoko market」で検索
+- **比較イメージ**: 両エリアを1枚で見せるマップ画像（Google Maps スクリーンショットは著作権注意）
+
+## Risk notes
+
+- **カニバリゼーション低リスク**: 既存のAsakusa/Ueno単体記事（`/blog/asakusa-guide`、Ueno記事なし）と重複度は推定40%以下。比較・判断型という差別化スラントあり。
+- **AI Overview リスク低**: 「どちらがいいか」の判断軸はManabuの主観・経験に基づく → Googleが一行で回答しにくい。情報型（営業時間・料金）セクションは最小限に留めること。
+- **競合過密注意**: DR65-80のLonely Planet/JapanGuide/TimeOutが「best tokyo neighborhoods」で上位。ただし「Asakusa vs Ueno 比較 × ガイドの視点」は空白地帯。ロングテールで勝てる。
+- **ファクト変動リスク**: 上野動物園・東京国立博物館の料金・休館日は年次変動あり。Last Updated 更新必須。執筆時に最新を確認。
+- **Ueno混雑の正直記述**: 花見シーズン（3-4月）のUeno公園は混雑が極端。正直な注意書きを入れることで「Manabuは信頼できる」という権威付けになる。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `templates/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/AsakusaVsUenoTokyo.tsx` を作成
+2. `src/pages/es/blog/EsAsakusaVsUenoTokio.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加
+   - EN: `<Route path="/blog/asakusa-vs-ueno-tokyo" element={<AsakusaVsUenoTokyo />} />`
+   - ES: `<Route path="/es/blog/asakusa-vs-ueno-tokio" element={<EsAsakusaVsUenoTokio />} />`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. `tsc` で型チェック
+7. feature ブランチ作成 + commit
+
+---
+
+## データ取得ステータス（本日 2026-06-21）
+
+```
+GSC/GA4 API: FAILED — No module named 'googleapiclient'
+対応策: pip install google-api-python-client google-auth を実行して再試行
+本briefは 2026-05-22 データ（最新利用可能）を使用
+```
+
+---
+
+*Generated by Daily SEO Brief Routine — 2026-06-21*

--- a/seo-pipeline/data/daily/2026-06-21.json
+++ b/seo-pipeline/data/daily/2026-06-21.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-21",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要
本日の Daily SEO Brief Routine が生成したブリーフです。

**最優先案**: Asakusa vs Ueno: Which Tokyo Neighborhood Should You Explore First? (2026)
- **slug**: `asakusa-vs-ueno-tokyo` (EN), `asakusa-vs-ueno-tokio` (ES)
- **category**: Decision Helpers（主） + Neighborhoods（副）
- **priority**: high

## なぜこの案か

比較フォーマットは本サイト最強パターン（`kamakura-vs-hakone-vs-nikko-day-trip`：28日で表示3,292、CTR 1.12%、GA4平均滞在**50分**）。Uenoはconfig.ymlのターゲット一覧に明記されているが記事ゼロ。Asakusa vs Uenoの比較記事は競合にも存在しない空白地帯で、ガイド判断型のためAI Overviewリスクが低い。

## ⚠️ 注意: GSC/GA4 API 取得失敗

本日の `fetch_daily.py` が `google-api-python-client` モジュール未インストールのためエラー。データは 2026-05-22 の最新利用可能データを使用。

**修正方法（次回実行前）**:
```bash
pip install google-api-python-client google-auth
```

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → merge して記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（3箇所のプレースホルダー）に実体験を追記
  - 早朝Asakusa/Ueno体験談
  - ゲストタイプ別反応の実例
  - 東京国立博物館での解説体験
- [ ] H2 outlineが論理的か（7セクション + FAQ構成）
- [ ] Required factsリスト（上野動物園・東博料金・メトロ時間等）を確認
- [ ] competitor_difficulty: medium / ai_overview_risk: low が妥当か

## 詳細
ブリーフ本体: [seo-pipeline/briefs/2026-06-21-asakusa-vs-ueno-tokyo.md](https://github.com/mkmanabu122003/private-tour-page-new/blob/claude/daily-brief-2026-06-21/seo-pipeline/briefs/2026-06-21-asakusa-vs-ueno-tokyo.md)

---
🤖 Generated by Daily SEO Brief Routine — 2026-06-21

---
_Generated by [Claude Code](https://claude.ai/code/session_016wshKdrTBXHxmsZcigUrV4)_