### PR TITLE
brief: 2026-06-28 — Is Kamakura Worth Visiting in 2026?

### DIFF
--- a/seo-pipeline/briefs/2026-06-28-is-kamakura-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-06-28-is-kamakura-worth-visiting.md
@@ -1,0 +1,123 @@
+---
+date: 2026-06-28
+slug: is-kamakura-worth-visiting
+slug_es: vale-la-pena-visitar-kamakura
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: low
+---
+
+# Is Kamakura Worth Visiting in 2026? A Licensed Guide's Honest Take
+
+**Spanish Title**: ¿Vale la Pena Visitar Kamakura en 2026? La Opinión Honesta de un Guía Certificado
+
+---
+
+> **Data note**: Today's GSC/GA4 fetch (2026-06-28) failed due to missing `googleapiclient` library in this environment. Analysis below is based on the most recent successful fetch: **2026-05-22** (28-day window: 2026-04-24 → 2026-05-22). Install with `pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib` to restore live fetches.
+
+---
+
+## Why this article (data-driven rationale)
+
+- **GSC signal**: 「is kamakura worth visiting」直近28日で 表示 27、クリック 1、順位 3.11 — 専用記事なしで3位台に自然浮上している。専用slug化でクリック取得の余地が大きい
+- **Kamakuraクラスターの驚異的GA4パフォーマンス**: `/blog/kamakura-vs-hakone-vs-nikko-day-trip` は同28日間で 3,292 impr / 37 clicks / CTR 1.12% / pos 6.23。GA4オーガニックで47セッション・エンゲージメント率 63.8%・**平均セッション49分42秒**（サイト最高水準）。Kamakuraコンテンツへの需要は実証済み
+- **既存記事ギャップ**: `/blog/is-hakone-worth-visiting` は存在するが、Kamakura版が欠落。同シリーズ展開で内部リンク補完が自然
+- **想定CV影響**: **high** — 「行く価値があるか」は旅行決断の最上流。ここで読者を掴めばツアー問い合わせへの導線が最短になる
+- **競合状況**: Japan Guide (DR75)、Lonely Planet (DR82) が上位だが、「プライベートガイド視点」「実際に何百組も案内した経験談」は差別化余地あり。AI Overviewリスク低（判断・体験slantのため）
+
+## Target keyword cluster
+
+- **Primary**: "is kamakura worth visiting"
+- **Secondary**: "kamakura day trip worth it", "how long to spend in kamakura", "kamakura or hakone", "kamakura worth it"
+- **Search intent**: commercial investigation（旅行先決定の判断段階）
+
+## Differentiation slant (Manabuならでは)
+
+1. **500回以上のKamakuraガイド経験から語る「本当の混雑」の実態**  
+   [ここにManabuさんの実体験エピソードを挿入 — 例: 週末の高徳院前で外国人グループが長蛇の列に並ぶ様子を目撃し、平日朝9時台との差を数字で語れるか / 大仏前の撮影待ち時間の目安など]
+
+2. **「Kamakura vs 京都」という比較軸——全国通訳案内士の試験で両方の歴史を深く学んだからこそ語れる違い**  
+   [ここにManabuさんの具体的視点を挿入 — 例: 「初めて日本を旅行する方にはKamakuraの方が京都より密度が高い体験になる理由」を歴史的背景と共に解説。試験勉強で得た知識が一般ガイドと差別化するポイント]
+
+3. **「鎌倉で見落とされがちなスポット」——高徳院以外のManabu推薦**  
+   [ここにManabuさんのお気に入りスポットと実体験を挿入 — 例: 銭洗弁財天・英勝寺・報国寺の竹の庭など、ガイドブックに載っていない視点。実際に案内した中で「ここを見せると反応が一番良かった」エピソード]
+
+## Meta tags (SEO)
+
+- **Title (EN)** (54字): `Is Kamakura Worth Visiting in 2026? A Guide's Take`
+- **Meta description (EN)** (138字): `A licensed Tokyo private guide with 500+ tours gives an honest answer: yes, but only if you avoid these timing mistakes. What to see, how long to stay.`
+- **Title (ES)** (56字): `¿Vale la Pena Visitar Kamakura en 2026? Guía Honesta`
+- **Meta description (ES)** (152字): `Un guía privado con más de 500 tours responde sin rodeos: sí, pero solo si evitas estos errores de planificación. Qué ver y cuánto tiempo necesitas.`
+
+## H2 outline (6 sections + FAQ)
+
+1. **Section 01 · The Short Answer** — 一行の結論 + なぜこの記事を読む価値があるかを示す（quick-decision ブロック使用候補）
+2. **Section 02 · What Makes Kamakura Genuinely Special** — 歴史的背景をManabuの試験知識で補足。「日光・京都とどう違うか」の切り口で読者の先入観を更新する
+3. **Section 03 · The Crowd Problem — And How a Guide Solves It** — 週末vs平日、季節別混雑マップ。guide-note-callout でManabuのタイミング tips を差し込む
+4. **Section 04 · How Much Time Do You Actually Need** — 半日 / 1日 / ガイド付きで変わるカバレッジ比較。cost-table候補（時間 × 体験密度）
+5. **Section 05 · Kamakura vs. Hakone vs. Nikko — Which Should You Choose** — 内部リンクハブとして機能。choice-gridブロックで「Kamakura向き」「Hakone向き」を整理
+6. **Section 06 · FAQ** — 4問構成（below）
+
+### FAQ候補
+- Is Kamakura worth visiting for just half a day?
+- What's the best time of year to visit Kamakura?
+- Is Kamakura better than Kyoto for first-time visitors?
+- Can you visit Kamakura without a guide?
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 高徳院（鎌倉大仏）の入場料・営業時間・定休日（2026年最新）
+- [ ] 江ノ電の運行本数・混雑時間帯（週末ピーク時刻）
+- [ ] 東京〜鎌倉の所要時間・運賃（横須賀線直通・乗り継ぎ両パターン）
+- [ ] 鎌倉の主要寺社（報国寺・銭洗弁財天・建長寺）の入場料・拝観時間
+- [ ] 観光人数・シーズンデータ（鎌倉市観光課の最新統計、あれば2025-2026）
+- [ ] IC一日乗車券（江ノ電のりおりくん等）の有無と価格
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura vs Hakone vs Nikko: Which Day Trip is Best?](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 三択比較の詳細はこちら（Section 05から自然リンク）
+- [Kamakura Day Trip from Tokyo: Complete Guide](/blog/kamakura-day-trip-from-tokyo) — アクセス・スケジュールの詳細はこちら（Section 04から）
+- [Private Guide vs Solo in Kamakura](/blog/kamakura-day-trip-guide-vs-solo) — ガイド付き vs 一人旅の詳細比較（Section 03または05から）
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — 比較検討中の読者への自然な誘導（Section 05 choice-gridから）
+- [How to Choose a Private Tokyo Guide](/blog/how-to-choose-private-tokyo-guide) — ガイド選びに進む読者向け（Section 05末尾CTA）
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["kamakura-day-trip", "kamakura-private-tour"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: `/public/images/kamakura*` に既存写真があれば流用（大仏・竹の庭・江ノ電）
+- **不足分（Wikimedia/Unsplash提案）**: 
+  - 高徳院（鎌倉大仏）の正面ショット（混雑比較用に週末・平日2枚あると理想）
+  - 江ノ電の海沿い走行シーン（由比ヶ浜〜稲村ヶ崎区間）
+  - 報国寺の竹の庭（差別化スポット紹介用）
+
+## Risk notes
+
+- **AI Overviewリスク: low** — 「worth visiting（判断）」slantは体験・比較型。純情報型（opening hours等）ではないためzero-click化リスクは低い
+- **カニバリリスク: low** — 既存Kamakura記事（day trip guide、vs solo、vs Hakone）はイテラリー・コスト比較焦点。「行く価値があるか」の意思決定段階は現状カバー薄い
+- **競合難易度: medium** — Japan Guide (DR75) / Lonely Planet (DR82) が上位だが、「ガイド視点」「体験談」の一次情報で差別化可能。ニッチslant必須
+- **ファクト変動リスク: 低〜中** — 入場料・時刻は年次変動あり。Last updated 2026年6月で公開、年次レビュー推奨
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `templates/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsKamakuraWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValelapenaVisitarKamakura.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加:
+   - `<Route path="/blog/is-kamakura-worth-visiting" element={<IsKamakuraWorthVisiting />} />`
+   - `<Route path="/es/blog/vale-la-pena-visitar-kamakura" element={<EsValelapenaVisitarKamakura />} />`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. tsc で型チェック
+7. feature ブランチ `claude/feat-is-kamakura-worth-visiting` 作成 + commit

--- a/seo-pipeline/data/daily/2026-06-28.json
+++ b/seo-pipeline/data/daily/2026-06-28.json
@@ -1,0 +1,10 @@
+{
+  "generated_at": "2026-06-28",
+  "window_days": 28,
+  "gsc": {
+    "error": "No module named 'googleapiclient'"
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'"
+  }
+}


### PR DESCRIPTION
## 概要
本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Kamakura Worth Visiting in 2026? A Licensed Guide's Honest Take
- **slug**: `is-kamakura-worth-visiting` (EN), `vale-la-pena-visitar-kamakura` (ES)
- **category**: Decision Helpers
- **priority**: high

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → mergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（3か所のプレースホルダー）に実体験を追記
- [ ] H2 outline（6セクション + FAQ）が論理的か
- [ ] Required facts（鎌倉大仏入場料・江ノ電時刻・アクセス情報など）を記事執筆前にweb検索で確認
- [ ] competitor_difficulty: medium / ai_overview_risk: low の評価が妥当か

## なぜこの案か

**Kamakuraクラスターの強さが実証済み**:
- `/blog/kamakura-vs-hakone-vs-nikko-day-trip` — 28日で 3,292 impr / 37 clicks / CTR 1.12%
- GA4オーガニック: 47セッション、エンゲージメント率 63.8%、**平均セッション49分42秒**（サイト最高水準）
- "is kamakura worth visiting" が既に pos 3.11 で自然浮上しているが専用記事なし

`/blog/is-hakone-worth-visiting` の好例に倣い、Decision Helper シリーズのKamakura版を投入することで内部リンクネットを強化し、form_submitへの直接寄与を狙います。

## 技術メモ

今日のGSC/GA4フェッチは `googleapiclient` 未インストールのため失敗しました。  
修正: `pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib`  
データは 2026-05-22 の最新成功フェッチを参照しています。

## 詳細
ブリーフ本体: [seo-pipeline/briefs/2026-06-28-is-kamakura-worth-visiting.md](seo-pipeline/briefs/2026-06-28-is-kamakura-worth-visiting.md)

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrUHdfmTt4ms9HFuLdppQz)_