### PR TITLE
brief: 2026-06-23 — Half-Day vs Full-Day Private Tour Tokyo

### DIFF
--- a/seo-pipeline/briefs/2026-06-23-tokyo-half-day-vs-full-day-tour.md
+++ b/seo-pipeline/briefs/2026-06-23-tokyo-half-day-vs-full-day-tour.md
@@ -1,0 +1,134 @@
+---
+date: 2026-06-23
+slug: tokyo-half-day-vs-full-day-tour
+slug_es: tour-tokio-medio-dia-vs-dia-completo
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Half-Day vs Full-Day Private Tour Tokyo: Which Is Right for You?
+
+**Spanish Title**: Tour Privado en Tokio: ¿Medio Día o Día Completo? Guía para Elegir
+
+## Why this article (data-driven rationale)
+
+> ⚠️ Note: GSC/GA4 API returned auth errors on 2026-06-23 (missing `googleapiclient` package).
+> Figures below are from the 2026-05-22 28-day window (last successful pull) used as reference baseline.
+
+- **GSC signal A**: `/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` — 直近28日で 表示 1,414、クリック 10、CTR 0.71%、順位 9.73 → サイト内で最高クラスのCTRを持つCV起点ページ。このページを読んだユーザーの「次の疑問」は自然に **「何時間のツアーを予約すれば良いか」** に移る。
+- **GSC signal B**: `/blog/tokyo-private-tour-guide-cost` — 表示 2,564、クリック 11、CTR 0.43%、順位 7.38 → 料金を調べているユーザーは半日と1日の価格差を比較する段階にある。このページから「半日 vs 1日」記事への内部リンクで自然なファネル流入が期待できる。
+- **GSC signal C**: `/blog/group-vs-private-tour-tokyo`（新規ページ、まだGSCデータなし）+ `/blog/viator-vs-getyourguide-vs-direct-tokyo`（同）→ Decision Helpersクラスターが急拡大中。「ツアー時間の選び方」はこのクラスターの自然な穴。
+- **既存記事ギャップ**: `how-to-choose-private-tokyo-guide` はガイドの選び方、`what-to-expect-private-tour-tokyo` は当日の流れを扱うが、**ツアー時間フォーマット（半日 vs 1日）の決断を扱う記事は存在しない**。購入前の最後の判断材料が欠けている。
+- **想定CV影響**: HIGH — 時間フォーマット選択は予約フォーム送信の直前の行動。「迷っている → 記事で納得 → 問い合わせ」の最短ルート。
+- **競合状況**: Viator/TripAdvisor は「半日ツアー一覧」のリスト形式。**ガイド本人が「なぜ半日で十分か/なぜ1日必要か」を判断目線で書いた記事は存在しない** → ニッチ優位性あり。DR的には TripAdvisor DR90+ だが、advisory content として差別化可能。
+
+## Target keyword cluster
+
+- **Primary**: "half day private tour tokyo"
+- **Secondary**: "tokyo full day private tour", "how long should a tokyo private tour be", "half day vs full day tour tokyo", "tokyo private tour duration"
+- **Long-tail**: "is half day enough for tokyo private tour", "tokyo guided tour how many hours"
+- **ES Primary**: "tour privado tokio medio día"
+- **ES Secondary**: "medio día o día completo tokio", "cuántas horas de tour privado tokio"
+- **Search intent**: commercial / decision (購入前判断フェーズ)
+
+## Differentiation slant (Manabuならでは)
+
+> ここにManabuさんの実体験エピソードを挿入してください。以下は差別化スラントの方向性です。
+
+1. **「詰め込みすぎの失敗談」エピソード**: 半日に6エリアを詰め込もうとしたゲストの体験談から、なぜ「移動時間 + 解説 + 写真撮影 + 休憩 = 4時間でカバーできる範囲の現実」を伝えられる。
+   - **[Manabuさん記入欄]**: 「例えば、〇〇から来たご夫婦が半日で浅草・渋谷・新宿を全部回りたいとおっしゃって…実際どうなったか」など実体験を1-2段落で。
+
+2. **「1日ツアーで変わった瞬間」エピソード**: 朝の下町の表情と夕方の新宿の喧騒を対比体験できるのは1日ツアーだけ——という具体的なシーン。
+   - **[Manabuさん記入欄]**: 「午前は谷根千の昭和な商店街、午後は渋谷の若者文化…という1日で、ゲストが『東京は全然別の都市が重なってる』と言っていた」など。
+
+3. **政府公認ガイドならではの時間計算**: 500件超のツアー経験から「この距離の移動は電車でX分 + 歩行Y分 + 解説Z分」という実測データを持っている。一般旅行サイトの「〇〇は徒歩5分」より正確な時間配分を提示。
+   - **[Manabuさん記入欄]**: 半日ツアーで実際に使う標準コースの時間内訳（例：浅草コース: 雷門 25分 + 仲見世 15分 + 本堂 20分 + 周辺 30分 + 移動 20分 = 約2時間）を記載すると説得力大。
+
+## Meta tags (SEO)
+
+- **Title (EN)** (53字): "Tokyo Half-Day vs Full-Day Private Tour: Which Fits?"
+- **Meta description (EN)** (152字): "Can't decide between a half-day or full-day private tour in Tokyo? Licensed guide Manabu explains what each covers, who each suits, and how to choose."
+- **Title (ES)** (51字): "Tour Privado Tokio: ¿Medio Día o Día Completo?"
+- **Meta description (ES)** (153字): "¿Medio día o día completo en Tokio con guía privado? Manabu, guía oficial, explica qué cubre cada opción, para quién es ideal y cómo tomar la decisión."
+
+## H2 outline (6 sections + FAQ)
+
+1. **Section 01 · What Half-Day Actually Covers** — 半日（3〜4時間）で現実的にできること・できないことを具体的に。「1エリアを深く」vs「2エリアを浅く」の選択肢。
+2. **Section 02 · What Full-Day Unlocks** — 1日（6〜8時間）で可能になる「朝と夜の東京の対比」「ランチ同行」「2エリア深掘り」の価値。
+3. **Section 03 · Choose Half-Day If…** — クルーズ船寄港者・時差ボケ直後・東京2度目以降・子連れで午後は昼寝させたい、等の具体的なユースケース。
+4. **Section 04 · Choose Full-Day If…** — 東京初訪問・歴史や文化を深く学びたい・ランチ体験を含めたい・シニアや足が心配なペースで歩きたい、等。
+5. **Section 05 · The Cost Equation** — 半日と1日の時間単価を比較。「半日 × 2回」vs「1日 × 1回」の実際の費用感と満足度の違い。`/blog/tokyo-private-tour-guide-cost` への誘導。
+6. **Section 06 · FAQ** — 4〜5問（以下参照）
+
+### FAQ候補（4-5問）
+- Q: Can I extend a half-day tour to full-day on the day?
+- Q: Is a full-day tour too tiring for elderly parents or young children?
+- Q: Do you cover different neighborhoods for half-day vs full-day?
+- Q: What's included in each (transport, entrance fees, meals)?
+- Q: I only have 2 hours — is a shorter session possible?
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に必ずManabuさんに確認 or 公式サイトで検証：
+
+- [ ] **Manabuの半日ツアー定義**: 正確な時間（3時間？4時間？4.5時間？）と開始可能な時間帯
+- [ ] **Manabuの1日ツアー定義**: 正確な時間（6時間？8時間？）と標準的な開始・終了時刻
+- [ ] **価格帯**: 半日と1日それぞれの料金（円建て・税込）— 予約ページまたは `/blog/tokyo-private-tour-guide-cost` 参照
+- [ ] **ランチ同行の可否**: 1日ツアーにランチ時間は含まれるか、別途手配か
+- [ ] **最小・最大グループ人数**: 半日と1日で異なるか
+
+## Internal link plan (既存記事への参照)
+
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — 「そもそもガイドは必要か」段階のユーザーをこの記事に誘導
+- [Tokyo Private Tour Guide Cost 2026](/blog/tokyo-private-tour-guide-cost) — Section 05の料金比較で自然参照
+- [What to Expect on a Private Tour in Tokyo](/blog/what-to-expect-private-tour-tokyo) — 「決めたら次はこれ」として誘導
+- [How to Choose a Private Tokyo Guide](/blog/how-to-choose-private-tokyo-guide) — Section 06 FAQ後のCTA候補
+- [Group vs Private Tour Tokyo](/blog/group-vs-private-tour-tokyo) — 関連Decision Helper
+- [Free Walking Tour vs Private Tour Tokyo](/blog/free-walking-tour-vs-private-tokyo) — 関連Decision Helper
+
+## Related tour CTA
+
+```
+<RelatedTourCards tourIds={["tokyo-private-tour", "asakusa", "shibuya-harajuku"]} />
+```
+> ※ tourIDs はManabuさんの実際のツアーページのIDで確認・差し替えが必要
+
+## Image candidates
+
+- **Project内（最優先）**: `/public/images/` 以下に朝の浅草 or 夕方の渋谷の写真があれば「半日 vs 1日」の視覚対比に使えるもの
+- **不足分**: 朝の下町ゆったりシーン（半日イメージ）+ 夕暮れの都市対比シーン（1日イメージ）
+  - Unsplash: 検索ワード "Tokyo Asakusa morning" / "Shibuya evening guide"
+
+## Risk notes
+
+- **低カニバリゼーションリスク**: 既存Decision Helper記事（group-vs-private, how-to-choose, viator-vs-direct, free-vs-private, what-to-expect）はすべて**軸が異なる**（誰と行くか・どこで予約するか・何が起きるか）。本記事は**どれくらいの時間**という軸で明確に差別化されている。重複度推定 < 30%。
+- **低AI Overviewリスク**: 「半日と1日どちらにすべきか」は判断・体験ベースの質問であり、Google AI Overviewが一問一答で解決しにくいタイプ。ゼロクリック化リスク低。
+- **中競合難易度**: Viator/TripAdvisor は「半日ツアー一覧」リスト。advisory content としての記事は少ない。ただしTripAdvisor DR90+ が広いクエリをカバーするため、ロングテール中心で対策。
+- **ファクト変動リスク**: 料金・時間は変更可能性あり。Last Updated 更新必須。Manabuさんの実際のツアー内容が変わった場合は即反映。
+
+## データ取得失敗の注記
+
+本日（2026-06-23）のGSC/GA4 fetch は `No module named 'googleapiclient'` エラーにより実データ取得失敗。
+`seo-pipeline/data/daily/2026-06-23.json` は空データ（エラー記録のみ）。
+分析は `seo-pipeline/data/daily/2026-05-22.json`（前回成功分）を参照基準とした。
+
+**修正手順**: `pip install google-api-python-client google-auth` をRoutine環境に追加するか、Routine設定のsetup scriptに追記。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `templates/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/TokyoHalfDayVsFullDayTour.tsx` を作成
+2. `src/pages/es/blog/EsTourTokioMedioDiaVsDiaCompleto.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/tokyo-half-day-vs-full-day-tour` / `/es/blog/tour-tokio-medio-dia-vs-dia-completo`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. tsc で型チェック
+7. feature ブランチ作成 + commit

