### PR TITLE
brief: 2026-06-24 — Is Nikko Worth Visiting? (EN+ES)

### DIFF
--- a/seo-pipeline/briefs/2026-06-24-is-nikko-worth-it-day-trip.md
+++ b/seo-pipeline/briefs/2026-06-24-is-nikko-worth-it-day-trip.md
@@ -1,0 +1,106 @@
+---
+date: 2026-06-24
+slug: is-nikko-worth-it-day-trip
+slug_es: vale-la-pena-visitar-nikko
+status: pending
+priority: high
+category: Day Trips
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Is Nikko Worth Visiting? An Honest Take from a Licensed Tokyo Private Guide (2026)
+
+**Spanish Title**: ¿Vale la pena visitar Nikko? La opinión honesta de un guía privado de Tokio (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal**: `/blog/nikko-day-trip-from-tokyo` 直近28日で 表示 667、クリック 0、順位 23.8 — 致命的アンダーパフォーム。「hakone or nikko」45表示、CTR 2.22%、順位 8.56 → 読者がどちらに行くか比較検討中のシグナル
+- **Pattern signal**: `is-hakone-worth-visiting` を直近に追加済み（AppRoutes確認）→ 同一Decision Helper構造でNikkoも成立、内部リンク網が強化される
+- **既存記事ギャップ**: `nikko-day-trip-from-tokyo`（ロジスティクス）、`nikko-day-trip-guide-vs-solo`（guide選択）、`hakone-vs-nikko-day-trip`（比較）は存在するが、**「そもそも行く価値があるか」という入口の意思決定記事がない**
+- **想定CV影響**: high — 「is it worth visiting?」クエリはツアー予約の最上流。決めた後にManabuのNikko private tour pageへ誘導できる
+- **競合状況**: Lonely Planet（DR90+）、Japan-guide.com（DR70+）、Atlas Obscura（DR80+）が上位。DR的に劣るが「政府公認ガイドの一人称評価」という独自スラントで差別化の余地あり
+
+## Target keyword cluster
+
+- **Primary**: "is nikko worth visiting"
+- **Secondary**: "nikko day trip worth it", "is nikko worth a day trip", "how many hours do you need in nikko", "nikko one day enough", "nikko worth it 2026"
+- **Search intent**: commercial investigation（行くかどうかを決めようとしている段階）
+
+## Differentiation slant (Manabuならでは)
+
+[ここにManabuさんの実体験エピソードを挿入]
+
+1. **「もう少しで帰るところだったカップルの話」**: メイン参道しか見ていなかったゲストが「やっぱり観光地すぎる」と諦めかけたとき、裏ルート（奥の院への空いた杉並木道、眠り猫の裏面、奥社の静けさ）を案内した経験。ガイドありとなしでは文字通り別の場所になる瞬間があった — [ここにManabuさんの具体的なエピソードと感想を挿入]
+
+2. **全国通訳案内士の試験知識が生きる場所**: 東照宮の絢爛豪華な装飾は「江戸幕府の権威を視覚化した政治的装置」という歴史背景を知ると全く違って見える。「なぜここまで派手なのか」「なぜ京都の寺社と正反対のデザインなのか」を答えられるのは試験勉強済みのManabuの強み — [ここに具体的な説明例を挿入]
+
+3. **「1日で足りるか」へのリアルな時間配分**: 500件以上のツアー経験から導き出した「このペースで回れば奥の院まで見られる」というタイムライン — [ここにManabuさんの実際のモデルスケジュールを挿入（例：9時着 → 10時表門 → 11時奥の院 → 13時昼食 → 14時华厳の滝 → 16時帰途）]
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Nikko Worth Visiting? A Private Guide's Honest Take (2026)`
+- **Meta description (EN)** (155字以内): `Nikko in one day — is it actually worth it? A Tokyo-licensed private guide shares what solo visitors miss, how long you really need, and when hiring a guide changes everything.`
+- **Title (ES)** (60字以内): `¿Vale la pena visitar Nikko? Opinión de un guía privado (2026)`
+- **Meta description (ES)** (155字以内): `¿Merece la pena Nikko en un día? Un guía privado con licencia nacional te dice qué pierde el viajero independiente, cuánto tiempo necesitas de verdad y si contratar guía marca la diferencia.`
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Honest Answer** — Quick Decision box: Yes / Depends / Not for everyone。「NikkoはKamakuraより時間がかかる、それでも行く価値があるのか」という正直な入り口。誰に向いていて誰には向かないかを1パラグラフで結論から述べる
+2. **Section 02 · What Makes Nikko Genuinely Special** — 世界遺産103棟の規模感、1,000年以上の杉並木（日本三大美林のひとつ）、华厳の滝の迫力。「写真では伝わらない実物の圧倒感」をManabuの言葉で
+3. **Section 03 · The Honest Downsides (Don't Skip This)** — 東京から2時間超の移動時間、入場料合計（執筆時に要検証）、紅葉・桜シーズンの混雑実態、「お土産屋だらけ」という先入観の実態。過大評価されがちな点も正直に
+4. **Section 04 · Is One Day Enough in Nikko?** — 「標準ルート（東照宮エリアのみ）」vs「奥の院＋华厳の滝フルコース」の所要時間比較。ガイドありとなしでの時間差（移動ロスの削減効果）。Manabuのモデルタイムラインを挿入（プレースホルダー）
+5. **Section 05 · What a Private Guide Adds (And What It Doesn't)** — Manabuの実体験エピソード（プレースホルダー参照）。歴史解説の深さ、裏ルート・穴場への案内、英語対応の安心感。「ガイドなしでも回れる、ただし〇〇は難しい」という正直な評価
+6. **Section 06 · Practical Planning Tips** — 季節別おすすめ（紅葉vs新緑vs冬の雪景色）、日光フリーパスのコスパ実態（執筆時に要検証）、早朝出発の重要性、持ち物チェック。ManabuのNikkoツアーへのCTAリンク
+7. **Section 07 · FAQ** — 5問：「Is Nikko worth it without a guide?」「Can I do Nikko and Kamakura on the same trip?」「Is Nikko good in summer?」「How early should I leave Tokyo for Nikko?」「Is Nikko worth it compared to Hakone?」
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 東照宮・輪王寺・二荒山神社 セット入場料（円建て、税込、2026年最新）—公式サイト優先
+- [ ] 华厳の滝エレベーター料金（2026年版）
+- [ ] 東京→日光 最速ルートと所要時間（東武特急きぬ/日光号、またはJR+東武乗り換え）
+- [ ] 日光フリーパス 料金と対象範囲（2026年版）—東武公式サイト確認
+- [ ] 東照宮の定休日・年間臨時休館日
+- [ ] 紅葉ピークシーズンの混雑実態（公式情報 or 近年の実績）
+
+## Internal link plan (既存記事への参照)
+
+- [Nikko Day Trip from Tokyo: Full Guide](/blog/nikko-day-trip-from-tokyo) — アクセス・時刻表の詳細はこちら、と参照させる
+- [Nikko With a Guide vs Solo](/blog/nikko-day-trip-guide-vs-solo) — ガイド有無の詳細比較へ
+- [Hakone vs Nikko Day Trip](/blog/hakone-vs-nikko-day-trip) — どちらを選ぶか迷っている読者向け
+- [Kamakura vs Hakone vs Nikko](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 三択比較の参照先
+- [Is Hakone Worth Visiting](/blog/is-hakone-worth-visiting) — 「HakoneかNikkoか」で迷っている読者への対案
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["nikko-day-trip"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/nikko/` 配下の既存画像（東照宮陽明門、杉並木、奥の院）を確認
+- **不足分（Wikimedia/Unsplash提案）**: 华厳の滝の全景（CC BY）、紅葉シーズンの東照宮参道（著作権要確認）
+
+## Risk notes
+
+- **カニバリゼーション低**: 既存4本のNikko記事とは検索意図が明確に異なる（商業調査 vs 実用情報）。タイトルとH1が重複しない限り共存可能
+- **AI Overview リスク低**: 「is it worth visiting?」は体験・判断型クエリ → AIが苦手とする主観的評価領域。Manabuの一人称視点が差別化に機能する
+- **競合難易度中**: Lonely Planet, Japan-guide.com がDR70-90+で上位。ただしガイド視点の差別化でSERPに食い込む余地はある（is-hakone-worth-visitingの実績を参考に）
+- **ファクト変動リスク**: 入場料・フリーパス料金は年次変動あり → Last updated タグ必須、執筆後も定期確認
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsNikkoWorthItDayTrip.tsx` を作成
+2. `src/pages/es/blog/EsValelapenaVisitarNikko.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 2本追加（`/blog/is-nikko-worth-it-day-trip` と `/es/blog/vale-la-pena-visitar-nikko`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加（trailing slash なし統一）
+6. `tsc --noEmit` で型チェック
+7. feature ブランチ作成 + commit

--- a/seo-pipeline/data/daily/2026-06-24.json
+++ b/seo-pipeline/data/daily/2026-06-24.json
@@ -1,0 +1,145 @@
+{
+  "generated_at": "2026-06-24",
+  "window_days": 28,
+  "_note": "Google API fetch failed in this session due to cffi/cryptography native module issue in the execution environment. Analysis performed using 2026-05-22 baseline data (28-day window: 2026-04-24 to 2026-05-22). Brief generation proceeded with that dataset.",
+  "gsc": {
+    "error": "ModuleNotFoundError: No module named '_cffi_backend' (cryptography native extension crash). See _note for fallback.",
+    "_baseline_ref": "2026-05-22.json",
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "clicks": 275,
+      "impressions": 101626,
+      "page_count": 154,
+      "query_count": 2556
+    },
+    "top_pages_by_impression": [
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it",
+        "clicks": 15,
+        "impressions": 38565,
+        "ctr": 0.0389,
+        "position": 8.18
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide",
+        "clicks": 92,
+        "impressions": 26845,
+        "ctr": 0.3427,
+        "position": 6.52
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip",
+        "clicks": 37,
+        "impressions": 3292,
+        "ctr": 1.1239,
+        "position": 6.23
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost",
+        "clicks": 11,
+        "impressions": 2564,
+        "ctr": 0.429,
+        "position": 7.38
+      },
+      {
+        "page": "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo",
+        "clicks": 0,
+        "impressions": 667,
+        "ctr": 0,
+        "position": 23.8
+      }
+    ],
+    "near_page_one_pushup": [
+      {
+        "query": "japan rail pass price 2026",
+        "clicks": 0,
+        "impressions": 400,
+        "ctr": 0,
+        "position": 11.92
+      }
+    ],
+    "zero_click_opportunities": [
+      {
+        "query": "jr pass price increase 2026",
+        "clicks": 0,
+        "impressions": 1121,
+        "ctr": 0,
+        "position": 5.45
+      },
+      {
+        "query": "tsukiji outer market official hours 2026",
+        "clicks": 0,
+        "impressions": 252,
+        "ctr": 0,
+        "position": 3.4
+      }
+    ],
+    "new_queries_last7": [
+      {
+        "query": "is hakone worth visiting",
+        "clicks": 0,
+        "impressions": 6,
+        "ctr": 0,
+        "position": 40.83
+      },
+      {
+        "query": "best places to see mount fuji from tokyo 2026",
+        "clicks": 0,
+        "impressions": 4,
+        "ctr": 0,
+        "position": 5.75
+      },
+      {
+        "query": "early morning breakfast tokyo",
+        "clicks": 0,
+        "impressions": 2,
+        "ctr": 0,
+        "position": 1
+      }
+    ]
+  },
+  "ga4": {
+    "error": "ModuleNotFoundError: No module named '_cffi_backend' (same crash). See _note for fallback.",
+    "_baseline_ref": "2026-05-22.json",
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "sessions": 749.0,
+      "totalUsers": 623.0,
+      "form_submit": 8.0,
+      "engagementRate": 0.3925,
+      "averageSessionDuration": 306.08
+    },
+    "top_organic_landing_pages": [
+      {
+        "page": "/blog/tsukiji-market-guide",
+        "sessions": 135,
+        "engagementRate": 0.533,
+        "avgDuration_s": 245.9
+      },
+      {
+        "page": "/blog/kamakura-vs-hakone-vs-nikko-day-trip",
+        "sessions": 47,
+        "engagementRate": 0.638,
+        "avgDuration_s": 2982.6
+      },
+      {
+        "page": "/blog/tokyo-private-tour-guide-cost",
+        "sessions": 12,
+        "engagementRate": 0.833,
+        "avgDuration_s": 311.6
+      },
+      {
+        "page": "/blog/nikko-day-trip-guide-vs-solo",
+        "sessions": 2,
+        "engagementRate": 0.5,
+        "avgDuration_s": 373.5
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Nikko Worth Visiting? An Honest Take from a Licensed Tokyo Private Guide (2026)
- **slug**: `is-nikko-worth-it-day-trip` (EN), `vale-la-pena-visitar-nikko` (ES)
- **category**: Day Trips（+ Decision Helper要素）
- **priority**: high

## なぜこの案か

GSCデータ（2026-04-24〜05-22 28日間）より:
- `/blog/nikko-day-trip-from-tokyo` — 667表示、**0クリック**、順位23.8（致命的アンダーパフォーム）
- 「hakone or nikko」— 45表示、2.22%CTR、順位8.56（比較検討クエリが存在）
- `is-hakone-worth-visiting` を直近追加済み → 同パターンでNikkoクラスターを強化する自然な次手
- 既存Nikko記事4本はロジスティクス・比較系だが「行く価値があるか」という**入口の意思決定記事がない**

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → 記事化（`/build-article` スキル）に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（3箇所のプレースホルダー）に実体験を追記
  - 「もう少しで帰るところだったカップル」エピソード
  - 全国通訳案内士の知識が生きた具体的な説明例
  - 実際のモデルスケジュール（時間配分）
- [ ] Required factsチェックリスト（入場料・フリーパス料金・アクセス所要時間）を確認
- [ ] H2アウトラインが論理的か確認
- [ ] `is-hakone-worth-visiting` との差別化が十分か確認

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-24-is-nikko-worth-it-day-trip.md](seo-pipeline/briefs/2026-06-24-is-nikko-worth-it-day-trip.md)

### ガードレールチェック結果
- カニバリゼーション: **低** — 既存4本のNikko記事と検索意図が明確に異なる（商業調査 vs 実用情報）
- AI Overview リスク: **低** — 「is it worth visiting?」は主観的判断クエリ
- 競合難易度: **中** — Lonely Planet/Japan-guide.com が上位だがガイド一人称視点で差別化可能
- avoid keyword: 該当なし

### 注意事項
今回のGSCデータ取得はPython環境の`cffi`モジュール問題で直近28日分のライブデータ取得に失敗。
2026-05-22の既存データ（28日間ウィンドウ）を基に分析を実施。
`seo-pipeline/data/daily/2026-06-24.json` にエラー詳細と使用したベースラインデータを記載。

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_0179nXmyFcXR2GtqXm7MwG71)_