### PR TITLE
brief: 2026-06-25 — Is Nikko Worth Visiting? A Licensed Guide's Honest Take for 2026

### DIFF
--- a/seo-pipeline/briefs/2026-06-25-is-nikko-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-06-25-is-nikko-worth-visiting.md
@@ -1,0 +1,112 @@
+---
+date: 2026-06-25
+slug: is-nikko-worth-visiting
+slug_es: vale-la-pena-visitar-nikko
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: medium
+---
+
+# Is Nikko Worth Visiting? A Licensed Guide's Honest Take for 2026
+
+**Spanish Title**: ¿Vale la Pena Visitar Nikko? La Opinión Honesta de un Guía Oficial (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (primary page)**: `/blog/nikko-day-trip-from-tokyo` → 直近28日で表示 **667**、クリック **0**、順位 **23.8**。表示数は中位クラスだがCTRゼロという異常値。検索者の意図（「行く価値あるか?」）にコンテンツが応えられていない可能性が高い。
+- **新規クエリシグナル（姉妹記事）**: 「is hakone worth visiting」がnew_queries_last7に登場（6 impressions、pos 40.83）。既存の `/blog/is-hakone-worth-visiting` は同じフォーマットで存在し、このパターンがSERP上で認知されつつある。Nikko版が空白。
+- **近接クエリ**: 「nikko o kamakura」（1 click、10 impressions、pos 13）がメインGSCに浮上→スペイン語話者も含め「どちらに行くべきか」評価フェーズの読者が存在する。
+- **既存記事ギャップ**: `/blog/nikko-day-trip-guide-vs-solo`（ガイド vs ソロ比較）と `/blog/kamakura-vs-hakone-vs-nikko-day-trip`（3択比較）は存在するが、「そもそも行く価値があるか?」という最上流の評価クエリに答える記事がない。
+- **想定CV影響**: high — 「行く価値あり」と結論付けた読者が「それなら専門ガイドと行こう」というステップに自然に進む。フォーム送信（form_submit）の上流意思決定段階に直撃する。
+- **競合状況**: 上位は TripAdvisor、Lonely Planet、Japan Guide 等の DR70-90 サイト。ただし、これらの記事は「何がある」という情報型。「行く価値があるか?」に対して個人ガイドの判断軸で答えるニッチ slant は競合が薄い。
+
+## Target keyword cluster
+
+- **Primary**: "is nikko worth visiting"
+- **Secondary**: "nikko worth it", "nikko day trip worth it", "is nikko worth a day trip from tokyo", "nikko 2026"
+- **Search intent**: commercial investigation（行くかどうかを決める段階）
+- **Semantic neighbors**: "nikko day trip", "best things to do in nikko", "nikko vs kamakura", "nikko for one day"
+
+## Differentiation slant (Manabuならでは)
+
+**[ここにManabuさんの実体験エピソード挿入指示]** — 以下の3方向から選んで1〜2エピソードを追記してください:
+
+1. **「日光を案内した印象深い瞬間」**: [例: 「60代のアメリカ人カップルを連れていったとき、陽明門の彫刻を英語で説明したら涙を流された」「子ども連れで三猿の本当の意味を伝えた体験」等、Manabuさんの実体験エピソードを挿入]
+2. **「政府公認ガイドだからこそ知るNikkoの"外せないのに見落とされる場所"」**: [例: 「観光客の90%が素通りする◯◯は、実は〜という背景があって…」「眠り猫の裏側まで見た人はほとんどいない」など、公認ガイドの深い知識から]
+3. **「行くべきでないシナリオ」の正直な話**: [例: 「混雑する祝日、特に◯月の連休はおすすめしない理由」「1時間しかいられない場合は正直もったいない」など、他のガイドサイトが書かない"行かない方がいいケース"を正直に記述]
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Nikko Worth Visiting? A Private Guide's Verdict for 2026`
+- **Meta description (EN)** (155字以内): `After guiding 500+ private tours, here's my honest take on whether Nikko is worth a day trip from Tokyo — what to skip, when to go, and why a guide changes everything.`
+- **Title (ES)** (60字以内): `¿Vale la Pena Visitar Nikko? La Opinión de un Guía Privado 2026`
+- **Meta description (ES)** (155字以内): `Tras guiar más de 500 tours privados, te doy mi opinión honesta sobre si merece la pena visitar Nikko desde Tokio — qué evitar, cuándo ir y por qué un guía marca la diferencia.`
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Short Answer** — Quick Decision ボックス形式で結論を先出し（「日帰りなら○○な人に強くおすすめ」と1文で。体験・文化好きなら high推奨、時間が2時間以下なら見送り推奨）
+2. **Section 02 · What Makes Nikko Different** — 日光の核心的価値（世界遺産・江戸時代の権力と信仰の結節点）を他の日帰り先と比較。「東照宮だけじゃない」視点でガイドならではの付加価値を提示。Manabu実体験エピソードを配置。
+3. **Section 03 · When Nikko Is Absolutely Worth It** — 行く価値が高いシナリオ（日本史・建築好き、紅葉シーズン、家族旅行で"日本らしさ"を強く感じたい等）。箇条書き+具体的理由。
+4. **Section 04 · When You Might Want to Skip It** — 正直なデメリット（東京から2時間の移動時間、混雑する祝日、予算・時間制約があるケース）。他サイトが書かない逆張り情報でE-E-A-T強化。
+5. **Section 05 · With a Guide vs. Solo: What Changes** — ガイドあり/なしで体験の深さがどう変わるか（英語解説、非公開エリア案内、食事場所の選び方等）。Manabuの500+ tours実績を軸に。CTA: プライベートツアーページへ自然な誘導。
+6. **Section 06 · Planning Your Nikko Day Trip** — 実用情報のサマリー（所要時間・アクセス・おすすめ時期）。ただし**具体的価格・時刻は"Required facts"で検証後に記載**。
+7. **Section 07 · FAQ** — 4-5問。faq-block形式。
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 東京（新宿・浅草）から日光へのアクセス：最寄り路線・所要時間・2026年時点の運賃（東武日光線 vs JR）
+- [ ] 日光東照宮の拝観料（税込・2026年現在）と営業時間・定休日
+- [ ] 輪王寺・二荒山神社の拝観料と営業時間
+- [ ] 日光世界遺産エリア内の共通拝観券の有無と金額
+- [ ] JR Passで日光まで行けるか（東武は対象外のはず——要確認）
+- [ ] 混雑が特にひどい時期・祝日（秋の行楽シーズン等）
+- [ ] 2026年に入って施設情報の変更がないか（公式サイト必須）
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura vs. Hakone vs. Nikko Day Trip](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 3択比較の読者をこちらに誘導（Nikko単独の掘り下げとして）
+- [Nikko Day Trip from Tokyo](/blog/nikko-day-trip-from-tokyo) — アクセス・時刻情報の詳細はこちらへ委譲
+- [Nikko: Guide vs. Solo](/blog/nikko-day-trip-guide-vs-solo) — Section 05「ガイドあり/なし比較」からリンク
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — Section 05のCTA前のサポートリンク
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — Section 04の末尾に「Nikkoと迷っている人はこちらも」として比較リンク
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["nikko-day-trip"]} />`
+
+（Section 05「With a Guide vs. Solo」の末尾と、記事下部フッター付近に配置）
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/blog/` 以下に既存日光写真があれば使用（東照宮、神橋、いろは坂等）
+- **不足分（Wikimedia/Unsplash提案）**: 
+  - 日光東照宮陽明門の全景（秋の紅葉バック）
+  - 神橋（赤い橋）の朝霧カット
+  - 奥日光・中禅寺湖の風景（後半セクション用）
+
+## Risk notes
+
+- **AI Overview ゼロクリック化リスク（medium）**: 「is nikko worth visiting」は評価型クエリだが、AIが"おすすめです"程度の回答を返す可能性あり。対策: Manabu個人の判断軸・体験・「行かない方がいいケース」を充実させ、AI Overviewが代替できない一次情報を前面に出す。
+- **カニバリリスク（low）**: `/blog/nikko-day-trip-from-tokyo`（情報型）と`/blog/nikko-day-trip-guide-vs-solo`（ガイド比較型）との差別化は「評価フェーズ」で明確。ただし Section 06（実用情報）は薄く留め、詳細は既存記事に委譲する。
+- **ファクト変動リスク**: 東武鉄道の運賃・東照宮の拝観料は年次改定あり。Last updated を記事冒頭に明示し、次回レビュー予定を設定。
+- **競合（DR難易度）**: TripAdvisor・Lonely Planet が上位だが、いずれも「情報型」。「ガイドの正直な評価」フォーマットでのニッチ slant は競合が薄い。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `templates/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsNikkoWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValelapenaVisitarNikko.tsx` も作成（hreflang 対応）
+3. `src/AppRoutes.tsx` に import + Route 追加（`/blog/is-nikko-worth-visiting` と `/es/blog/vale-la-pena-visitar-nikko`）
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. `tsc` で型チェック
+7. feature ブランチ作成 + commit