--- a/seo-pipeline/data/daily/2026-06-23.json
+++ b/seo-pipeline/data/daily/2026-06-23.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-23",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Half-Day vs Full-Day Private Tour Tokyo: Which Is Right for You?
- **slug**: `tokyo-half-day-vs-full-day-tour` (EN), `tour-tokio-medio-dia-vs-dia-completo` (ES)
- **category**: Decision Helpers
- **priority**: high

## なぜこの案か

`/blog/is-it-worth-hiring-a-tour-guide-in-tokyo`（表示 1,414・CTR 0.71%・サイト最高クラス）を読んだユーザーの「次の疑問」は「何時間のツアーを予約すべきか」。既存の Decision Helper 記事はすべて「誰と・どこで・何を」軸であり、**「何時間」軸の記事がクラスターに欠けていた**。購入直前フェーズの読者に直接届く → form_submit CV影響: HIGH。

AI Overview リスク: LOW（判断・体験ベースのクエリ）。競合はリスト系サイトのみでadvisory contentは空白。

## ⚠️ GSC/GA4 APIエラーの注記

2026-06-23 のデータ取得が `No module named 'googleapiclient'` で失敗。
分析は前回成功分（2026-05-22）を参照基準としました。

**恒久対策**: Routine の setup script に `pip install google-api-python-client google-auth` を追加してください。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] **Manabu独自エピソード**（プレースホルダー3箇所）に実体験を追記
- [ ] **Required facts** 5項目（半日/1日の正確な時間・価格・人数制限）を確認
- [ ] H2 outline（6セクション + FAQ）が論理的か
- [ ] RelatedTourCards の tourIDs を実際のツアーIDに差し替え

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-23-tokyo-half-day-vs-full-day-tour.md](seo-pipeline/briefs/2026-06-23-tokyo-half-day-vs-full-day-tour.md)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_017GWgoCB4mfgW8WguuVifDv)_