### PR TITLE
brief: 2026-06-26 — Is Kamakura Worth Visiting from Tokyo? A Guide's Honest Take (2026)

### DIFF
--- a/seo-pipeline/briefs/2026-06-26-is-kamakura-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-06-26-is-kamakura-worth-visiting.md
@@ -1,0 +1,112 @@
+---
+date: 2026-06-26
+slug: is-kamakura-worth-visiting
+slug_es: vale-la-pena-visitar-kamakura
+status: pending
+priority: high
+category: Day Trips
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Is Kamakura Worth Visiting from Tokyo? A Guide's Honest Take (2026)
+
+**Spanish Title**: ¿Vale la pena visitar Kamakura desde Tokio? La opinión del guía (2026)
+
+## Why this article (data-driven rationale)
+
+> ⚠️ データ注記: 2026-06-26 の GSC/GA4 fetch が `googleapiclient` モジュール不在でエラー終了。下記数値はすべて最新有効データ **2026-05-22（28日窓）** から引用。fetch エラーは `pip install google-api-python-client` で解消可能。
+
+- **GSC signal (top page)**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` — 表示 **3,292**、クリック **37**、CTR **1.12%**、順位 **6.23**（旅行記事カテゴリでサイト最高パフォーマンス）
+- **GSC signal (判断クエリ)**: 「is kamakura worth visiting」— 表示 **27**、クリック **1**、順位 **3.11**。すでにページ1に表示されているが、当たりの記事が比較ページ止まり。専用記事を用意すればスニペット獲得・クリック大幅改善の余地大
+- **GSC signal (ブランドクエリ)**: 「kamakura」— 表示 **403**、クリック **2**、順位 **4.37**（高インプレッション × 低CTR = 判断コンテンツの不足を示す）
+- **GSC signal (比較クエリ)**: 「kamakura vs hakone」— 表示 **86**、クリック **2**、順位 **6.14**。「hakone or kamakura」— 表示 **74**、クリック **1**、順位 **6.95**
+- **GA4 engagement**: `kamakura-vs-hakone-vs-nikko-day-trip` オーガニックランディング → セッション **47**、エンゲージメント率 **63.8%**、平均滞在 **2,982秒（49分）** ← サイト全記事中最長。Kamakura 判断コンテンツへの読者需要は証明済み
+- **既存記事ギャップ**: `is-hakone-worth-visiting`（承認・公開済、2026-05 brief → PR#85）と同フォーマットの Kamakura 版が不在。"is X worth visiting" クラスターとして対称展開できる。sister article が内部リンクで互いを強化
+- **想定CV影響**: **high** — Kamakura は Manabu のコアツアー商品。「行く価値があるか → 自分に向いているか → ガイド付きの方がいいか」というCV導線の入口として機能。`/blog/kamakura-day-trip-guide-vs-solo` → ツアー予約ページへの内部リンク強化も可能
+
+## Target keyword cluster
+
+- **Primary**: "is kamakura worth visiting"
+- **Secondary**: "is kamakura worth a day trip", "kamakura from tokyo worth it", "kamakura day trip review", "kamakura worth visiting 2026"
+- **Search intent**: commercial investigation（行くかどうかの判断フェーズ）— AI Overview ゼロクリック化リスク低い判断型クエリ
+
+## Differentiation slant (Manabuならでは)
+
+[ここにManabuさんの実体験エピソードを挿入]
+
+1. **「何度 Kamakura に行ったか」の一次証言**: 500+ ツアーのうち Kamakura 案内の件数、そこから蓄積した「リピーターでも楽しめるゲスト vs 一度で満足なゲスト」の判断軸。競合ブログは書けない「行かなくていい人の話」が差別化の核心。
+   - 例：「60代アメリカ人夫婦を案内した時、大仏より報国寺の竹林で泣いた理由」
+   - 例：「Kyoto 経験者 vs 初めての日本でKamakuraがベストな理由」
+
+2. **混雑を避けるガイド視点の知恵**: 大仏・報国寺・銭洗弁財天の「ガイドが選ぶ入場タイミング」（開門直後の○時台 vs 一般観光客が集まる○時以降の差）。ManabuがクライアントをどのルートとタイミングでConductしているかの具体的開示。
+
+3. **「Kamakura か Hakone か」の実践判断**: `is-hakone-worth-visiting` との cross-link を活かし、両方案内した経験から Manabu が引き出す「旅行スタイル別の優先順位」。比較記事を読んだ読者が「自分はどちら向きか」を決める最終判断材料として機能させる。
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): "Is Kamakura Worth Visiting from Tokyo? A Guide's Take (2026)"
+- **Meta description (EN)** (155字以内): "Is Kamakura worth a day trip from Tokyo? Licensed guide Manabu's honest take after 500+ tours—what's worth seeing, what to skip, and who should go."
+- **Title (ES)** (60字以内): "¿Vale la pena visitar Kamakura desde Tokio? (2026)"
+- **Meta description (ES)** (155字以内): "¿Merece la pena Kamakura para una excursión desde Tokio? La opinión honesta del guía Manabu: qué ver, qué evitar y para quién es ideal."
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Short Answer** — "Yes for most, no for some": quick decision box（初回訪日 → 必須、京都訪問済みリピーターは好みによる）。「5秒で分かる」判定チャート
+2. **Section 02 · What Makes Kamakura Different** — 京都・奈良との違いを Manabu 視点で。海×山×古都が1日で体験できる希少性。23区の密度との対比でガイドが感じる「開放感」の価値
+3. **Section 03 · Highlights Worth Your Time** — 大仏（高徳院）、報国寺竹林、銭洗弁財天、若宮大路段葛、由比ガ浜への流れ。Manabu が実際のルートで選ぶ優先順位を開示（時間別最適解）
+4. **Section 04 · What's Overhyped — and What to Skip** — 「SNS映え渋滞」の現実、詰め込みすぎ注意の具体例。Manabu が「ここは時間の無駄」と言える立場で書く正直な評価
+5. **Section 05 · Practical Planning** — 最適所要時間（5h vs 8h の差）、行くべき季節・避ける時期（混雑カレンダー）、主要駅からの所要時間・交通費（要ファクトチェック）
+6. **Section 06 · With a Guide or Solo?** — どのタイプの旅行者にガイドが価値を生むか（初回 vs リピーター、ファミリー vs カップル等）。ManabuのKamaкuraツアーへのソフトCTA
+7. **Section 07 · FAQ** — 4-5問（Is Kamakura better than Nikko? / Can I combine Kamakura and Enoshima in one day? / What's the best time of year for Kamakura? / Is Kamakura kid-friendly? / How crowded is Kamakura on weekends?）
+
+## Required facts (web search before writing)
+
+- [ ] 高徳院（鎌倉大仏）入場料・営業時間・定休日（公式サイト: kotoku-in.jp）
+- [ ] 報国寺（竹の庭）入場料・営業時間
+- [ ] 銭洗弁財天 宇賀福神社 参拝料・営業時間
+- [ ] 東京主要駅→鎌倉駅の所要時間・運賃（新宿：湘南新宿ライン、品川：横須賀線、渋谷：湘南新宿ライン）
+- [ ] 2026年の混雑ピーク時期（桜・GW・紅葉・年末）と推奨訪問時期
+- [ ] 鎌倉観光の入場制限・観光客対策（近年の過剰観光対策の最新情報）
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura vs Hakone vs Nikko](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 他の選択肢との比較。3択で迷っている読者のハブ記事
+- [Kamakura Day Trip from Tokyo](/blog/kamakura-day-trip-from-tokyo) — 実践的なアクセス・計画情報へ誘導
+- [Kamakura: With a Guide vs Going Solo](/blog/kamakura-day-trip-guide-vs-solo) — Section 06 のガイドCTAを強化するサポート記事
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — sister article。「Kamakura or Hakone?」で迷う読者への cross-link（FAQ で自然に誘導）
+- [Best Day Trips from Tokyo](/blog/best-day-trips-from-tokyo) — pillar 記事への上位リンクでクラスター強化
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["kamakura-day-trip"]} />` ← 実際のtour ID は `/src/data/tours` または `AppRoutes.tsx` の `/tours/kamakura-day-trip` を確認して合わせる
+
+## Image candidates
+
+- **Project内（最優先）**: 既存 Kamakura 記事（`/blog/kamakura-day-trip-from-tokyo`、`/blog/kamakura-vs-hakone-vs-nikko-day-trip`）で使用している画像を流用。アイキャッチは大仏or竹林が望ましい
+- **不足分（要確認）**: 報国寺竹林の雰囲気写真、由比ガ浜の海岸線、混雑する小町通りのリアルショット（Wikimedia Commons CC-BY で探す、または Manabu 撮影写真）
+
+## Risk notes
+
+- **AI Overview リスク: LOW** — "is kamakura worth visiting" は評価・判断型クエリ。Manabu の一次体験と個人的推奨を軸にすれば AI Overview の侵食は限定的（価値判断は AI が代替しにくい）
+- **カニバリゼーション: LOW** — 既存3記事（`kamakura-day-trip-from-tokyo` = 実践計画、`kamakura-day-trip-guide-vs-solo` = ガイドvs独立比較、`kamakura-vs-hakone-vs-nikko` = 3択比較）とは検索意図が異なる（「行くべきか否かの価値判断」はカバーされていない）
+- **競合: MEDIUM** — Japan Guide (DR52)、Lonely Planet (DR88)、TimeOut Tokyo (DR82) が上位に存在。ただし「licensed guide's 1st-person honest take」スラントはこれらが書けない差別化。DR20 でも commercial intent × 個人経験 × 内部リンク網が整えば勝機あり
+- **ファクト変動リスク: MEDIUM** — 入場料・営業時間は年次変動あり。記事内 "Last updated: June 2026" 表示 + 公式リンクを必須とする
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsKamakuraWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValelapenaVisitarKamakura.tsx` も作成（hreflang 対応）
+3. `src/AppRoutes.tsx` に import + Route 追加:
+   - `<Route path="/blog/is-kamakura-worth-visiting" element={<IsKamakuraWorthVisiting />} />`
+   - `<Route path="/es/blog/vale-la-pena-visitar-kamakura" element={<EsValelapenaVisitarKamakura />} />`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に 2 URL 追加
+6. `tsc --noEmit` で型チェック（エラーゼロを確認）
+7. feature ブランチ作成 + commit → `/build-article` スキルで実行

--- a/seo-pipeline/data/daily/2026-06-26.json
+++ b/seo-pipeline/data/daily/2026-06-26.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-26",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Kamakura Worth Visiting from Tokyo? A Guide's Honest Take (2026)
- **slug**: `is-kamakura-worth-visiting` (EN), `vale-la-pena-visitar-kamakura` (ES)
- **category**: Day Trips
- **priority**: high

## なぜこの案か（データ根拠）

- `kamakura-vs-hakone-vs-nikko-day-trip` ページが 表示 3,292 / クリック 37 / **平均滞在49分**（サイト最長）→ Kamakura 判断コンテンツへの需要が実証済み
- 「is kamakura worth visiting」クエリで既に順位 3.11（ページ1）だが専用記事なし → 記事化でスニペット獲得
- `is-hakone-worth-visiting` (PR#85) の承認・公開に続く自然な sister article

> ⚠️ 本日の GSC/GA4 fetch は `googleapiclient` モジュール不在でエラー。数値は 2026-05-22 データから引用。`pip install google-api-python-client` で次回から解消。

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → home で merge して記事化へ（`/build-article` スキル）
- [ ] **却下** → PR を Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus 指示を書いて commit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu 独自エピソード（プレースホルダー × 3）に実体験を追記
- [ ] H2 outline（7セクション + FAQ）が論理的か確認
- [ ] Required facts（入場料・営業時間・交通費）を web search で検証
- [ ] tour ID（`kamakura-day-trip`）が正しいか AppRoutes で確認

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-26-is-kamakura-worth-visiting.md](``https://github.com/mkmanabu122003/private-tour-page-new/blob/claude/daily-brief-2026-06-26/seo-pipeline/briefs/2026-06-26-is-kamakura-worth-visiting.md``)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJQE4J5AdTk4kKmiTYJKpb)_