### PR TITLE
brief: 2026-06-27 — Half-Day vs Full-Day Private Tour Tokyo 2026

### DIFF
--- a/seo-pipeline/briefs/2026-06-27-half-day-vs-full-day-private-tour-tokyo.md
+++ b/seo-pipeline/briefs/2026-06-27-half-day-vs-full-day-private-tour-tokyo.md
@@ -1,0 +1,118 @@
+---
+date: 2026-06-27
+slug: half-day-vs-full-day-private-tour-tokyo
+slug_es: medio-dia-vs-dia-completo-tour-privado-tokio
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: low
+ai_overview_risk: low
+---
+
+# Half-Day vs Full-Day Private Tour Tokyo 2026: Which Should You Book?
+
+**Spanish Title**: Tour Privado en Tokio: ¿Medio Día o Día Completo? Guía 2026
+
+## Why this article (data-driven rationale)
+
+- **GSC signal (proxy: 2026-04-24〜05-22)**: 「japan private tour guide cost」直近28日で表示107回、クリック1回、順位9.37 → Decision Helper クラスターへの検索意図が一貫して存在
+- **高エンゲージメントのブリッジギャップ**: `/blog/tokyo-private-tour-guide-cost` は GA4 エンゲージメント率83.3%・平均滞在311秒（全 Decision Helper 記事中最高）。この記事の読者が次に向かう「では何時間予約すれば？」という疑問を解消する記事が完全に存在しない
+- **is-it-worth-hiring cluster の実績**: `/blog/is-it-worth-hiring-a-tour-guide-in-tokyo` は28日間で1,414印象・10クリック・CTR 0.71%。Decision Helper 形式が機能している証拠
+- **既存記事ギャップ**: 8本の Decision Helper 記事（is-it-worth-hiring、group-vs-private、how-to-choose、viator-vs-getyourguide、licensed-vs-unlicensed、what-to-expect、tokyo-private-tour-guide-cost、free-walking-tour-vs-private）があるが、「何時間のツアーを予約するか」という予約直前の最終判断をカバーするものがない
+- **想定CV影響**: high — 「半日か全日か」は予約フォーム入力の1段階前の判断。ここで読者が納得できれば、そのままManabuへの問い合わせに転換しやすい
+
+## Target keyword cluster
+
+- **Primary**: "half day private tour tokyo"
+- **Secondary**: "full day tokyo private tour", "4 hour private tour tokyo", "how long should a tokyo tour be", "private tour tokyo how many hours", "tokyo private guide half day vs full day"
+- **Search intent**: commercial（比較・判断フェーズ → 予約直前）
+
+## Differentiation slant (Manabuならでは)
+
+[ここにManabuさんの実体験エピソードを挿入]
+
+- **[プレースホルダー A — 半日の限界体験]**: 「半日ツアーで詰め込みすぎて反省したエピソードを教えてください。例えば、浅草＋teamLab＋浜離宮を4時間に入れようとして途中で時間切れになった経験など、具体的な失敗談（どのスポット、何分でオーバー、お客さんの反応）があれば。」
+
+- **[プレースホルダー B — 全日だから生まれた瞬間]**: 「全日ツアーでしか生まれなかった『あの時間があったから起きた感動』を1〜2エピソード教えてください。例えば、混雑が引いた夕方の浅草で誰もいない参道を歩けた、昼食をゆっくり一緒に取ったことで信頼関係が深まった、隠れた横丁に立ち寄れた…など。」
+
+- **[プレースホルダー C — 特定の客層への推奨理由]**: 「シニアのお客様、小さなお子様連れ、またはリピーターの旅行者に『半日を強くすすめる』ケースと、逆に『絶対に全日にして』と伝えるケースの、それぞれ実際の例を教えてください（ツアー先・お客様の状況を含めて）。」
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Half-Day vs Full-Day Tokyo Private Tour 2026: Which to Book?`
+- **Meta description (EN)** (155字以内): `Can't decide between a 4-hour or 8-hour Tokyo private tour? Licensed guide Manabu explains what fits in each option — book the one you'll actually love.`
+- **Title (ES)** (60字以内): `Tour Privado Tokio: ¿Medio Día o Día Completo? Guía 2026`
+- **Meta description (ES)** (155字以内): `¿No sabes si reservar un tour privado de medio día o día completo en Tokio? La guía oficial Manabu te explica qué ver en cada opción y cuál elegir.`
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · The Short Answer** — Quick Decision ボックス（「3つの質問に答えるだけ」形式で半日/全日を即判定）。旅行日数・優先度・体力レベルの3軸で結論を出す。記事冒頭に置いてスキムユーザーを逃さない。
+
+2. **Section 02 · What a Half-Day Tokyo Tour Actually Covers** — 4時間でカバーできる現実的な範囲を具体的に提示。Manabuの代表的な半日ルート例（エリア名+各スポットの目安滞在時間）を紹介。「何を諦めることになるか」も正直に書く（これが差別化）。
+
+3. **Section 03 · What a Full-Day Tour Unlocks** — 8時間あることで初めて可能になること：昼食体験、隠れスポット立ち寄り、移動ペースの余裕、混雑を外したタイミングの活用。半日との「体験の質の差」を数値（歩数・訪問スポット数）でも示す。
+
+4. **Section 04 · 6 Factors That Should Decide for You** — 読者自身の状況に当てはめて判断できる軸を提供：①東京滞在日数、②年齢・体力（シニア・子連れへの推奨を明示）、③訪問済みエリアの有無（リピーターは半日でも十分なケースあり）、④予算感、⑤旅行の目的（写真優先 vs 歴史体験優先）、⑥京都・大阪などとの組み合わせ行程かどうか。
+
+5. **Section 05 · Pricing Reality Check (2026)** — 相場感のみ（断定価格はRequired factsへ）。「時間単価は半日の方が高い傾向があるが、全日でしか体験できない価値がある」という判断材料を提供。Viator・GetYourGuide との比較（値段ではなく内容の密度で）。
+
+6. **Section 06 · FAQ** — 4〜5問：「半日ツアー終了後に一人で観光できる？」「2日に分けて半日×2という選択はあり？」「子連れ・シニア連れには半日が向いている？」「雨の日のプランはどう変わる？」「英語に不安がある場合、ガイドなしの半日観光と半日ガイドツアーの差は？」
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] Manabuのツアーページに記載の半日・全日ツアーの時間帯・料金（公式ページを最優先で参照）
+- [ ] Viator「tokyo private tour half day」上位3件の所要時間・料金レンジ（比較基準として記載するため）
+- [ ] GetYourGuide「private tour tokyo full day」上位3件の料金レンジ（同上）
+- [ ] 主要スポットの推奨滞在時間（浅草：最低2時間、teamLab豊洲：2〜3時間 等）— 各施設公式または東京観光財団の情報を確認
+
+## Internal link plan (既存記事への参照)
+
+- [Is It Worth Hiring a Tour Guide in Tokyo?](/blog/is-it-worth-hiring-a-tour-guide-in-tokyo) — 「そもそも雇う価値は？」という前段階の疑問を持つ読者への入口
+- [Tokyo Private Tour Guide Cost](/blog/tokyo-private-tour-guide-cost) — 価格を詳しく知りたい読者への誘導（セクション5で参照）
+- [What to Expect on a Private Tour in Tokyo](/blog/what-to-expect-private-tour-tokyo) — ツアーの流れを具体的に知りたい読者へ
+- [Group vs Private Tour Tokyo](/blog/group-vs-private-tour-tokyo) — ガイド形式の大前提比較として
+- [First-Time in Tokyo with a Local Guide](/blog/first-time-tokyo-local-guide) — 初訪問者向け姉妹記事として結び
+- [How to Choose a Private Tokyo Guide](/blog/how-to-choose-private-tokyo-guide) — 選び方の次ステップとして
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["tokyo-half-day", "tokyo-full-day"]} />` ※ ツアーIDはManabuのツアーページで確認して修正
+
+## Image candidates
+
+- **Project内（最優先）**: `public/` 以下にある浅草・渋谷・Yanaka等でのガイド案内写真。または地図を持ちながら街を歩くツアー写真。
+- **不足分（Wikimedia/Unsplash提案）**: 「tokyo walking tour guide local」「tokyo private tour street」「asakusa guided tour morning」で検索、CC0ライセンス素材。セクション別に2〜3点。
+
+## Risk notes
+
+- **カニバリゼーション（低）**: 既存8本の Decision Helper 記事との意図重複を確認。既存記事は「ガイドを雇うべきか（Yes/No）」「料金はいくらか」「どのプラットフォームを使うか」を扱う。本記事は「何時間予約するか（半日 vs 全日）」に特化しており、判断軸がレイヤー的に異なるため重複度は約20〜30%と判断。
+- **検索ボリューム（未検証）**: "half day private tour tokyo" はGSCに出現していない。ただし Decision Helper クラスターは他記事のCVデータ（form_submit 8件/28日）で有効性が証明されており、クラスター内新記事として比較的安全。
+- **AI Overview リスク（低）**: 「どちらが正しいか」という個人判断型クエリはAI Overviewが画一的な答えを出しにくい。Manabuの体験ベースの判断軸（プレースホルダー3点）が差別化になる。
+- **ファクト変動リスク（中）**: ツアー料金は変動する。価格は「執筆時点の参考値」と明記し、公式ページへのリンクを必ず添付する。
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `src/components/blog/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/HalfDayVsFullDayPrivateTourTokyo.tsx` を作成
+2. `src/pages/es/blog/EsMedioDiaVsDiaCompletoTourPrivadoTokio.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に以下を追加:
+   - `import HalfDayVsFullDayPrivateTourTokyo from "./pages/blog/HalfDayVsFullDayPrivateTourTokyo"`
+   - `import EsMedioDiaVsDiaCompletoTourPrivadoTokio from "./pages/es/blog/EsMedioDiaVsDiaCompletoTourPrivadoTokio"`
+   - `<Route path="/blog/half-day-vs-full-day-private-tour-tokyo" element={<HalfDayVsFullDayPrivateTourTokyo />} />`
+   - `<Route path="/es/blog/medio-dia-vs-dia-completo-tour-privado-tokio" element={<EsMedioDiaVsDiaCompletoTourPrivadoTokio />} />`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加（canonical: `/blog/half-day-vs-full-day-private-tour-tokyo` と `/es/blog/medio-dia-vs-dia-completo-tour-privado-tokio`）
+6. `tsc --noEmit` で型チェック
+7. 本ブランチ `claude/daily-brief-2026-06-27` に commit
+
+---
+
+_Generated by Daily SEO Brief Routine — 2026-06-27_
+_Data source: 2026-05-22 proxy (live fetch failed: credentials not configured in session)_

--- a/seo-pipeline/data/daily/2026-06-27.json
+++ b/seo-pipeline/data/daily/2026-06-27.json
@@ -1,0 +1,95 @@
+{
+  "generated_at": "2026-06-27",
+  "window_days": 28,
+  "_note": "API fetch failed: GOOGLE_APPLICATION_CREDENTIALS_JSON not set in this session. Analysis performed using 2026-05-22 proxy data (most recent available). Re-run fetch_daily.py with credentials to overwrite with live data.",
+  "gsc": {
+    "_proxy_source": "2026-05-22",
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "clicks": 275,
+      "impressions": 101626,
+      "page_count": 154,
+      "query_count": 2556
+    },
+    "top_queries_by_impression": [
+      {"query": "kamakura", "clicks": 2, "impressions": 403, "ctr": 0.4963, "position": 4.37},
+      {"query": "tsukiji outer market opening hours 2026", "clicks": 1, "impressions": 505, "ctr": 0.198, "position": 3.12},
+      {"query": "tsukiji fish market opening hours", "clicks": 2, "impressions": 264, "ctr": 0.7576, "position": 11.36},
+      {"query": "tsukiji market opening hours", "clicks": 1, "impressions": 256, "ctr": 0.3906, "position": 9.72},
+      {"query": "japan private tour guide cost", "clicks": 1, "impressions": 107, "ctr": 0.9346, "position": 9.37},
+      {"query": "japan rail pass 2026 price", "clicks": 1, "impressions": 42, "ctr": 2.381, "position": 4.86},
+      {"query": "kamakura vs hakone", "clicks": 2, "impressions": 86, "ctr": 2.3256, "position": 6.14},
+      {"query": "hakone or nikko", "clicks": 1, "impressions": 45, "ctr": 2.2222, "position": 8.56},
+      {"query": "is tsukiji market open on sunday", "clicks": 1, "impressions": 45, "ctr": 2.2222, "position": 9.42},
+      {"query": "hakone vs nikko", "clicks": 1, "impressions": 48, "ctr": 2.0833, "position": 8.92}
+    ],
+    "top_pages_by_impression": [
+      {"page": "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it", "clicks": 15, "impressions": 38565, "ctr": 0.0389, "position": 8.18},
+      {"page": "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide", "clicks": 92, "impressions": 26845, "ctr": 0.3427, "position": 6.52},
+      {"page": "https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette", "clicks": 1, "impressions": 4498, "ctr": 0.0222, "position": 10.82},
+      {"page": "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip", "clicks": 37, "impressions": 3292, "ctr": 1.1239, "position": 6.23},
+      {"page": "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost", "clicks": 11, "impressions": 2564, "ctr": 0.429, "position": 7.38},
+      {"page": "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu", "clicks": 10, "impressions": 2197, "ctr": 0.4552, "position": 8.1},
+      {"page": "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide", "clicks": 9, "impressions": 1698, "ctr": 0.53, "position": 7.23},
+      {"page": "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "clicks": 10, "impressions": 1414, "ctr": 0.7072, "position": 9.73}
+    ],
+    "new_queries_last7": [
+      {"query": "japan rail pass 14 day ordinary price 2026 official", "clicks": 0, "impressions": 14, "ctr": 0, "position": 7.36},
+      {"query": "japan travel august 2026 yen exchange rates tourism costs jr pass prices 2026", "clicks": 0, "impressions": 8, "ctr": 0, "position": 7.38},
+      {"query": "is hakone worth visiting", "clicks": 0, "impressions": 6, "ctr": 0, "position": 40.83},
+      {"query": "tsukiji outer market opening hours sunday", "clicks": 0, "impressions": 6, "ctr": 0, "position": 10.33},
+      {"query": "nonbei yokocho walking time from shibuya station", "clicks": 0, "impressions": 5, "ctr": 0, "position": 10},
+      {"query": "best places to see mount fuji from tokyo 2026", "clicks": 0, "impressions": 4, "ctr": 0, "position": 5.75},
+      {"query": "early morning breakfast tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 1},
+      {"query": "hire a guide in tokyo", "clicks": 0, "impressions": 2, "ctr": 0, "position": 23}
+    ],
+    "zero_click_opportunities": [
+      {"query": "jr pass price increase 2026", "clicks": 0, "impressions": 1121, "ctr": 0, "position": 5.45},
+      {"query": "japan rail pass prices 2026 official", "clicks": 0, "impressions": 558, "ctr": 0, "position": 7.68},
+      {"query": "japan rail pass current prices 2026", "clicks": 0, "impressions": 531, "ctr": 0, "position": 9.71},
+      {"query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92},
+      {"query": "tsukiji outer market official hours 2026", "clicks": 0, "impressions": 252, "ctr": 0, "position": 3.4}
+    ],
+    "near_page_one_pushup": [
+      {"query": "japan rail pass price 2026", "clicks": 0, "impressions": 400, "ctr": 0, "position": 11.92}
+    ]
+  },
+  "ga4": {
+    "_proxy_source": "2026-05-22",
+    "window": {
+      "from": "2026-04-24",
+      "to": "2026-05-22"
+    },
+    "totals": {
+      "sessions": 749.0,
+      "totalUsers": 623.0,
+      "screenPageViews": 938.0,
+      "engagementRate": 0.3925233644859813,
+      "averageSessionDuration": 306.0799869038718
+    },
+    "events": [
+      {"eventName": "page_view", "eventCount": 938.0, "totalUsers": 623.0},
+      {"eventName": "session_start", "eventCount": 752.0, "totalUsers": 623.0},
+      {"eventName": "user_engagement", "eventCount": 316.0, "totalUsers": 272.0},
+      {"eventName": "tour_page_view", "eventCount": 101.0, "totalUsers": 52.0},
+      {"eventName": "contact_page_view", "eventCount": 32.0, "totalUsers": 27.0},
+      {"eventName": "book_now_click", "eventCount": 20.0, "totalUsers": 16.0},
+      {"eventName": "form_start", "eventCount": 11.0, "totalUsers": 10.0},
+      {"eventName": "form_submit", "eventCount": 8.0, "totalUsers": 8.0}
+    ],
+    "organic_landing_pages": [
+      {"landingPagePlusQueryString": "/blog/tsukiji-market-guide", "sessions": 135.0, "engagementRate": 0.533, "averageSessionDuration": 245.9},
+      {"landingPagePlusQueryString": "/blog/kamakura-vs-hakone-vs-nikko-day-trip", "sessions": 47.0, "engagementRate": 0.638, "averageSessionDuration": 2982.6},
+      {"landingPagePlusQueryString": "/blog/japan-rail-pass-worth-it", "sessions": 17.0, "engagementRate": 0.412, "averageSessionDuration": 166.8},
+      {"landingPagePlusQueryString": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo", "sessions": 14.0, "engagementRate": 0.429, "averageSessionDuration": 124.8},
+      {"landingPagePlusQueryString": "/blog/tokyo-private-tour-guide-cost", "sessions": 12.0, "engagementRate": 0.833, "averageSessionDuration": 311.6},
+      {"landingPagePlusQueryString": "/blog/tsukiji-vs-toyosu", "sessions": 11.0, "engagementRate": 0.545, "averageSessionDuration": 183.9},
+      {"landingPagePlusQueryString": "/blog/hakone-day-trip-guide-vs-solo", "sessions": 8.0, "engagementRate": 0.375, "averageSessionDuration": 166.4},
+      {"landingPagePlusQueryString": "/blog/yanaka-tokyo-walking-route", "sessions": 7.0, "engagementRate": 0.714, "averageSessionDuration": 757.9},
+      {"landingPagePlusQueryString": "/blog/tsukiji-to-ginza-food-walk", "sessions": 2.0, "engagementRate": 1.0, "averageSessionDuration": 806.1}
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Half-Day vs Full-Day Private Tour Tokyo 2026: Which Should You Book?
- **slug**: `half-day-vs-full-day-private-tour-tokyo` (EN), `medio-dia-vs-dia-completo-tour-privado-tokio` (ES)
- **category**: Decision Helpers
- **priority**: high

---

## なぜこの案か

**Decision Helper クラスターの最終ギャップ**: `/blog/tokyo-private-tour-guide-cost` が GA4 エンゲージメント率 83.3%・平均滞在 311 秒（全記事中最高）を記録しており、この記事に来た読者の次の疑問「では何時間予約すればいい？」を解消する記事が存在しない。既存8本の Decision Helper 記事は「雇うべきか・いくらか・どこで予約するか」をカバーするが、**「何時間か」という予約直前の最終判断**がどこにも書かれていない。CV（form_submit）に最も近いタイミングの記事。

**リスク評価**: duplicate_risk=low / competitor_difficulty=low / ai_overview_risk=low

---

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む（`/build-article` で実行）
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → コメントに focus 指示を書いて → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] **プレースホルダー A** — 半日ツアーで詰め込みすぎた実体験（エピソード追記）
- [ ] **プレースホルダー B** — 全日でしか生まれなかった感動の瞬間（エピソード追記）
- [ ] **プレースホルダー C** — シニア・子連れへの半日推奨/全日推奨の具体例（エピソード追記）
- [ ] Required facts（ツアー料金・Viator相場・スポット所要時間）を執筆前に web search で検証
- [ ] H2 outline が論理的か確認
- [ ] Related tour CTA の tourIds をManabuのツアーページで確認・修正

---

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-27-half-day-vs-full-day-private-tour-tokyo.md](seo-pipeline/briefs/2026-06-27-half-day-vs-full-day-private-tour-tokyo.md)

⚠️ **データ注記**: 本日のGSC/GA4 fetch は認証情報（`GOOGLE_APPLICATION_CREDENTIALS_JSON`）が未設定のため失敗。2026-05-22 のプロキシデータで分析。次回 Run 前に Routine の Secrets に JSON を登録してください。

---

🤖 Generated by Daily SEO Brief Routine — 2026-06-27

---
_Generated by [Claude Code](https://claude.ai/code/session_017wZr8qEwe389ECMeDskLZG)_