### PR TITLE
brief: 2026-06-29 — Is Kamakura Worth Visiting? A Private Guide's Honest Take (2026)

### DIFF
--- a/seo-pipeline/briefs/2026-06-29-is-kamakura-worth-visiting.md
+++ b/seo-pipeline/briefs/2026-06-29-is-kamakura-worth-visiting.md
@@ -1,0 +1,117 @@
+---
+date: 2026-06-29
+slug: is-kamakura-worth-visiting
+slug_es: vale-la-pena-visitar-kamakura
+status: pending
+priority: high
+category: Decision Helpers
+estimated_word_count: 2200
+fact_check_required: yes
+manabu_experience_needed: yes
+duplicate_risk: low
+competitor_difficulty: medium
+ai_overview_risk: medium
+---
+
+# Is Kamakura Worth Visiting? A Private Guide's Honest Take (2026)
+
+**Spanish Title**: ¿Vale la Pena Visitar Kamakura? Un Guía Privado Responde (2026)
+
+## Why this article (data-driven rationale)
+
+- **GSC signal**: 「is kamakura worth visiting」直近28日（2026-04-24〜05-22）で 表示 27、クリック 1、順位 3.11（→ クリックギャップ大。3位なのにCTR 3.7%止まり。意思決定クエリなのでクリック率が上がれば直接CV貢献）
+- **クラスター実績**: 親記事 `/blog/kamakura-vs-hakone-vs-nikko-day-trip` が同期間 表示 3,292、クリック 37、CTR 1.12%、順位 6.23 — 全日帰り記事中トップパフォーマー。このクラスターへの追加は内部リンク強化に直結
+- **ギャップ**: `/blog/is-hakone-worth-visiting` を追加済みだが Kamakura 版がない。同パターン（"is X worth visiting"）でカバーされていない最大の穴
+- **想定CV影響**: HIGH — 「行く価値があるか」はツアー予約直前フェーズの疑問。Manabu の Kamakura ツアーへの自然な導線
+- **競合状況**: Condé Nast Traveler, Lonely Planet, Japan Guide が「kamakura worth visiting」クエリ上位。ただし体験型・ガイド視点の記事はなく、差別化余地あり。DR的には中程度の戦い
+
+## Target keyword cluster
+
+- **Primary**: "is kamakura worth visiting"
+- **Secondary**: "kamakura worth it", "is kamakura worth a day trip", "kamakura day trip worth it", "what to see in kamakura in one day"
+- **Search intent**: commercial investigation（行くかどうか判断している旅行者）
+
+## Differentiation slant (Manabuならでは)
+
+**[以下はManabuさんの実体験エピソードを挿入する領域です。Claudeは代筆できません]**
+
+1. **「行かなくてよかった」と言ったお客様エピソード** — 例: Kamakura を最初はスキップしようとしていた旅行者が、案内後に「来て本当によかった」と言ったとき/または逆に「期待と違った」と感じたお客様のタイプと、その理由。どんな旅行者には向いて/向かないか、ガイド視点で正直に書く
+
+2. **500+ ツアーの経験から言える「本当の混雑実態」** — 例: 土曜の大仏エリアは何時ごろから混むか、Manabu が実際にお客様を連れていくベストタイミング（季節・時間帯）について。公式情報ではなく、体感データ
+
+3. **政府公認ガイドとして知っている「見た目に騙される穴」** — 例: 鎌倉で観光客が「ここは行かなくていい」と後悔しがちなスポット vs 「地元ガイドだから連れて行ける」穴場スポット。全国通訳案内士として歴史知識も添える
+
+## Meta tags (SEO)
+
+- **Title (EN)** (60字以内): `Is Kamakura Worth Visiting? A Private Guide's Take (2026)` — 58文字
+- **Meta description (EN)** (155字以内): `Crowds, costs, and what you'll actually see—a licensed Tokyo guide who's led 500+ Kamakura tours gives his honest verdict. Is one day enough? Yes, if you do it right.` — 170文字 → 調整要: `Crowds, costs, what you'll really see—a licensed guide answers honestly. Is one day in Kamakura enough in 2026? Yes, if you do it right.` — 138文字 ✓
+- **Title (ES)** (60字以内): `¿Vale la Pena Visitar Kamakura? Guía Privado Responde 2026` — 59文字
+- **Meta description (ES)** (155字以内): `Aglomeraciones, costes y qué verás de verdad. Un guía con licencia oficial que ha dirigido 500+ tours en Kamakura responde sin rodeos en 2026.` — 144文字 ✓
+
+## H2 outline (5-7 sections + FAQ)
+
+1. **Section 01 · Why Kamakura Keeps Topping "Day Trips from Tokyo" Lists** — 鎌倉がなぜ人気なのか客観的に説明（大仏・禅宗寺院・ハイキング・海の組み合わせ）。京都との違いも一言。読者を「検討フェーズ」から引き込む
+
+2. **Section 02 · Who Will Love Kamakura (and Who Might Regret Going)** — Decision Helper の核心。「こんな旅行者には絶対おすすめ」「こんな旅行者には向かない」を具体的に箇条書き。ファミリー/カップル/歴史好き/寺院疲れ/体力別に分類。Manabuエピソード挿入ゾーン
+
+3. **Section 03 · The Great Buddha and What Nobody Tells You First-Timers** — 高徳院（大仏）の実体験インサイト。単なる観光情報ではなく、「混む時間帯」「中に入る価値があるか」「周辺の見逃しポイント」をガイド視点で。Manabuエピソード挿入ゾーン
+
+4. **Section 04 · What One Full Day in Kamakura Actually Looks Like** — リアルなタイムライン例。鎌倉駅からの実際の動線、移動時間、食事スポット。"Instagramで見た鎌倉"と"実際"のギャップも正直に書く。Required facts からファクトチェック後に詳細化
+
+5. **Section 05 · Is Kamakura Worth the Effort With a Private Guide?** — 自力 vs ガイドの選択肢を比較。Manabu の Kamakura ツアーへの自然なCTA。「一人で行けるか?」という読者の疑問に正直に答えつつ、ガイドの付加価値を体験ベースで説明
+
+6. **Section 06 · FAQ** — 4-5問:
+   - Is one day enough in Kamakura?
+   - Is Kamakura better than Kyoto for a day trip from Tokyo?
+   - What's the best time of year to visit Kamakura?
+   - Is Kamakura kid-friendly?
+   - Can I combine Kamakura with Enoshima in one day?
+
+## Required facts (web search before writing)
+
+これらは記事執筆前に web search で必ず検証：
+
+- [ ] 高徳院（大仏）: 入場料（大人・子供）、開門時間・閉門時間、定休日（2026年現在）
+- [ ] 鎌倉〜東京の所要時間・料金: 東京駅から横須賀線、新宿から湘南新宿ライン、それぞれ所要時間と運賃（2026年現在）
+- [ ] 鶴岡八幡宮: 参拝無料か、特定エリアの入場料（宝物殿等）、開館時間
+- [ ] 建長寺・円覚寺: 入場料・開門時間（2026年現在）
+- [ ] 主要観光スポット間の移動: 鎌倉駅〜大仏、駅〜鶴岡八幡宮の徒歩・バス所要時間
+- [ ] 季節ベストシーズン: 紫陽花（6-7月）、紅葉（11-12月）の例年ピーク時期
+
+## Internal link plan (既存記事への参照)
+
+- [Kamakura vs Hakone vs Nikko: Which Day Trip?](/blog/kamakura-vs-hakone-vs-nikko-day-trip) — 三択比較の最上位記事から/へ双方向リンク
+- [Kamakura Day Trip from Tokyo: Complete Guide](/blog/kamakura-day-trip-from-tokyo) — ロジスティクス詳細へ誘導
+- [Is a Private Guide Worth It for Kamakura?](/blog/kamakura-day-trip-guide-vs-solo) — ガイドの意思決定へ自然に続く
+- [Best Day Trips from Tokyo](/blog/best-day-trips-from-tokyo) — ピラーページへの内部リンク
+- [Is Hakone Worth Visiting?](/blog/is-hakone-worth-visiting) — 同フォーマットの記事との横断比較を促す
+
+## Related tour CTA
+
+`<RelatedTourCards tourIds={["kamakura-day-trip"]} />`
+
+## Image candidates
+
+- **Project内（最優先）**: `public/images/kamakura/` 以下（大仏・小町通り・鶴岡八幡宮の既存アセットがあれば優先使用）
+- **不足分（Wikimedia/Unsplash提案）**: 高徳院（大仏）全景（混雑時と空いている時の対比）、竹林の小径（報国寺）、江ノ電と鎌倉の街並み
+
+## Risk notes
+
+- **カニバリゼーションリスク（低）**: `kamakura-day-trip-guide-vs-solo`（"should I hire a guide"）と `kamakura-day-trip-from-tokyo`（ロジスティクス）は intent が異なる。本記事は"go or skip"の意思決定フェーズ
+- **AI Overview ゼロクリック化リスク（中）**: "is kamakura worth visiting" は情報型に見えるが、主観的判断・体験ベースの回答が必要なため AI Overview に吸収されにくい。Manabu の一人称視点を強く出すことでリスク軽減
+- **競合過密（中）**: Lonely Planet, Japan Guide, Condé Nast Traveler が上位。ただし全て汎用ライター記事。ガイド実体験の差別化で勝負
+- **ファクト変動リスク（低〜中）**: 入場料・交通費は年次変動。"Last updated: June 2026" 表記必須。数字は Required facts でファクトチェック後に記載
+
+## Build instructions for Claude Code
+
+承認後、以下を実行する：
+
+1. `templates/BlogArticleTemplate.tsx` をコピーして `src/pages/blog/IsKamakuraWorthVisiting.tsx` を作成
+2. `src/pages/es/blog/EsValelapenaVisitarKamakura.tsx` も作成（hreflang対応）
+3. `src/AppRoutes.tsx` に import + Route 追加:
+   - `<Route path="/blog/is-kamakura-worth-visiting" element={<IsKamakuraWorthVisiting />} />`
+   - `<Route path="/es/blog/vale-la-pena-visitar-kamakura" element={<EsValelapenaVisitarKamakura />} />`
+4. `src/pages/blog/BlogIndex.tsx` に entry 追加
+5. `public/sitemap.xml` に2 URL 追加
+6. tsc で型チェック
+7. feature ブランチ作成 + commit（`/build-article` skill を使用）