--- a/seo-pipeline/data/daily/2026-06-25.json
+++ b/seo-pipeline/data/daily/2026-06-25.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-25",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Nikko Worth Visiting? A Licensed Guide's Honest Take for 2026
- **slug**: `is-nikko-worth-visiting` (EN), `vale-la-pena-visitar-nikko` (ES)
- **category**: Decision Helpers
- **priority**: high

## なぜこの案か（データ根拠）

- `/blog/nikko-day-trip-from-tokyo` が直近28日で **667表示、0クリック、順位23.8** という異常値 — 検索者の「行く価値あるか?」という評価意図にコンテンツが応えられていない
- "is hakone worth visiting" が直近7日の新規クエリ（6 imp、pos 40.83）に登場 → 同フォーマットの Nikko 版が空白
- Decision Helpers カテゴリ（config weight 30%）で form_submit 直前の意思決定層をカバー
- 既存記事との重複度 low（「行く価値あるか?」評価型 vs「どう行くか」情報型 vs「ガイドvsソロ」比較型で明確に分離）

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → マージして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（3方向のプレースホルダー）に実体験を追記
- [ ] H2 outline が論理的か（7セクション + FAQ）
- [ ] 「行かない方がいいケース」セクションの正直さが競合差別化になっているか
- [ ] Required facts（7項目）を web search で検証してから執筆開始

## ⚠️ 注意事項

今回 `seo-pipeline/data/daily/2026-06-25.json` は GSC/GA4 API 認証エラー（`No module named 'googleapiclient'`）のため実データ取得ができていません。分析は `2026-05-22.json`（最新の実データ）をベースに実施しました。

**対処**: 本番環境で `pip install google-api-python-client google-auth` が必要です。Environment の setup スクリプト or requirements.txt に追加を検討してください。

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-25-is-nikko-worth-visiting.md](seo-pipeline/briefs/2026-06-25-is-nikko-worth-visiting.md)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRpX2JQYUnqmALwhMUzsgL)_