### PR TITLE
Fix: broken thumbnail paths on blog index (4 images)

### DIFF
--- a/src/pages/blog/BlogIndex.tsx
+++ b/src/pages/blog/BlogIndex.tsx
@@ -525,7 +525,7 @@ const blogPosts: BlogPost[] = [
     date: "May 22, 2026",
     author: "Manabu, Licensed Tour Guide",
     category: "Day Trips from Tokyo",
-    image: "/images/blog/hakone-lake-ashi-fuji.webp",
+    image: "/images/tours/hakone-lake-ashi-fuji.webp",
   },
   {
     slug: "kawaguchiko-vs-hakone-for-mt-fuji",
@@ -535,7 +535,7 @@ const blogPosts: BlogPost[] = [
     date: "May 22, 2026",
     author: "Manabu, Licensed Tour Guide",
     category: "Day Trips from Tokyo",
-    image: "/images/blog/hakone-lake-ashi-fuji.webp",
+    image: "/images/tours/hakone-lake-ashi-fuji.webp",
   },
   {
     slug: "enoshima-day-trip-from-tokyo",
@@ -545,7 +545,7 @@ const blogPosts: BlogPost[] = [
     date: "May 22, 2026",
     author: "Manabu, Licensed Tour Guide",
     category: "Day Trips from Tokyo",
-    image: "/images/blog/kamakura-great-buddha.webp",
+    image: "/images/tours/kamakura-great-buddha.webp",
   },
   {
     slug: "group-vs-private-tour-tokyo",
@@ -595,7 +595,7 @@ const blogPosts: BlogPost[] = [
     date: "May 22, 2026",
     author: "Manabu, Licensed Tour Guide",
     category: "Plan Your Trip",
-    image: "/images/blog/imperial-palace-gardens.webp",
+    image: "/images/tours/imperial-palace-gardens.webp",
   },
   {
     slug: "english-friendly-tokyo-tips",
@@ -605,7 +605,7 @@ const blogPosts: BlogPost[] = [
     date: "May 22, 2026",
     author: "Manabu, Licensed Tour Guide",
     category: "Plan Your Trip",
-    image: "/images/blog/tokyo-night-tour-hero.webp",
+    image: "/images/tours/tokyo-night-tour-hero.webp",
   },
   {
     slug: "rainy-day-tokyo",
@@ -615,7 +615,7 @@ const blogPosts: BlogPost[] = [
     date: "May 22, 2026",
     author: "Manabu, Licensed Tour Guide",
     category: "Plan Your Trip",
-    image: "/images/blog/tokyo-night-tour-hero.webp",
+    image: "/images/tours/tokyo-night-tour-hero.webp",
   },
   // 2026-05-23 batch (from daily brief Routine)
   {


### PR DESCRIPTION
## Summary

Blog一覧ページで複数記事のサムネイルが表示されていなかった問題を修正。

6つの blogPosts エントリが `/images/blog/<name>.webp` を参照していたが、実ファイルは `/images/tours/` 配下にあり404になっていた。既存の tours/ パスに修正（全ファイル実在確認済み）。

## 修正した画像

| slug | before | after |
|---|---|---|
| hakone-vs-nikko-day-trip | /images/blog/hakone-lake-ashi-fuji.webp | /images/tours/... |
| private-mount-fuji-tour-2026 | /images/blog/hakone-lake-ashi-fuji.webp | /images/tours/... |
| (kamakura) | /images/blog/kamakura-great-buddha.webp | /images/tours/... |
| (imperial palace) | /images/blog/imperial-palace-gardens.webp | /images/tours/... |
| best-tokyo-night-tour-2026 (x2) | /images/blog/tokyo-night-tour-hero.webp | /images/tours/... |

## Notes

- 既存の本番バグ。Tier 1 記事PR（#129/#130/#131）とは独立。
- ES一覧（EsBlogIndex）は欠落なしを確認済み。

🤖 Generated with Claude Code