--- a/seo-pipeline/data/daily/2026-06-29.json
+++ b/seo-pipeline/data/daily/2026-06-29.json
@@ -1,0 +1,18 @@
+{
+  "generated_at": "2026-06-29",
+  "window_days": 28,
+  "fetch_status": "api_error",
+  "fetch_error": "GOOGLE_APPLICATION_CREDENTIALS_JSON not set; google-api-python-client not installed. Analysis performed using last valid dataset (2026-05-22) as fallback.",
+  "fallback_data_date": "2026-05-22",
+  "gsc": {
+    "error": "No module named 'googleapiclient'",
+    "note": "Using 2026-05-22 data for brief generation. Re-run after setting GOOGLE_APPLICATION_CREDENTIALS_JSON and installing google-api-python-client."
+  },
+  "ga4": {
+    "error": "No module named 'googleapiclient'",
+    "note": "Using 2026-05-22 data for brief generation."
+  },
+  "brief_generated": true,
+  "brief_slug": "is-kamakura-worth-visiting",
+  "brief_rationale": "Decision Helper category (weight 30). 'is kamakura worth visiting' query at pos 3.11 with 27 impressions in 28-day window — clear decision-stage gap not covered by existing kamakura-day-trip-guide-vs-solo or kamakura-day-trip-from-tokyo articles. Kamakura cluster (3,292 impressions, 1.12% CTR) is our strongest day-trip performer. Same 'is X worth visiting' pattern as recently-added is-hakone-worth-visiting."
+}


