### PR TITLE
brief: 2026-06-22 — Is Nikko Worth Visiting from Tokyo?

### DIFF
--- a/seo-pipeline/briefs/2026-06-22-is-nikko-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-06-22-is-nikko-worth-visiting.md
@@ -1,0 +1,138 @@
+---
+date: 2026-06-22
+slug: is-nikko-worth-visiting
+slug_es: vale-la-pena-visitar-nikko
+status: pending
+priority: high
+category: Day Trips
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Is Nikko Worth Visiting from Tokyo? A Licensed Guide's Honest Verdict (2026)
+
+**Spanish Title**: ¿Vale la Pena Visitar Nikko desde Tokio? La Opinión de un Guía 2026
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (2026-05-22データ)**: クラスター3記事の複合パフォーマンスが強力
+  - `/blog/kamakura-vs-hakone-vs-nikko-day-trip` — 表示 3,292・クリック 37・CTR 1.12%・順位 6.23
+  - `/blog/nikko-day-trip-from-tokyo` — 表示 667・クリック 0・CTR 0%・順位 23.8（完全クリックゼロ、クラスター強化が急務）
+  - `hakone or nikko`クエリ — 表示 45・クリック 1・CTR 1.35%・順位 8.56
+  - `nikko or kamakura`クエリ — 表示 10・クリック 1・CTR 10%・順位 13
+  - `is hakone worth visiting`クエリ — 直近7日 6 impressions で新規登場（"is X worth visiting" フォーマット需要を確認）
+- **GA4 signal**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` がオーガニック 47 セッション・エンゲージメント 63.8%・平均セッション時間 **2,983 秒（49.7 分）** — サイト内トップクラスの滞在時間。このクラスターへの追加記事 ROI は最高水準
+- **既存記事ギャップ**: `/blog/nikko-day-trip-guide-vs-solo`（「行くなら guide か solo か」）と `/blog/nikko-day-trip-from-tokyo`（ロジスティクス）は存在するが、「そもそも Nikko に行く価値があるか」という上流の決断クエリをカバーする記事がない。`/blog/is-hakone-worth-visiting` との対称性でクラスターが完成する
+- **想定 CV 影響**: high — 「行く価値あるか」という問いは旅行計画の最上流段階。ここで Manabu の verdict に共感した読者が次のステップ（ガイド検討）に進む確率が高い
+- **競合状況**: `is nikko worth visiting` 上位は Lonely Planet, TripAdvisor, Japan Guide。いずれもガイドブック的な客観記述。Manabu の「500+ tours guided / licensed guide の一人称 verdict」は明確に差別化可能。DR 的にも 80+ 独占ではなくニッチ slant で十分競争可能
+
+## Target keyword cluster
+
+- **Primary**: "is nikko worth visiting"
+- **Secondary**: "nikko worth visiting from tokyo", "is nikko worth a day trip", "nikko day trip worth it", "vale la pena visitar nikko" (ES)
+- **Search intent**: commercial investigation（旅行の意思決定段階）— informational ではなく判断・比較
+
+## Differentiation slant (Manabuならでは)
+
+**[ここにManabuさんの実体験エピソードを挿入]**
+
+以下3つの差別化スラントを提案。Manabuさんに実体験を加筆いただく箇所を `[EP]` でマーク：
+
+1. **「期待外れで帰った人」と「最高だったと言う人」の違い**
+   - `[EP]` Manabuが案内した中で「思ったより普通だった」と言ったゲストと「人生で一番良かった」と言ったゲストの違いを具体的エピソードで語る
+   - 差別化の軸：「Nikko は知識と文脈がないと素通りになる場所」というインサイト → ガイド有り無しで体験の質が180度変わる理由につながる
+
+2. **政府公認ガイドとして持つ「歴史的深度」の実例**
+   - `[EP]` 東照宮の彫刻（見猿・聞か猿・言わ猿 / 眠り猫 / 陽明門の逆柱）について、一般観光客が素通りするがガイドが解説すると「なぜそこにあるか」が分かる具体例を1-2個
+   - 差別化の軸：全国通訳案内士として日本史の試験に合格した Manabu だからこそ語れる層の深さ
+
+3. **「2.5時間かけても行くべき人・行くべきでない人」の明確な仕分け基準**
+   - `[EP]` Manabu が実際にゲストを事前ヒアリングするときの判断基準（何を重視するか、滞在日数、体力、他の予定）を具体化
+   - 差別化の軸：ガイドブックが書けない「あなた個人の旅行条件に合わせた判断」= 記事読後にフォーム送信への自然な誘導
+
+## Meta tags (SEO)
+
+- **Title (EN)** (59 chars): `Is Nikko Worth Visiting from Tokyo? A Guide's Verdict 2026`
+- **Meta description (EN)** (143 chars): `Licensed guide Manabu has led 100+ Nikko day tours. His honest verdict: who should visit, who should skip it, and what you'll miss going solo.`
+- **Title (ES)** (58 chars): `¿Vale la Pena Visitar Nikko desde Tokio? Opinión de Guía 2026`
+- **Meta description (ES)** (148 chars): `Nikko está a 2,5 horas de Tokio: ¿merece la pena? Un guía oficial con más de 100 excursiones da su veredicto honesto sobre quién debería ir y quién no.`
+
+## H2 outline (6 sections + FAQ)
+
+1. **Section 01 · The Honest Verdict** — まず結論から。「行くべき人・行かなくていい人」を Quick Decision ボックスで明示。記事冒頭で読者を仕分けする
+2. **Section 02 · What Nikko Actually Is** — 東照宮の UNESCO 登録の意味、日光山全体の構造を200字でコンパクトに。「知ってから見る」vs「知らずに見る」の違いを予告
+3. **Section 03 · The Reality of the Journey** — 東京からのアクセス（東武 vs JR）、所要時間、往復コスト（要ファクトチェック）。「2.5時間かけて何時間滞在できるか」の実態
+4. **Section 04 · What You Can Actually See in a Day** — 標準的な6-8時間滞在で何が見られ何が見られないか。午前中着き必須の理由、混雑回避ポイント。`[EP]` Manabu の推奨ルーティング
+5. **Section 05 · Solo vs. With a Private Guide — The Knowledge Gap** — 彫刻の意味、儀礼の背景、なぜそこに建てられたかを「知っている」か否かで体験の質が変わる具体例。`[EP]` ガイドなし vs ガイドあり の比較エピソード
+6. **Section 06 · FAQ** — 4-5問（以下参照）
+
+**FAQ 候補:**
+- Q: Is one day enough for Nikko?
+- Q: Is Nikko better than Kamakura or Hakone?
+- Q: When is the best time to visit Nikko?
+- Q: Is Nikko expensive to visit?
+- Q: Can I do Nikko without a guide?
+
+## Required facts (web search before writing)
+
+記事執筆前に web search で必ず検証：
+
+- [ ] 東武日光駅・JR日光駅からの東照宮アクセス方法と所要時間（2026年現在）
+- [ ] 東武日光フリーパス（2デイパス / 1デイパス）価格（2026年、税込）
+- [ ] 東照宮拝観料（2026年、大人・子供、税込）
+- [ ] 東照宮の開館時間・定休日（2026年）
+- [ ] 輪王寺・大猷院の拝観料（2026年）
+- [ ] 東京（浅草 or 新宿）→ 東武日光・JR日光の所要時間と運賃比較（2026年）
+- [ ] 日光山内の主要スポット（東照宮・輪王寺・二荒山神社）の拝観セット券の有無
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura vs Hakone vs Nikko Day Trip](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — メインクラスターハブ。3-way比較からNikko詳細へのナビ
+- [Nikko Day Trip: With a Guide vs Solo](/blog/nikko-day-trip-guide-vs-solo) — 「行く価値あり」と判断した読者の次のステップ
+- [Hakone vs Nikko Day Trip](/blog/hakone-vs-nikko-day-trip) — どちらかで迷っている読者への誘導
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — 対称記事として相互リンク。「Nikkoを選んだ理由」として引用可
+- [Best Day Trips from Tokyo](/blog/best-day-trips-from-tokyo) — 上位ピラー。クラスター文脈を与える
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["nikko-day-trip"]} />`
+
+（`/tours/nikko-day-trip` ページが GSC で 443 impressions を獲得中 → CTA の実績あり）
+
+## Image candidates
+
+- **Project 内（最優先）**: `src/assets/` 内の Nikko 関連画像を確認（`/blog/nikko-day-trip-*` 記事で使用済みのものを流用可）
+- **Wikimedia 候補**:
+  - 陽明門（Yomeimon Gate）: 彫刻の細部が分かるもの
+  - 神橋（Shinkyo Bridge）: 日光の象徴として記事冒頭 OG に適している
+  - 杉並木（Cedar Avenue）: スケール感が伝わるもの
+  - 東照宮 眠り猫（Nemuri Neko）: ガイドの説明バリューが伝わる
+
+## Risk notes
+
+- **Duplicate risk LOW**: 既存の `/blog/nikko-day-trip-guide-vs-solo`（「行くなら guide vs solo」）と `/blog/nikko-day-trip-from-tokyo`（ロジスティクス）は search intent が異なる。本記事は "should I go at all?" の上流意思決定段階をカバー。H2 重複度は 30% 以下に収まる見込み
+- **AI Overview risk LOW**: 「行く価値があるか」は価値判断・体験ベースの質問。価格・時刻のような事実型クエリではないため AI Overview のゼロクリック化リスクは低い
+- **Competitor difficulty MEDIUM**: Lonely Planet（DR95+）、TripAdvisor（DR93+）が上位だが、いずれもガイドブック的客観記述。"Licensed guide's verdict" スラントで差別化可。Time Out 等の娯楽メディアはほぼ不在
+- **Fact update risk**: 東照宮拝観料・鉄道運賃は年次改定あり。本文中に断定的な価格を書かず、"Required facts" で執筆時に検証する運用を徹底。"Last updated: June 2026" タグ必須
+
+---
+
+> **⚠️ Data fetch note (2026-06-22)**: 本日の GSC/GA4 fetch スクリプトが `google-api-python-client` モジュール未インストールのため失敗（`seo-pipeline/data/daily/2026-06-22.json` にエラーが記録済み）。上記の GSC/GA4 数値はすべて直近の実データ `seo-pipeline/data/daily/2026-05-22.json`（window: 2026-04-24〜2026-05-22）に基づく。修正方法: `pip install google-api-python-client google-auth` を実行環境にインストールする
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `templates/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsNikkoWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValeLaPenaVisitarNikko.tsx` も作成（hreflang 対応）
+3. `src/AppRoutes.tsx` に import + Route 追加
+   - EN: `<Route path="/blog/is-nikko-worth-visiting" element={<IsNikkoWorthVisiting />} />`
+   - ES: `<Route path="/es/blog/vale-la-pena-visitar-nikko" element={<EsValeLaPenaVisitarNikko />} />`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. `tsc` で型チェック
+7. feature ブランチ作成 + commit

--- a/seo-pipeline/data/daily/2026-06-22.json
+++ b/seo-pipeline/data/daily/2026-06-22.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-22",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Nikko Worth Visiting from Tokyo? A Licensed Guide's Honest Verdict (2026)
- **slug**: `is-nikko-worth-visiting` (EN), `vale-la-pena-visitar-nikko` (ES)
- **category**: Day Trips
- **priority**: high
- **推定文字数**: 2,200語

## 選定理由（データ要約）

データソース: `seo-pipeline/data/daily/2026-05-22.json`（直近28日）

| シグナル | 値 |
|---|---|
| `/blog/kamakura-vs-hakone-vs-nikko-day-trip` GA4 平均滞在時間 | **49.7分**（サイト内最高水準） |
| `hakone or nikko` クエリ | 表示45・クリック1・順位8.56 |
| `nikko or kamakura` クエリ | 表示10・クリック1・順位13 |
| `is hakone worth visiting` 直近7日 新規出現 | 6 impressions（フォーマット需要を確認） |
| `/blog/nikko-day-trip-from-tokyo` | 表示667・クリック0・CTR 0%（クラスター補強が急務） |

**既存記事との差別化**: `/blog/nikko-day-trip-guide-vs-solo`（行くなら guide か solo か）、`/blog/nikko-day-trip-from-tokyo`（ロジスティクス）は存在するが、「**そもそも Nikko に行く価値があるか**」という上流決断クエリをカバーする記事が空白。`/blog/is-hakone-worth-visiting` との対称性でクラスターが完成する。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → merge して記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（`[EP]` プレースホルダー 3か所）に実体験を追記
  - 「期待外れ vs 最高だった」ゲストの違いエピソード
  - 東照宮の彫刻について知識が体験を変えた具体例
  - ゲスト事前ヒアリングでの Nikko 判断基準
- [ ] Required facts（東照宮入場料・鉄道料金・営業時間 2026年版）を web search で確認
- [ ] H2 アウトラインが旅行計画の流れに沿っているか確認
- [ ] `/tours/nikko-day-trip` への CTA が適切か確認

## ⚠️ Data fetch エラーの補足

本日（2026-06-22）の GSC/GA4 取得は `google-api-python-client` 未インストールのため失敗。
上記の数値は `2026-05-22.json` の実データに基づいています。

修正: `pip install google-api-python-client google-auth` を実行環境に追加してください。

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-22-is-nikko-worth-visiting.md](seo-pipeline/briefs/2026-06-22-is-nikko-worth-visiting.md)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3ELWWvAfchZRJmwdwpgE3)_