### PR DESCRIPTION
## 概要
本日の Daily SEO Routine が生成したブリーフです。

**最優先案**: Is Kamakura Worth Visiting? A Private Guide's Honest Take (2026)
- **slug**: `is-kamakura-worth-visiting` (EN), `vale-la-pena-visitar-kamakura` (ES)
- **category**: Decision Helpers
- **priority**: high

## チェックリスト（Manabu さん向け）

朝の判断：
- [ ] **採用** → このPRを Ready for review に変更 → 家でmergeして記事化に進む
- [ ] **却下** → PRを Close + ブランチ削除
- [ ] **要再生成** → `seo-pipeline/regenerate.md` に focus指示を書いてcommit → Routine "Regenerate Brief" を Run now

採用時のチェック：
- [ ] Manabu独自エピソード（プレースホルダー）に実体験を追記
- [ ] H2 outlineが論理的か
- [ ] competitor_difficulty, ai_overview_risk が妥当か
- [ ] Required facts のチェックリストが網羅的か

## 詳細

ブリーフ本体: [seo-pipeline/briefs/2026-06-29-is-kamakura-worth-visiting.md](seo-pipeline/briefs/2026-06-29-is-kamakura-worth-visiting.md)

### なぜこの案か

- `is kamakura worth visiting` クエリ（直近28日: 表示27、クリック1、**順位 3.11**）— 3位なのにクリックを取れていない意思決定クエリ。クリック率改善でCV直結
- 鎌倉クラスター（`kamakura-vs-hakone-vs-nikko-day-trip`）は表示3,292・CTR 1.12%と全日帰り記事トップ。クラスター補強でさらに押し上げ可能
- `is-hakone-worth-visiting` と同パターン — Kamakura版が唯一の空白
- ガードレール: avoidキーワード非該当 ✓ カニバリ低 ✓ Manabuプレースホルダー含む ✓

### ⚠️ データ取得エラーについて

本日（2026-06-29）のGSC/GA4データ取得に失敗しました（`GOOGLE_APPLICATION_CREDENTIALS_JSON` 未設定 / `google-api-python-client` 未インストール）。直近の有効データ（2026-05-22）を使ってブリーフ生成を実施しています。

修正方法: Routine の Environment settings に `GOOGLE_APPLICATION_CREDENTIALS_JSON` シークレットを設定してください。

---
🤖 Generated by Daily SEO Brief Routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8cRGkSZvYrs8qQoLYBS6V)_