### PR TITLE
fix(conversion): 診断ツールのツアー導線復旧 + 情報系→意思決定系の内部リンク

### DIFF
--- a/docs/analytics/raw/2026-07-28_28d_ga4_channels.json
+++ b/docs/analytics/raw/2026-07-28_28d_ga4_channels.json
@@ -1,0 +1,137 @@
+{
+  "dimensionHeaders": [
+    {
+      "name": "sessionDefaultChannelGroup"
+    }
+  ],
+  "metricHeaders": [
+    {
+      "name": "sessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "engagedSessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "conversions",
+      "type": "TYPE_FLOAT"
+    }
+  ],
+  "rows": [
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1083"
+        },
+        {
+          "value": "552"
+        },
+        {
+          "value": "182"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "386"
+        },
+        {
+          "value": "86"
+        },
+        {
+          "value": "104"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "47"
+        },
+        {
+          "value": "26"
+        },
+        {
+          "value": "44"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "12"
+        },
+        {
+          "value": "6"
+        },
+        {
+          "value": "4"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Unassigned"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "8"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "6"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Social"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    }
+  ],
+  "rowCount": 6,
+  "metadata": {
+    "currencyCode": "JPY",
+    "timeZone": "Asia/Tokyo"
+  },
+  "kind": "analyticsData#runReport"
+}

--- a/docs/analytics/raw/2026-07-28_28d_ga4_country.json
+++ b/docs/analytics/raw/2026-07-28_28d_ga4_country.json
@@ -1,0 +1,389 @@
+{
+  "dimensionHeaders": [
+    {
+      "name": "country"
+    }
+  ],
+  "metricHeaders": [
+    {
+      "name": "sessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "activeUsers",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "conversions",
+      "type": "TYPE_FLOAT"
+    }
+  ],
+  "rows": [
+    {
+      "dimensionValues": [
+        {
+          "value": "Japan"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "326"
+        },
+        {
+          "value": "224"
+        },
+        {
+          "value": "68"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "United States"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "323"
+        },
+        {
+          "value": "236"
+        },
+        {
+          "value": "48"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Spain"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "196"
+        },
+        {
+          "value": "131"
+        },
+        {
+          "value": "59"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Singapore"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "159"
+        },
+        {
+          "value": "147"
+        },
+        {
+          "value": "16"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "United Kingdom"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "77"
+        },
+        {
+          "value": "41"
+        },
+        {
+          "value": "7"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Australia"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "55"
+        },
+        {
+          "value": "39"
+        },
+        {
+          "value": "2"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Canada"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "32"
+        },
+        {
+          "value": "31"
+        },
+        {
+          "value": "5"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Mexico"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "32"
+        },
+        {
+          "value": "27"
+        },
+        {
+          "value": "6"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Hong Kong"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "25"
+        },
+        {
+          "value": "18"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "China"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "21"
+        },
+        {
+          "value": "21"
+        },
+        {
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Netherlands"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "21"
+        },
+        {
+          "value": "16"
+        },
+        {
+          "value": "24"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Brazil"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "18"
+        },
+        {
+          "value": "14"
+        },
+        {
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Denmark"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "18"
+        },
+        {
+          "value": "13"
+        },
+        {
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "India"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "18"
+        },
+        {
+          "value": "16"
+        },
+        {
+          "value": "2"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Philippines"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "16"
+        },
+        {
+          "value": "12"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Malaysia"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "14"
+        },
+        {
+          "value": "11"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Germany"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "12"
+        },
+        {
+          "value": "11"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "France"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "11"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Indonesia"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "11"
+        },
+        {
+          "value": "10"
+        },
+        {
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Argentina"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "1"
+        }
+      ]
+    }
+  ],
+  "rowCount": 76,
+  "metadata": {
+    "currencyCode": "JPY",
+    "timeZone": "Asia/Tokyo"
+  },
+  "kind": "analyticsData#runReport"
+}

--- a/docs/analytics/raw/2026-07-28_28d_ga4_events.json
+++ b/docs/analytics/raw/2026-07-28_28d_ga4_events.json
@@ -1,0 +1,280 @@
+{
+  "dimensionHeaders": [
+    {
+      "name": "eventName"
+    }
+  ],
+  "metricHeaders": [
+    {
+      "name": "eventCount",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "conversions",
+      "type": "TYPE_FLOAT"
+    }
+  ],
+  "rows": [
+    {
+      "dimensionValues": [
+        {
+          "value": "page_view"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2089"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "session_start"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1536"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "first_visit"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1145"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "user_engagement"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "685"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "scroll"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "229"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "tour_page_view"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "205"
+        },
+        {
+          "value": "205"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "contact_page_view"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "54"
+        },
+        {
+          "value": "54"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "blog_to_tour_click"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "50"
+        },
+        {
+          "value": "50"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "diagnostic_answer"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "50"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "click"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "26"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "form_start"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "23"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "diagnostic_start"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "18"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "book_now_click"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "16"
+        },
+        {
+          "value": "16"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "diagnostic_complete"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "16"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "form_submit"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "15"
+        },
+        {
+          "value": "15"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "diagnostic_to_contact"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "diagnostic_to_tour"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    }
+  ],
+  "rowCount": 17,
+  "metadata": {
+    "currencyCode": "JPY",
+    "timeZone": "Asia/Tokyo"
+  },
+  "kind": "analyticsData#runReport"
+}

--- a/docs/analytics/raw/2026-07-28_28d_ga4_landing.json
+++ b/docs/analytics/raw/2026-07-28_28d_ga4_landing.json
@@ -1,0 +1,663 @@
+{
+  "dimensionHeaders": [
+    {
+      "name": "landingPage"
+    }
+  ],
+  "metricHeaders": [
+    {
+      "name": "sessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "engagedSessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "conversions",
+      "type": "TYPE_FLOAT"
+    },
+    {
+      "name": "averageSessionDuration",
+      "type": "TYPE_SECONDS"
+    }
+  ],
+  "rows": [
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/tsukiji-market-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "336"
+        },
+        {
+          "value": "176"
+        },
+        {
+          "value": "20"
+        },
+        {
+          "value": "203.87827970238092"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "(not set)"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "116"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "1.2612817155172416"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "96"
+        },
+        {
+          "value": "34"
+        },
+        {
+          "value": "39"
+        },
+        {
+          "value": "172.17787955208334"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/kamakura-vs-hakone-vs-nikko-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "78"
+        },
+        {
+          "value": "41"
+        },
+        {
+          "value": "11"
+        },
+        {
+          "value": "227.89338729487179"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/senso-ji-most-visited-temple"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "67"
+        },
+        {
+          "value": "33"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "443.34114905970148"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/japan-rail-pass-worth-it"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "62"
+        },
+        {
+          "value": "32"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "126.69668685483872"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/comparativa-excursiones"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "58"
+        },
+        {
+          "value": "36"
+        },
+        {
+          "value": "37"
+        },
+        {
+          "value": "501.32193127586208"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/licensed-vs-unlicensed-tour-guides-japan"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "54"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "28.346122370370367"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/guia-tsukiji"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "46"
+        },
+        {
+          "value": "21"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "165.37381397826087"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/tokyo-private-tour-guide-cost"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "42"
+        },
+        {
+          "value": "25"
+        },
+        {
+          "value": "20"
+        },
+        {
+          "value": "209.03591959523808"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/monte-fuji-se-ve-desde-tokio"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "33"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "60.308716818181814"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/tsukiji-vs-toyosu"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "28"
+        },
+        {
+          "value": "11"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "299.1201475357143"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "25"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "6"
+        },
+        {
+          "value": "72.85650444"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/yanaka-tokyo-walking-route"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "24"
+        },
+        {
+          "value": "17"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "280.7949435"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/etiqueta-templos-santuarios"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "18"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "166.62647105555556"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/japan-temple-shrine-etiquette"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "17"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "250.65910517647058"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "17"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "31"
+        },
+        {
+          "value": "328.24050264705886"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/asakusa-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "16"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "251.35591887500001"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/shibuya-harajuku-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "16"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "118.219221625"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/nikko-con-guia-vs-solo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "16"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "218.7429375"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/yokohama-day-trip-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "14"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "307.38169135714281"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/hakone-day-trip-guide-vs-solo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "13"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "5"
+        },
+        {
+          "value": "173.82685292307693"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/old-tokyo-shitamachi"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "12"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "266.98291341666669"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/propinas-en-japon"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "12"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "638.30960183333332"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/tipping-in-japan"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "11"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "200.34934381818178"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/vegetarian-food-tour-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "10"
+        },
+        {
+          "value": "5"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "130.8338605"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/contact"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "10"
+        },
+        {
+          "value": "10"
+        },
+        {
+          "value": "70"
+        },
+        {
+          "value": "112.0888103"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/asakusa-tokio-guia"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "10"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "278.41383329999996"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/comida-callejera-tokio"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "10"
+        },
+        {
+          "value": "5"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "1046.7036342"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/yanaka-tokio-itinerario"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "10"
+        },
+        {
+          "value": "5"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "470.0896627"
+        }
+      ]
+    }
+  ],
+  "rowCount": 112,
+  "metadata": {
+    "currencyCode": "JPY",
+    "timeZone": "Asia/Tokyo"
+  },
+  "kind": "analyticsData#runReport"
+}

--- a/docs/analytics/raw/2026-07-28_28d_ga4_landing_x_channel.json
+++ b/docs/analytics/raw/2026-07-28_28d_ga4_landing_x_channel.json
@@ -1,0 +1,2436 @@
+{
+  "dimensionHeaders": [
+    {
+      "name": "sessionDefaultChannelGroup"
+    },
+    {
+      "name": "landingPage"
+    }
+  ],
+  "metricHeaders": [
+    {
+      "name": "sessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "engagedSessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "conversions",
+      "type": "TYPE_FLOAT"
+    },
+    {
+      "name": "averageSessionDuration",
+      "type": "TYPE_SECONDS"
+    }
+  ],
+  "rows": [
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/tsukiji-market-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "290"
+        },
+        {
+          "value": "169"
+        },
+        {
+          "value": "20"
+        },
+        {
+          "value": "216.69462484827588"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "(not set)"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "99"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "1.4778654444444446"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/kamakura-vs-hakone-vs-nikko-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "69"
+        },
+        {
+          "value": "38"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "230.01167668115943"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "61"
+        },
+        {
+          "value": "10"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "122.31241186885246"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/comparativa-excursiones"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "53"
+        },
+        {
+          "value": "34"
+        },
+        {
+          "value": "33"
+        },
+        {
+          "value": "480.15443532075471"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/senso-ji-most-visited-temple"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "47"
+        },
+        {
+          "value": "31"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "614.82836087234045"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/tsukiji-market-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "44"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "128.6741085"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/licensed-vs-unlicensed-tour-guides-japan"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "44"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "34.281663431818181"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/guia-tsukiji"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "44"
+        },
+        {
+          "value": "21"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "172.89080552272728"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/japan-rail-pass-worth-it"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "35"
+        },
+        {
+          "value": "22"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "149.17996477142859"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/monte-fuji-se-ve-desde-tokio"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "31"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "64.199601774193553"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "23"
+        },
+        {
+          "value": "16"
+        },
+        {
+          "value": "24"
+        },
+        {
+          "value": "327.39756408695655"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/japan-rail-pass-worth-it"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "22"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "110.16376968181818"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/tsukiji-vs-toyosu"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "21"
+        },
+        {
+          "value": "10"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "394.22647661904756"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/senso-ji-most-visited-temple"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "20"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "40.3462013"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/tokyo-private-tour-guide-cost"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "20"
+        },
+        {
+          "value": "15"
+        },
+        {
+          "value": "10"
+        },
+        {
+          "value": "239.08313145000002"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/yanaka-tokyo-walking-route"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "20"
+        },
+        {
+          "value": "15"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "259.31318815000003"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "19"
+        },
+        {
+          "value": "6"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "86.630143473684214"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/tokyo-private-tour-guide-cost"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "16"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "32.8169318125"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/japan-temple-shrine-etiquette"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "15"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "284.0803192"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/etiqueta-templos-santuarios"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "15"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "199.95176526666668"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/nikko-con-guia-vs-solo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "15"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "233.32580000000002"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/shibuya-harajuku-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "14"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "134.98908192857144"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/asakusa-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "12"
+        },
+        {
+          "value": "6"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "333.3153855"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/hakone-day-trip-guide-vs-solo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "12"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "5"
+        },
+        {
+          "value": "188.312424"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/old-tokyo-shitamachi"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "11"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "291.01643854545455"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/propinas-en-japon"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "11"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "696.33774745454548"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/vegetarian-food-tour-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "10"
+        },
+        {
+          "value": "5"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "130.8338605"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "(not set)"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/kamakura-vs-hakone-vs-nikko-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "211.65316866666666"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/licensed-vs-unlicensed-tour-guides-japan"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "2.4774907777777777"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/yokohama-day-trip-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "295.67120611111113"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/yanaka-tokio-itinerario"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "5"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "522.32184744444442"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "8"
+        },
+        {
+          "value": "6"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "135.143597375"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/contact"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "8"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "66"
+        },
+        {
+          "value": "88.989247375"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/es/blog"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "8"
+        },
+        {
+          "value": "6"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "946.292747625"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/nikko-day-trip-guide-vs-solo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "8"
+        },
+        {
+          "value": "6"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "255.32867975"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/comida-callejera-tokio"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "8"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "326.115716875"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/es"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "7"
+        },
+        {
+          "value": "6"
+        },
+        {
+          "value": "15"
+        },
+        {
+          "value": "342.4045565714286"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/tsukiji-vs-toyosu"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "7"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "13.801160285714285"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/where-to-stay-in-tokyo-area-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "7"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "1.2094991428571429"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/es"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "7"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0.70693657142857147"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/teamlab-planets-vs-borderless"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "6"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "2.6892413333333334"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/nikko-day-trip-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "6"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "102.87478166666666"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/tipping-in-japan"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "6"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "224.06130533333331"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/tokyo-3-day-itinerary"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "6"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "119.608702"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/asakusa-tokio-guia"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "6"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "464.0230555"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "5"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/tipping-in-japan"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "5"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "171.89499"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/yokohama-day-trip-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "5"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "328.46056480000004"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/es/blog/comparativa-excursiones"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "5"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "725.6973884"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/onsen-day-trips-beyond-hakone"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "5"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "51.9675378"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/tokyo-hidden-gems"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "5"
+        },
+        {
+          "value": "5"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "226.4831368"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/tokyo-on-a-budget"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "5"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "353.6164754"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/tours/hakone-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "5"
+        },
+        {
+          "value": "5"
+        },
+        {
+          "value": "12"
+        },
+        {
+          "value": "318.63077"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/blog/private-mount-fuji-tour-2026"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "6"
+        },
+        {
+          "value": "277.7235795"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/asakusa-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "5.477519"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/harajuku-vs-shibuya-vs-shinjuku"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/imperial-palace-tokyo-tour-2026"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "80.83017325"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/mount-fuji-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/shinjuku-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/tokyo-cherry-blossom-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "3.52394125"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/toyosu-vs-tsukiji-outer"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/es/blog/asakusa-tokio-guia"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/es/contact"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "10.06924075"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/kawagoe-day-trip-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "97.92304225"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/kawaguchiko-vs-hakone-for-mt-fuji"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "160.20415725"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/tours/kamakura-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "0.0012285"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Referral"
+        },
+        {
+          "value": "(not set)"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/blog/japan-rail-pass-worth-it"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "56.086065666666663"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/blog/onsen-day-trips-beyond-hakone"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/blog/tokyo-private-tour-guide-cost"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "637.60275833333333"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/kawaguchiko-vs-hakone-for-mt-fuji"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "9.592348"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/yanaka-tokyo-walking-route"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "468.08266033333331"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/es/blog/etiqueta-templos-santuarios"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/es/blog/tour-palacio-imperial-tokio-2026"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/tours"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/best-day-trips-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "537.70525966666662"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/harajuku-vs-shibuya-vs-shinjuku"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "70.328355"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/blog/toyosu-vs-tsukiji-outer"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "115.76556766666666"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "16"
+        },
+        {
+          "value": "1059.436031"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/cuanto-cuesta-guia-privado-tokio"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "14.497909"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/itinerario-tokio-5-dias"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "858.79761966666672"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/que-comer-en-japon"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/es/blog/tour-gastronomico-tokio"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "68.911466666666669"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Organic Search"
+        },
+        {
+          "value": "/tours/nikko-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "7.1106056666666673"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Referral"
+        },
+        {
+          "value": "/"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "152.24218666666667"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Referral"
+        },
+        {
+          "value": "/blog/tokyo-private-tour-guide-cost"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "519.98893666666663"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "(not set)"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/blog/ginza-to-tsukiji-walking-route"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/blog/tokyo-itinerary-5-days"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/blog/toyosu-vs-tsukiji-outer"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "19.8210075"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/blog/tsukiji-market-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "AI Assistant"
+        },
+        {
+          "value": "/es/tours/nikko-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "151.076376"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/dHN1a2lqaS"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "24.1306485"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/japan-temple-shrine-etiquette"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/kawagoe-day-trip-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "2.2110475"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/nikko-day-trip-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "4.0788655"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/shibuya-harajuku-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0.8301995"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "Direct"
+        },
+        {
+          "value": "/blog/tokyo-3-day-itinerary"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    }
+  ],
+  "rowCount": 200,
+  "metadata": {
+    "currencyCode": "JPY",
+    "timeZone": "Asia/Tokyo"
+  },
+  "kind": "analyticsData#runReport"
+}

--- a/docs/analytics/raw/2026-07-28_28d_ga4_pages.json
+++ b/docs/analytics/raw/2026-07-28_28d_ga4_pages.json
@@ -1,0 +1,929 @@
+{
+  "dimensionHeaders": [
+    {
+      "name": "pagePath"
+    }
+  ],
+  "metricHeaders": [
+    {
+      "name": "screenPageViews",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "activeUsers",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "userEngagementDuration",
+      "type": "TYPE_SECONDS"
+    }
+  ],
+  "rows": [
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/tsukiji-market-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "369"
+        },
+        {
+          "value": "299"
+        },
+        {
+          "value": "18860"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "141"
+        },
+        {
+          "value": "76"
+        },
+        {
+          "value": "3920"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/senso-ji-most-visited-temple"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "103"
+        },
+        {
+          "value": "37"
+        },
+        {
+          "value": "1058"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/kamakura-vs-hakone-vs-nikko-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "86"
+        },
+        {
+          "value": "62"
+        },
+        {
+          "value": "5358"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/comparativa-excursiones"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "77"
+        },
+        {
+          "value": "46"
+        },
+        {
+          "value": "11909"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/japan-rail-pass-worth-it"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "71"
+        },
+        {
+          "value": "59"
+        },
+        {
+          "value": "3509"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "58"
+        },
+        {
+          "value": "32"
+        },
+        {
+          "value": "1688"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "57"
+        },
+        {
+          "value": "28"
+        },
+        {
+          "value": "1197"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/licensed-vs-unlicensed-tour-guides-japan"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "55"
+        },
+        {
+          "value": "13"
+        },
+        {
+          "value": "1195"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/guia-tsukiji"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "52"
+        },
+        {
+          "value": "42"
+        },
+        {
+          "value": "3324"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/tokyo-private-tour-guide-cost"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "50"
+        },
+        {
+          "value": "41"
+        },
+        {
+          "value": "2524"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "38"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "2990"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/monte-fuji-se-ve-desde-tokio"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "35"
+        },
+        {
+          "value": "33"
+        },
+        {
+          "value": "984"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/tsukiji-vs-toyosu"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "33"
+        },
+        {
+          "value": "26"
+        },
+        {
+          "value": "1522"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/yanaka-tokyo-walking-route"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "33"
+        },
+        {
+          "value": "21"
+        },
+        {
+          "value": "2473"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/contact"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "33"
+        },
+        {
+          "value": "30"
+        },
+        {
+          "value": "2682"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/is-it-worth-hiring-a-tour-guide-in-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "27"
+        },
+        {
+          "value": "21"
+        },
+        {
+          "value": "710"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours/hakone-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "24"
+        },
+        {
+          "value": "20"
+        },
+        {
+          "value": "323"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/about"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "21"
+        },
+        {
+          "value": "16"
+        },
+        {
+          "value": "859"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/etiqueta-templos-santuarios"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "21"
+        },
+        {
+          "value": "18"
+        },
+        {
+          "value": "1948"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/contact"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "20"
+        },
+        {
+          "value": "15"
+        },
+        {
+          "value": "1139"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/nikko-con-guia-vs-solo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "19"
+        },
+        {
+          "value": "13"
+        },
+        {
+          "value": "1679"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/asakusa-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "18"
+        },
+        {
+          "value": "14"
+        },
+        {
+          "value": "1677"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/japan-temple-shrine-etiquette"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "18"
+        },
+        {
+          "value": "17"
+        },
+        {
+          "value": "483"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/asakusa-tokio-guia"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "18"
+        },
+        {
+          "value": "12"
+        },
+        {
+          "value": "943"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours/nikko-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "17"
+        },
+        {
+          "value": "14"
+        },
+        {
+          "value": "235"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/hakone-day-trip-guide-vs-solo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "16"
+        },
+        {
+          "value": "13"
+        },
+        {
+          "value": "854"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/shibuya-harajuku-guide"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "16"
+        },
+        {
+          "value": "15"
+        },
+        {
+          "value": "794"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours/tsukiji-ginza"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "16"
+        },
+        {
+          "value": "16"
+        },
+        {
+          "value": "175"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours/yanaka"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "15"
+        },
+        {
+          "value": "12"
+        },
+        {
+          "value": "239"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/old-tokyo-shitamachi"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "14"
+        },
+        {
+          "value": "12"
+        },
+        {
+          "value": "544"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/yokohama-day-trip-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "14"
+        },
+        {
+          "value": "14"
+        },
+        {
+          "value": "870"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/comida-callejera-tokio"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "14"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "1246"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/yanaka-tokio-itinerario"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "14"
+        },
+        {
+          "value": "10"
+        },
+        {
+          "value": "639"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours/tokyo-food-tour"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "14"
+        },
+        {
+          "value": "13"
+        },
+        {
+          "value": "646"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/blog/propinas-en-japon"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "13"
+        },
+        {
+          "value": "13"
+        },
+        {
+          "value": "1692"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours/asakusa"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "13"
+        },
+        {
+          "value": "12"
+        },
+        {
+          "value": "152"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/tours/custom"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "12"
+        },
+        {
+          "value": "4"
+        },
+        {
+          "value": "634"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours/shibuya-harajuku"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "12"
+        },
+        {
+          "value": "10"
+        },
+        {
+          "value": "71"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours/tokyo-night-tour"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "12"
+        },
+        {
+          "value": "11"
+        },
+        {
+          "value": "219"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/tipping-in-japan"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "11"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "1406"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/vegetarian-food-tour-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "10"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "671"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/es/tours/nikko-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "10"
+        },
+        {
+          "value": "10"
+        },
+        {
+          "value": "516"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours/imperial-palace"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "10"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "201"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/tours/kamakura-day-trip"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "10"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "87"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "200"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/harajuku-vs-shibuya-vs-shinjuku"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "7"
+        },
+        {
+          "value": "211"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/kawaguchiko-vs-hakone-for-mt-fuji"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "424"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/nikko-day-trip-from-tokyo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "8"
+        },
+        {
+          "value": "787"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "/blog/nikko-day-trip-guide-vs-solo"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "9"
+        },
+        {
+          "value": "1553"
+        }
+      ]
+    }
+  ],
+  "rowCount": 129,
+  "metadata": {
+    "currencyCode": "JPY",
+    "timeZone": "Asia/Tokyo"
+  },
+  "kind": "analyticsData#runReport"
+}

--- a/docs/analytics/raw/2026-07-28_28d_ga4_source_medium.json
+++ b/docs/analytics/raw/2026-07-28_28d_ga4_source_medium.json
@@ -1,0 +1,557 @@
+{
+  "dimensionHeaders": [
+    {
+      "name": "sessionSource"
+    },
+    {
+      "name": "sessionMedium"
+    }
+  ],
+  "metricHeaders": [
+    {
+      "name": "sessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "engagedSessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "conversions",
+      "type": "TYPE_FLOAT"
+    }
+  ],
+  "rows": [
+    {
+      "dimensionValues": [
+        {
+          "value": "google"
+        },
+        {
+          "value": "organic"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "924"
+        },
+        {
+          "value": "477"
+        },
+        {
+          "value": "148"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "(direct)"
+        },
+        {
+          "value": "(none)"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "386"
+        },
+        {
+          "value": "86"
+        },
+        {
+          "value": "104"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "bing"
+        },
+        {
+          "value": "organic"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "107"
+        },
+        {
+          "value": "42"
+        },
+        {
+          "value": "8"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "chatgpt.com"
+        },
+        {
+          "value": "ai-assistant"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "44"
+        },
+        {
+          "value": "25"
+        },
+        {
+          "value": "44"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "duckduckgo"
+        },
+        {
+          "value": "organic"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "23"
+        },
+        {
+          "value": "14"
+        },
+        {
+          "value": "4"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "yahoo"
+        },
+        {
+          "value": "organic"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "12"
+        },
+        {
+          "value": "11"
+        },
+        {
+          "value": "19"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "camino-japan-travel.com"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "9"
+        },
+        {
+          "value": "5"
+        },
+        {
+          "value": "4"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "ecosia.org"
+        },
+        {
+          "value": "organic"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "6"
+        },
+        {
+          "value": "3"
+        },
+        {
+          "value": "2"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "copilot.com"
+        },
+        {
+          "value": "(not set)"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "4"
+        },
+        {
+          "value": "2"
+        },
+        {
+          "value": "4"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "(not set)"
+        },
+        {
+          "value": "(not set)"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "claude.ai"
+        },
+        {
+          "value": "ai-assistant"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "3"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "114.114.114.114:9421"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "au.search.yahoo.com"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "no.search.yahoo.com"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "sg.search.yahoo.com"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "2"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "avg"
+        },
+        {
+          "value": "organic"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "es.search.yahoo.com"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "m.facebook.com"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "mx.search.yahoo.com"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "openai"
+        },
+        {
+          "value": "organic"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "pe.search.yahoo.com"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "perplexity"
+        },
+        {
+          "value": "(not set)"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "2"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "ph.search.yahoo.com"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "teams.public.onecdn.static.microsoft"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "tiktok.com"
+        },
+        {
+          "value": "referral"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1"
+        },
+        {
+          "value": "0"
+        },
+        {
+          "value": "0"
+        }
+      ]
+    }
+  ],
+  "rowCount": 25,
+  "metadata": {
+    "currencyCode": "JPY",
+    "timeZone": "Asia/Tokyo"
+  },
+  "kind": "analyticsData#runReport"
+}

--- a/docs/analytics/raw/2026-07-28_28d_ga4_total.json
+++ b/docs/analytics/raw/2026-07-28_28d_ga4_total.json
@@ -1,0 +1,105 @@
+{
+  "dimensionHeaders": [
+    {
+      "name": "dateRange"
+    }
+  ],
+  "metricHeaders": [
+    {
+      "name": "activeUsers",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "sessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "engagedSessions",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "screenPageViews",
+      "type": "TYPE_INTEGER"
+    },
+    {
+      "name": "userEngagementDuration",
+      "type": "TYPE_SECONDS"
+    },
+    {
+      "name": "averageSessionDuration",
+      "type": "TYPE_SECONDS"
+    },
+    {
+      "name": "bounceRate",
+      "type": "TYPE_FLOAT"
+    }
+  ],
+  "rows": [
+    {
+      "dimensionValues": [
+        {
+          "value": "recent"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "1152"
+        },
+        {
+          "value": "1538"
+        },
+        {
+          "value": "675"
+        },
+        {
+          "value": "2089"
+        },
+        {
+          "value": "112268"
+        },
+        {
+          "value": "198.79519686801041"
+        },
+        {
+          "value": "0.56111833550065016"
+        }
+      ]
+    },
+    {
+      "dimensionValues": [
+        {
+          "value": "previous"
+        }
+      ],
+      "metricValues": [
+        {
+          "value": "779"
+        },
+        {
+          "value": "998"
+        },
+        {
+          "value": "436"
+        },
+        {
+          "value": "1463"
+        },
+        {
+          "value": "83383"
+        },
+        {
+          "value": "178.8309673006012"
+        },
+        {
+          "value": "0.56312625250501"
+        }
+      ]
+    }
+  ],
+  "rowCount": 2,
+  "metadata": {
+    "currencyCode": "JPY",
+    "timeZone": "Asia/Tokyo"
+  },
+  "kind": "analyticsData#runReport"
+}

--- a/docs/analytics/raw/2026-07-28_28d_gsc_country.json
+++ b/docs/analytics/raw/2026-07-28_28d_gsc_country.json
@@ -1,0 +1,1679 @@
+{
+  "rows": [
+    {
+      "keys": [
+        "jpn"
+      ],
+      "clicks": 196,
+      "impressions": 23001,
+      "ctr": 0.0085213686361462551,
+      "position": 7.7978783531150819
+    },
+    {
+      "keys": [
+        "usa"
+      ],
+      "clicks": 118,
+      "impressions": 40586,
+      "ctr": 0.002907406494850441,
+      "position": 8.722194845513231
+    },
+    {
+      "keys": [
+        "esp"
+      ],
+      "clicks": 106,
+      "impressions": 6990,
+      "ctr": 0.015164520743919885,
+      "position": 8.2763948497854081
+    },
+    {
+      "keys": [
+        "aus"
+      ],
+      "clicks": 28,
+      "impressions": 3369,
+      "ctr": 0.0083110715345799946,
+      "position": 8.43484713564856
+    },
+    {
+      "keys": [
+        "gbr"
+      ],
+      "clicks": 25,
+      "impressions": 4069,
+      "ctr": 0.0061440157286802655,
+      "position": 8.9451953797001718
+    },
+    {
+      "keys": [
+        "sgp"
+      ],
+      "clicks": 25,
+      "impressions": 1886,
+      "ctr": 0.013255567338282079,
+      "position": 9.4772004241781556
+    },
+    {
+      "keys": [
+        "mex"
+      ],
+      "clicks": 21,
+      "impressions": 3469,
+      "ctr": 0.0060536177572787543,
+      "position": 7.7284520034592106
+    },
+    {
+      "keys": [
+        "can"
+      ],
+      "clicks": 18,
+      "impressions": 3593,
+      "ctr": 0.0050097411633732254,
+      "position": 8.8246590592819381
+    },
+    {
+      "keys": [
+        "phl"
+      ],
+      "clicks": 13,
+      "impressions": 1525,
+      "ctr": 0.0085245901639344271,
+      "position": 8.7081967213114755
+    },
+    {
+      "keys": [
+        "bra"
+      ],
+      "clicks": 10,
+      "impressions": 1397,
+      "ctr": 0.0071581961345740875,
+      "position": 7.7967072297780957
+    },
+    {
+      "keys": [
+        "fra"
+      ],
+      "clicks": 9,
+      "impressions": 723,
+      "ctr": 0.012448132780082987,
+      "position": 7.2365145228215768
+    },
+    {
+      "keys": [
+        "ind"
+      ],
+      "clicks": 8,
+      "impressions": 1757,
+      "ctr": 0.0045532157085941948,
+      "position": 8.1724530449630048
+    },
+    {
+      "keys": [
+        "nld"
+      ],
+      "clicks": 8,
+      "impressions": 6823,
+      "ctr": 0.0011725047633006009,
+      "position": 6.3681664956763884
+    },
+    {
+      "keys": [
+        "ita"
+      ],
+      "clicks": 7,
+      "impressions": 1757,
+      "ctr": 0.00398406374501992,
+      "position": 6.468412066021628
+    },
+    {
+      "keys": [
+        "mys"
+      ],
+      "clicks": 7,
+      "impressions": 1073,
+      "ctr": 0.0065237651444548,
+      "position": 8.5834109972041013
+    },
+    {
+      "keys": [
+        "arg"
+      ],
+      "clicks": 6,
+      "impressions": 891,
+      "ctr": 0.0067340067340067337,
+      "position": 8.149270482603816
+    },
+    {
+      "keys": [
+        "deu"
+      ],
+      "clicks": 6,
+      "impressions": 5185,
+      "ctr": 0.0011571841851494697,
+      "position": 6.7853423336547731
+    },
+    {
+      "keys": [
+        "che"
+      ],
+      "clicks": 5,
+      "impressions": 386,
+      "ctr": 0.012953367875647668,
+      "position": 7.5880829015544045
+    },
+    {
+      "keys": [
+        "idn"
+      ],
+      "clicks": 5,
+      "impressions": 1069,
+      "ctr": 0.0046772684752104769,
+      "position": 8.9981290926099149
+    },
+    {
+      "keys": [
+        "pol"
+      ],
+      "clicks": 5,
+      "impressions": 532,
+      "ctr": 0.0093984962406015032,
+      "position": 6.9229323308270674
+    },
+    {
+      "keys": [
+        "nzl"
+      ],
+      "clicks": 4,
+      "impressions": 547,
+      "ctr": 0.0073126142595978062,
+      "position": 8.641681901279707
+    },
+    {
+      "keys": [
+        "tha"
+      ],
+      "clicks": 4,
+      "impressions": 762,
+      "ctr": 0.0052493438320209973,
+      "position": 7.5511811023622046
+    },
+    {
+      "keys": [
+        "tur"
+      ],
+      "clicks": 4,
+      "impressions": 443,
+      "ctr": 0.0090293453724604959,
+      "position": 8.7065462753950342
+    },
+    {
+      "keys": [
+        "bel"
+      ],
+      "clicks": 3,
+      "impressions": 373,
+      "ctr": 0.00804289544235925,
+      "position": 6.96514745308311
+    },
+    {
+      "keys": [
+        "chn"
+      ],
+      "clicks": 3,
+      "impressions": 185,
+      "ctr": 0.016216216216216217,
+      "position": 6.7189189189189191
+    },
+    {
+      "keys": [
+        "hkg"
+      ],
+      "clicks": 3,
+      "impressions": 1195,
+      "ctr": 0.0025104602510460251,
+      "position": 7.5196652719665273
+    },
+    {
+      "keys": [
+        "kor"
+      ],
+      "clicks": 3,
+      "impressions": 1742,
+      "ctr": 0.001722158438576349,
+      "position": 6.53788748564868
+    },
+    {
+      "keys": [
+        "swe"
+      ],
+      "clicks": 3,
+      "impressions": 329,
+      "ctr": 0.00911854103343465,
+      "position": 7.3829787234042552
+    },
+    {
+      "keys": [
+        "twn"
+      ],
+      "clicks": 3,
+      "impressions": 1236,
+      "ctr": 0.0024271844660194173,
+      "position": 6.55663430420712
+    },
+    {
+      "keys": [
+        "blr"
+      ],
+      "clicks": 2,
+      "impressions": 21,
+      "ctr": 0.095238095238095233,
+      "position": 7.8571428571428568
+    },
+    {
+      "keys": [
+        "col"
+      ],
+      "clicks": 2,
+      "impressions": 684,
+      "ctr": 0.0029239766081871343,
+      "position": 8.0014619883040936
+    },
+    {
+      "keys": [
+        "cri"
+      ],
+      "clicks": 2,
+      "impressions": 194,
+      "ctr": 0.010309278350515464,
+      "position": 7.65979381443299
+    },
+    {
+      "keys": [
+        "dnk"
+      ],
+      "clicks": 2,
+      "impressions": 318,
+      "ctr": 0.0062893081761006293,
+      "position": 7.0062893081761
+    },
+    {
+      "keys": [
+        "gtm"
+      ],
+      "clicks": 2,
+      "impressions": 101,
+      "ctr": 0.019801980198019802,
+      "position": 7.2673267326732676
+    },
+    {
+      "keys": [
+        "isr"
+      ],
+      "clicks": 2,
+      "impressions": 598,
+      "ctr": 0.0033444816053511705,
+      "position": 7.0484949832775916
+    },
+    {
+      "keys": [
+        "nor"
+      ],
+      "clicks": 2,
+      "impressions": 177,
+      "ctr": 0.011299435028248588,
+      "position": 6.7005649717514126
+    },
+    {
+      "keys": [
+        "per"
+      ],
+      "clicks": 2,
+      "impressions": 420,
+      "ctr": 0.0047619047619047623,
+      "position": 7.2547619047619047
+    },
+    {
+      "keys": [
+        "are"
+      ],
+      "clicks": 1,
+      "impressions": 627,
+      "ctr": 0.001594896331738437,
+      "position": 6.7224880382775121
+    },
+    {
+      "keys": [
+        "aut"
+      ],
+      "clicks": 1,
+      "impressions": 240,
+      "ctr": 0.0041666666666666666,
+      "position": 7.5958333333333332
+    },
+    {
+      "keys": [
+        "bol"
+      ],
+      "clicks": 1,
+      "impressions": 62,
+      "ctr": 0.016129032258064516,
+      "position": 8.693548387096774
+    },
+    {
+      "keys": [
+        "chl"
+      ],
+      "clicks": 1,
+      "impressions": 559,
+      "ctr": 0.0017889087656529517,
+      "position": 7.6189624329159216
+    },
+    {
+      "keys": [
+        "cze"
+      ],
+      "clicks": 1,
+      "impressions": 140,
+      "ctr": 0.0071428571428571426,
+      "position": 7.0285714285714285
+    },
+    {
+      "keys": [
+        "ecu"
+      ],
+      "clicks": 1,
+      "impressions": 215,
+      "ctr": 0.0046511627906976744,
+      "position": 8.4511627906976745
+    },
+    {
+      "keys": [
+        "fin"
+      ],
+      "clicks": 1,
+      "impressions": 156,
+      "ctr": 0.00641025641025641,
+      "position": 7.4423076923076925
+    },
+    {
+      "keys": [
+        "geo"
+      ],
+      "clicks": 1,
+      "impressions": 26,
+      "ctr": 0.038461538461538464,
+      "position": 6.8076923076923075
+    },
+    {
+      "keys": [
+        "grc"
+      ],
+      "clicks": 1,
+      "impressions": 175,
+      "ctr": 0.0057142857142857143,
+      "position": 6.8914285714285715
+    },
+    {
+      "keys": [
+        "gum"
+      ],
+      "clicks": 1,
+      "impressions": 40,
+      "ctr": 0.025,
+      "position": 5.5
+    },
+    {
+      "keys": [
+        "hun"
+      ],
+      "clicks": 1,
+      "impressions": 141,
+      "ctr": 0.0070921985815602835,
+      "position": 7.0992907801418443
+    },
+    {
+      "keys": [
+        "irl"
+      ],
+      "clicks": 1,
+      "impressions": 231,
+      "ctr": 0.004329004329004329,
+      "position": 7.6839826839826841
+    },
+    {
+      "keys": [
+        "kaz"
+      ],
+      "clicks": 1,
+      "impressions": 69,
+      "ctr": 0.014492753623188406,
+      "position": 7.7971014492753623
+    },
+    {
+      "keys": [
+        "ken"
+      ],
+      "clicks": 1,
+      "impressions": 26,
+      "ctr": 0.038461538461538464,
+      "position": 10.153846153846153
+    },
+    {
+      "keys": [
+        "ltu"
+      ],
+      "clicks": 1,
+      "impressions": 49,
+      "ctr": 0.020408163265306121,
+      "position": 6.8571428571428568
+    },
+    {
+      "keys": [
+        "mng"
+      ],
+      "clicks": 1,
+      "impressions": 15,
+      "ctr": 0.066666666666666666,
+      "position": 7.9333333333333336
+    },
+    {
+      "keys": [
+        "pri"
+      ],
+      "clicks": 1,
+      "impressions": 85,
+      "ctr": 0.011764705882352941,
+      "position": 6.6
+    },
+    {
+      "keys": [
+        "prt"
+      ],
+      "clicks": 1,
+      "impressions": 231,
+      "ctr": 0.004329004329004329,
+      "position": 7.06926406926407
+    },
+    {
+      "keys": [
+        "slv"
+      ],
+      "clicks": 1,
+      "impressions": 44,
+      "ctr": 0.022727272727272728,
+      "position": 7.9318181818181817
+    },
+    {
+      "keys": [
+        "srb"
+      ],
+      "clicks": 1,
+      "impressions": 45,
+      "ctr": 0.022222222222222223,
+      "position": 7.4222222222222225
+    },
+    {
+      "keys": [
+        "ury"
+      ],
+      "clicks": 1,
+      "impressions": 122,
+      "ctr": 0.00819672131147541,
+      "position": 6.9590163934426226
+    },
+    {
+      "keys": [
+        "zaf"
+      ],
+      "clicks": 1,
+      "impressions": 128,
+      "ctr": 0.0078125,
+      "position": 9.1640625
+    },
+    {
+      "keys": [
+        "abw"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "afg"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 6.666666666666667
+    },
+    {
+      "keys": [
+        "ago"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "keys": [
+        "ala"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "alb"
+      ],
+      "clicks": 0,
+      "impressions": 29,
+      "ctr": 0,
+      "position": 6.7931034482758621
+    },
+    {
+      "keys": [
+        "and"
+      ],
+      "clicks": 0,
+      "impressions": 19,
+      "ctr": 0,
+      "position": 6.3157894736842106
+    },
+    {
+      "keys": [
+        "arm"
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 5.083333333333333
+    },
+    {
+      "keys": [
+        "asm"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "aze"
+      ],
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 7.4117647058823533
+    },
+    {
+      "keys": [
+        "bfa"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4.5
+    },
+    {
+      "keys": [
+        "bgd"
+      ],
+      "clicks": 0,
+      "impressions": 215,
+      "ctr": 0,
+      "position": 12.706976744186047
+    },
+    {
+      "keys": [
+        "bgr"
+      ],
+      "clicks": 0,
+      "impressions": 62,
+      "ctr": 0,
+      "position": 7.82258064516129
+    },
+    {
+      "keys": [
+        "bhr"
+      ],
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 8.5625
+    },
+    {
+      "keys": [
+        "bhs"
+      ],
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 8.0769230769230766
+    },
+    {
+      "keys": [
+        "bih"
+      ],
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 7.1111111111111107
+    },
+    {
+      "keys": [
+        "blz"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.4
+    },
+    {
+      "keys": [
+        "bmu"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 7.666666666666667
+    },
+    {
+      "keys": [
+        "brb"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 6.7142857142857144
+    },
+    {
+      "keys": [
+        "brn"
+      ],
+      "clicks": 0,
+      "impressions": 31,
+      "ctr": 0,
+      "position": 7.032258064516129
+    },
+    {
+      "keys": [
+        "bwa"
+      ],
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "keys": [
+        "civ"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "keys": [
+        "cmr"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "cod"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "cog"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "cok"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "cpv"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "keys": [
+        "cub"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "keys": [
+        "cuw"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.2
+    },
+    {
+      "keys": [
+        "cym"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "cyp"
+      ],
+      "clicks": 0,
+      "impressions": 47,
+      "ctr": 0,
+      "position": 6.3829787234042552
+    },
+    {
+      "keys": [
+        "dom"
+      ],
+      "clicks": 0,
+      "impressions": 107,
+      "ctr": 0,
+      "position": 7.4205607476635516
+    },
+    {
+      "keys": [
+        "dza"
+      ],
+      "clicks": 0,
+      "impressions": 60,
+      "ctr": 0,
+      "position": 15.333333333333334
+    },
+    {
+      "keys": [
+        "egy"
+      ],
+      "clicks": 0,
+      "impressions": 72,
+      "ctr": 0,
+      "position": 11.458333333333334
+    },
+    {
+      "keys": [
+        "esh"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 24
+    },
+    {
+      "keys": [
+        "est"
+      ],
+      "clicks": 0,
+      "impressions": 32,
+      "ctr": 0,
+      "position": 7.96875
+    },
+    {
+      "keys": [
+        "eth"
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 9.0833333333333339
+    },
+    {
+      "keys": [
+        "fji"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 5.7142857142857144
+    },
+    {
+      "keys": [
+        "fro"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "gab"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 16
+    },
+    {
+      "keys": [
+        "ggy"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 1.6666666666666665
+    },
+    {
+      "keys": [
+        "gha"
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 5.5
+    },
+    {
+      "keys": [
+        "gib"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 7.8571428571428568
+    },
+    {
+      "keys": [
+        "gmb"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "grd"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "guf"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "guy"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "keys": [
+        "hnd"
+      ],
+      "clicks": 0,
+      "impressions": 56,
+      "ctr": 0,
+      "position": 6.75
+    },
+    {
+      "keys": [
+        "hrv"
+      ],
+      "clicks": 0,
+      "impressions": 60,
+      "ctr": 0,
+      "position": 7.7833333333333332
+    },
+    {
+      "keys": [
+        "hti"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "imn"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 7.25
+    },
+    {
+      "keys": [
+        "irn"
+      ],
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 8.6363636363636367
+    },
+    {
+      "keys": [
+        "irq"
+      ],
+      "clicks": 0,
+      "impressions": 38,
+      "ctr": 0,
+      "position": 11.684210526315789
+    },
+    {
+      "keys": [
+        "isl"
+      ],
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "jam"
+      ],
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 7.0434782608695654
+    },
+    {
+      "keys": [
+        "jey"
+      ],
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 3.5
+    },
+    {
+      "keys": [
+        "jor"
+      ],
+      "clicks": 0,
+      "impressions": 68,
+      "ctr": 0,
+      "position": 15.426470588235293
+    },
+    {
+      "keys": [
+        "kgz"
+      ],
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 8.875
+    },
+    {
+      "keys": [
+        "khm"
+      ],
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "kwt"
+      ],
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 8.7083333333333321
+    },
+    {
+      "keys": [
+        "lao"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 6.1428571428571432
+    },
+    {
+      "keys": [
+        "lbn"
+      ],
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "lka"
+      ],
+      "clicks": 0,
+      "impressions": 40,
+      "ctr": 0,
+      "position": 8.275
+    },
+    {
+      "keys": [
+        "lux"
+      ],
+      "clicks": 0,
+      "impressions": 31,
+      "ctr": 0,
+      "position": 5.4516129032258061
+    },
+    {
+      "keys": [
+        "lva"
+      ],
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 7.4545454545454541
+    },
+    {
+      "keys": [
+        "mac"
+      ],
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "maf"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "mar"
+      ],
+      "clicks": 0,
+      "impressions": 124,
+      "ctr": 0,
+      "position": 14.379032258064516
+    },
+    {
+      "keys": [
+        "mco"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 7.333333333333333
+    },
+    {
+      "keys": [
+        "mda"
+      ],
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 6.0714285714285712
+    },
+    {
+      "keys": [
+        "mdg"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "mdv"
+      ],
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "keys": [
+        "mhl"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "mkd"
+      ],
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "keys": [
+        "mli"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "mlt"
+      ],
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 6.4571428571428573
+    },
+    {
+      "keys": [
+        "mmr"
+      ],
+      "clicks": 0,
+      "impressions": 29,
+      "ctr": 0,
+      "position": 6.3448275862068968
+    },
+    {
+      "keys": [
+        "mne"
+      ],
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 7.5
+    },
+    {
+      "keys": [
+        "mnp"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 7.7142857142857144
+    },
+    {
+      "keys": [
+        "moz"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "mrt"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "keys": [
+        "mtq"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "mus"
+      ],
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 7.2857142857142856
+    },
+    {
+      "keys": [
+        "mwi"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5
+    },
+    {
+      "keys": [
+        "nam"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 14
+    },
+    {
+      "keys": [
+        "nga"
+      ],
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 10.885714285714286
+    },
+    {
+      "keys": [
+        "nic"
+      ],
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 10.038461538461538
+    },
+    {
+      "keys": [
+        "npl"
+      ],
+      "clicks": 0,
+      "impressions": 34,
+      "ctr": 0,
+      "position": 7.2058823529411766
+    },
+    {
+      "keys": [
+        "omn"
+      ],
+      "clicks": 0,
+      "impressions": 19,
+      "ctr": 0,
+      "position": 10.263157894736842
+    },
+    {
+      "keys": [
+        "pak"
+      ],
+      "clicks": 0,
+      "impressions": 216,
+      "ctr": 0,
+      "position": 13.055555555555555
+    },
+    {
+      "keys": [
+        "pan"
+      ],
+      "clicks": 0,
+      "impressions": 106,
+      "ctr": 0,
+      "position": 7.867924528301887
+    },
+    {
+      "keys": [
+        "png"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "pry"
+      ],
+      "clicks": 0,
+      "impressions": 66,
+      "ctr": 0,
+      "position": 7.833333333333333
+    },
+    {
+      "keys": [
+        "pse"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 13.571428571428571
+    },
+    {
+      "keys": [
+        "pyf"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "qat"
+      ],
+      "clicks": 0,
+      "impressions": 47,
+      "ctr": 0,
+      "position": 7.8085106382978724
+    },
+    {
+      "keys": [
+        "reu"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "keys": [
+        "rou"
+      ],
+      "clicks": 0,
+      "impressions": 125,
+      "ctr": 0,
+      "position": 6.544
+    },
+    {
+      "keys": [
+        "rus"
+      ],
+      "clicks": 0,
+      "impressions": 318,
+      "ctr": 0,
+      "position": 7.8647798742138368
+    },
+    {
+      "keys": [
+        "rwa"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.2
+    },
+    {
+      "keys": [
+        "sau"
+      ],
+      "clicks": 0,
+      "impressions": 178,
+      "ctr": 0,
+      "position": 10.49438202247191
+    },
+    {
+      "keys": [
+        "sen"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 11.5
+    },
+    {
+      "keys": [
+        "shn"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "sle"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "smr"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "keys": [
+        "ssd"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "sur"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "svk"
+      ],
+      "clicks": 0,
+      "impressions": 45,
+      "ctr": 0,
+      "position": 7.7555555555555555
+    },
+    {
+      "keys": [
+        "svn"
+      ],
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 8.0714285714285712
+    },
+    {
+      "keys": [
+        "sxm"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "syr"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "keys": [
+        "tgo"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 16.25
+    },
+    {
+      "keys": [
+        "tjk"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "tls"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "tto"
+      ],
+      "clicks": 0,
+      "impressions": 29,
+      "ctr": 0,
+      "position": 7.0344827586206895
+    },
+    {
+      "keys": [
+        "tun"
+      ],
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 9.5555555555555554
+    },
+    {
+      "keys": [
+        "tza"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 5.666666666666667
+    },
+    {
+      "keys": [
+        "uga"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 6.8571428571428568
+    },
+    {
+      "keys": [
+        "ukr"
+      ],
+      "clicks": 0,
+      "impressions": 100,
+      "ctr": 0,
+      "position": 10.44
+    },
+    {
+      "keys": [
+        "uzb"
+      ],
+      "clicks": 0,
+      "impressions": 20,
+      "ctr": 0,
+      "position": 8.25
+    },
+    {
+      "keys": [
+        "ven"
+      ],
+      "clicks": 0,
+      "impressions": 97,
+      "ctr": 0,
+      "position": 6.65979381443299
+    },
+    {
+      "keys": [
+        "vir"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 6.666666666666667
+    },
+    {
+      "keys": [
+        "vnm"
+      ],
+      "clicks": 0,
+      "impressions": 1102,
+      "ctr": 0,
+      "position": 13.945553539019963
+    },
+    {
+      "keys": [
+        "vut"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "keys": [
+        "xkk"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "zmb"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 12.5
+    },
+    {
+      "keys": [
+        "zwe"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 11.5
+    },
+    {
+      "keys": [
+        "zzz"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8
+    }
+  ],
+  "responseAggregationType": "byProperty"
+}

--- a/docs/analytics/raw/2026-07-28_28d_gsc_device.json
+++ b/docs/analytics/raw/2026-07-28_28d_gsc_device.json
@@ -1,0 +1,32 @@
+{
+  "rows": [
+    {
+      "keys": [
+        "MOBILE"
+      ],
+      "clicks": 400,
+      "impressions": 40749,
+      "ctr": 0.0098161918083879366,
+      "position": 8.0300620874131887
+    },
+    {
+      "keys": [
+        "DESKTOP"
+      ],
+      "clicks": 285,
+      "impressions": 85677,
+      "ctr": 0.0033264470044469343,
+      "position": 8.2148884764872712
+    },
+    {
+      "keys": [
+        "TABLET"
+      ],
+      "clicks": 9,
+      "impressions": 701,
+      "ctr": 0.012838801711840228,
+      "position": 8.146932952924395
+    }
+  ],
+  "responseAggregationType": "byProperty"
+}

--- a/docs/analytics/raw/2026-07-28_28d_gsc_page.json
+++ b/docs/analytics/raw/2026-07-28_28d_gsc_page.json
@@ -1,0 +1,1850 @@
+{
+  "rows": [
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide"
+      ],
+      "clicks": 215,
+      "impressions": 33020,
+      "ctr": 0.0065112053301029675,
+      "position": 7.1031798909751664
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip"
+      ],
+      "clicks": 49,
+      "impressions": 3380,
+      "ctr": 0.014497041420118343,
+      "position": 6.8875739644970411
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/guia-tsukiji"
+      ],
+      "clicks": 39,
+      "impressions": 2353,
+      "ctr": 0.016574585635359115,
+      "position": 6.7475563110922225
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comparativa-excursiones"
+      ],
+      "clicks": 36,
+      "impressions": 706,
+      "ctr": 0.050991501416430593,
+      "position": 5.0793201133144477
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it"
+      ],
+      "clicks": 30,
+      "impressions": 39812,
+      "ctr": 0.00075354164573495426,
+      "position": 7.60994172611273
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio"
+      ],
+      "clicks": 29,
+      "impressions": 5741,
+      "ctr": 0.0050513847761713988,
+      "position": 7.6868141438773732
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple"
+      ],
+      "clicks": 20,
+      "impressions": 6194,
+      "ctr": 0.0032289312237649337,
+      "position": 6.57458831126897
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu"
+      ],
+      "clicks": 18,
+      "impressions": 2571,
+      "ctr": 0.0070011668611435242,
+      "position": 8.634772462077013
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route"
+      ],
+      "clicks": 18,
+      "impressions": 1699,
+      "ctr": 0.01059446733372572,
+      "position": 8.9540906415538544
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost"
+      ],
+      "clicks": 16,
+      "impressions": 4096,
+      "ctr": 0.00390625,
+      "position": 7.0673828125
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/propinas-en-japon"
+      ],
+      "clicks": 14,
+      "impressions": 1873,
+      "ctr": 0.0074746396155899626,
+      "position": 6.0133475707421251
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo"
+      ],
+      "clicks": 13,
+      "impressions": 1508,
+      "ctr": 0.0086206896551724137,
+      "position": 14.830901856763926
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/etiqueta-templos-santuarios"
+      ],
+      "clicks": 13,
+      "impressions": 543,
+      "ctr": 0.023941068139963169,
+      "position": 6.2633517495395949
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/nikko-con-guia-vs-solo"
+      ],
+      "clicks": 13,
+      "impressions": 1031,
+      "ctr": 0.012609117361784675,
+      "position": 8.6003879728419
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/"
+      ],
+      "clicks": 12,
+      "impressions": 128,
+      "ctr": 0.09375,
+      "position": 4.796875
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide"
+      ],
+      "clicks": 12,
+      "impressions": 2275,
+      "ctr": 0.0052747252747252747,
+      "position": 8.0303296703296709
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/hakone-day-trip-guide-vs-solo"
+      ],
+      "clicks": 10,
+      "impressions": 429,
+      "ctr": 0.023310023310023312,
+      "position": 10.358974358974359
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/old-tokyo-shitamachi"
+      ],
+      "clicks": 10,
+      "impressions": 1320,
+      "ctr": 0.007575757575757576,
+      "position": 8.084090909090909
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yokohama-day-trip-from-tokyo"
+      ],
+      "clicks": 10,
+      "impressions": 2623,
+      "ctr": 0.003812428516965307,
+      "position": 10.700724361418223
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/japan-temple-shrine-etiquette"
+      ],
+      "clicks": 8,
+      "impressions": 2945,
+      "ctr": 0.0027164685908319186,
+      "position": 9.8319185059422747
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/nikko-day-trip-guide-vs-solo"
+      ],
+      "clicks": 8,
+      "impressions": 165,
+      "ctr": 0.048484848484848485,
+      "position": 7.96969696969697
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/vegetarian-food-tour-tokyo"
+      ],
+      "clicks": 8,
+      "impressions": 286,
+      "ctr": 0.027972027972027972,
+      "position": 10.37062937062937
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/asakusa-tokio-guia"
+      ],
+      "clicks": 8,
+      "impressions": 1181,
+      "ctr": 0.0067739204064352241,
+      "position": 9.819644369178663
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comida-callejera-tokio"
+      ],
+      "clicks": 8,
+      "impressions": 538,
+      "ctr": 0.014869888475836431,
+      "position": 7.6282527881040894
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/yanaka-tokio-itinerario"
+      ],
+      "clicks": 7,
+      "impressions": 1458,
+      "ctr": 0.0048010973936899867,
+      "position": 9.1460905349794235
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/asakusa-guide"
+      ],
+      "clicks": 6,
+      "impressions": 1181,
+      "ctr": 0.0050804403048264179,
+      "position": 10.244707874682472
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/kawaguchiko-vs-hakone-for-mt-fuji"
+      ],
+      "clicks": 6,
+      "impressions": 286,
+      "ctr": 0.02097902097902098,
+      "position": 10.594405594405595
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-hidden-gems"
+      ],
+      "clicks": 5,
+      "impressions": 93,
+      "ctr": 0.053763440860215055,
+      "position": 6.913978494623656
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-on-a-budget"
+      ],
+      "clicks": 5,
+      "impressions": 574,
+      "ctr": 0.0087108013937282226,
+      "position": 15.841463414634147
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo"
+      ],
+      "clicks": 4,
+      "impressions": 1183,
+      "ctr": 0.0033812341504649195,
+      "position": 18.499577345731193
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/best-day-trips-from-tokyo"
+      ],
+      "clicks": 3,
+      "impressions": 45,
+      "ctr": 0.066666666666666666,
+      "position": 12.066666666666666
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/rainy-day-tokyo"
+      ],
+      "clicks": 3,
+      "impressions": 717,
+      "ctr": 0.0041841004184100415,
+      "position": 14.940027894002789
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tipping-in-japan"
+      ],
+      "clicks": 3,
+      "impressions": 168,
+      "ctr": 0.017857142857142856,
+      "position": 12.446428571428571
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tipping-in-japan/"
+      ],
+      "clicks": 3,
+      "impressions": 513,
+      "ctr": 0.0058479532163742687,
+      "position": 18.243664717348928
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-3-day-itinerary"
+      ],
+      "clicks": 3,
+      "impressions": 281,
+      "ctr": 0.010676156583629894,
+      "position": 19.491103202846976
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es"
+      ],
+      "clicks": 3,
+      "impressions": 43,
+      "ctr": 0.069767441860465115,
+      "position": 8.4651162790697683
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/tour-gastronomico-tokio"
+      ],
+      "clicks": 3,
+      "impressions": 130,
+      "ctr": 0.023076923076923078,
+      "position": 17.846153846153847
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-to-ginza-food-walk"
+      ],
+      "clicks": 2,
+      "impressions": 173,
+      "ctr": 0.011560693641618497,
+      "position": 8.3121387283237
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/cuanto-cuesta-guia-privado-tokio"
+      ],
+      "clicks": 2,
+      "impressions": 165,
+      "ctr": 0.012121212121212121,
+      "position": 5.1757575757575758
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/japan-rail-pass-vale-la-pena"
+      ],
+      "clicks": 2,
+      "impressions": 469,
+      "ctr": 0.0042643923240938165,
+      "position": 8.9402985074626855
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours"
+      ],
+      "clicks": 2,
+      "impressions": 49,
+      "ctr": 0.040816326530612242,
+      "position": 5.8979591836734695
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours/hakone-day-trip"
+      ],
+      "clicks": 2,
+      "impressions": 115,
+      "ctr": 0.017391304347826087,
+      "position": 11.782608695652174
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog"
+      ],
+      "clicks": 1,
+      "impressions": 69,
+      "ctr": 0.014492753623188406,
+      "position": 7.5652173913043477
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/kawagoe-day-trip-from-tokyo"
+      ],
+      "clicks": 1,
+      "impressions": 109,
+      "ctr": 0.0091743119266055051,
+      "position": 9.5871559633027523
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/mount-fuji-from-tokyo"
+      ],
+      "clicks": 1,
+      "impressions": 36,
+      "ctr": 0.027777777777777776,
+      "position": 8.1944444444444446
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-itinerary-5-days"
+      ],
+      "clicks": 1,
+      "impressions": 45,
+      "ctr": 0.022222222222222223,
+      "position": 28.577777777777779
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-with-elderly-parents"
+      ],
+      "clicks": 1,
+      "impressions": 71,
+      "ctr": 0.014084507042253521,
+      "position": 8.0985915492957758
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide#section-01-tsukiji-outer-market-hours"
+      ],
+      "clicks": 1,
+      "impressions": 8521,
+      "ctr": 0.00011735711770918906,
+      "position": 8.44278840511677
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/itinerario-tokio-5-dias"
+      ],
+      "clicks": 1,
+      "impressions": 104,
+      "ctr": 0.0096153846153846159,
+      "position": 23.778846153846153
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/kamakura-desde-tokio"
+      ],
+      "clicks": 1,
+      "impressions": 112,
+      "ctr": 0.0089285714285714281,
+      "position": 16.071428571428569
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/tour-vegetariano-tokio"
+      ],
+      "clicks": 1,
+      "impressions": 5,
+      "ctr": 0.2,
+      "position": 7
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/vale-la-pena-contratar-guia"
+      ],
+      "clicks": 1,
+      "impressions": 43,
+      "ctr": 0.023255813953488372,
+      "position": 7.4186046511627906
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/tours"
+      ],
+      "clicks": 1,
+      "impressions": 2,
+      "ctr": 0.5,
+      "position": 26.5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/tours/nikko-day-trip"
+      ],
+      "clicks": 1,
+      "impressions": 67,
+      "ctr": 0.014925373134328358,
+      "position": 35.223880597014926
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/tours/yanaka"
+      ],
+      "clicks": 1,
+      "impressions": 19,
+      "ctr": 0.052631578947368418,
+      "position": 7
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours/asakusa"
+      ],
+      "clicks": 1,
+      "impressions": 222,
+      "ctr": 0.0045045045045045045,
+      "position": 14.675675675675675
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours/imperial-palace"
+      ],
+      "clicks": 1,
+      "impressions": 61,
+      "ctr": 0.016393442622950821,
+      "position": 20.0327868852459
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/about"
+      ],
+      "clicks": 0,
+      "impressions": 52,
+      "ctr": 0,
+      "position": 6.0192307692307692
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/assets/imperial-palace-D3ohH6g9.webp"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 15
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/asakusa-guide#section-01-why-i-always-start-tours-at-7am-in-asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 10.2
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/asakusa-guide#section-02-senso-ji"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 9.5714285714285712
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/asakusa-guide#section-03-beyond-the-temple"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 9.5714285714285712
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/asakusa-guide#section-04-where-to-eat-in-asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 9.5714285714285712
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/asakusa-guide-what-to-see"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/english-friendly-tokyo-tips"
+      ],
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 9.6428571428571423
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/enoshima-day-trip-from-tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 43,
+      "ctr": 0,
+      "position": 8.5581395348837219
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/group-vs-private-tour-tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 32,
+      "ctr": 0,
+      "position": 8.78125
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/how-to-choose-private-tokyo-guide"
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 6.833333333333333
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo#section-01-when-a-guide-is-worth-it"
+      ],
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 5.75
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo#section-02-when-you-might-not-need-a-guide"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo#section-03-what-a-licensed-guide-provides-that-google-cant"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 5.7142857142857144
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo#section-04-how-much-does-a-private-guide-cost-in-tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo#section-05-private-guide-vs-booking-platforms"
+      ],
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 5.4545454545454541
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo#section-06-what-you-actually-get-with-a-licensed-guide"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/is-it-worth-hiring-a-tour-guide-in-tokyo#section-07-real-guest-experiences"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it#calculate"
+      ],
+      "clicks": 0,
+      "impressions": 17697,
+      "ctr": 0,
+      "position": 7.34056619766062
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it#price-changes"
+      ],
+      "clicks": 0,
+      "impressions": 18735,
+      "ctr": 0,
+      "position": 7.34678409394182
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it#when-worth"
+      ],
+      "clicks": 0,
+      "impressions": 937,
+      "ctr": 0,
+      "position": 7.462113127001067
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/japan-rail-pass-worth-it#why-complicated"
+      ],
+      "clicks": 0,
+      "impressions": 18674,
+      "ctr": 0,
+      "position": 7.3471136339295278
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/kamakura-day-trip-from-tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 7.583333333333333
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/kamakura-day-trip-guide-vs-solo"
+      ],
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 5.875
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip#section-01-quick-comparison"
+      ],
+      "clicks": 0,
+      "impressions": 199,
+      "ctr": 0,
+      "position": 8.1155778894472359
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip#section-02-kamakura"
+      ],
+      "clicks": 0,
+      "impressions": 332,
+      "ctr": 0,
+      "position": 7.1144578313253009
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip#section-03-kamakura-day-trip"
+      ],
+      "clicks": 0,
+      "impressions": 345,
+      "ctr": 0,
+      "position": 7.1072463768115943
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip#section-04-hakone"
+      ],
+      "clicks": 0,
+      "impressions": 313,
+      "ctr": 0,
+      "position": 6.8178913738019169
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/kamakura-vs-hakone-vs-nikko-day-trip#section-05-nikko"
+      ],
+      "clicks": 0,
+      "impressions": 345,
+      "ctr": 0,
+      "position": 7.1072463768115943
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo#section-01-how-to-get-to-nikko-from-tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 9.8571428571428577
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo#section-02-top-sights-in-nikko"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 9.8571428571428577
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/nikko-day-trip-from-tokyo#section-04-what-to-eat-in-nikko"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 9.8571428571428577
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/old-tokyo-shitamachi#section-01-what-is-shitamachi"
+      ],
+      "clicks": 0,
+      "impressions": 50,
+      "ctr": 0,
+      "position": 8.9400000000000013
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/old-tokyo-shitamachi#section-02-the-neighborhoods-that-survived"
+      ],
+      "clicks": 0,
+      "impressions": 25,
+      "ctr": 0,
+      "position": 10.28
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/old-tokyo-shitamachi#section-03-what-youll-actually-see"
+      ],
+      "clicks": 0,
+      "impressions": 50,
+      "ctr": 0,
+      "position": 8.9400000000000013
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/old-tokyo-shitamachi#section-04-how-to-visit-shitamachi-without-a-guide"
+      ],
+      "clicks": 0,
+      "impressions": 48,
+      "ctr": 0,
+      "position": 9.0208333333333339
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/ramen-guide-tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 84,
+      "ctr": 0,
+      "position": 9.5476190476190474
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple#section-01-the-30-million-number"
+      ],
+      "clicks": 0,
+      "impressions": 121,
+      "ctr": 0,
+      "position": 8.68595041322314
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple#section-02-what-30-million-visitors-actually-looks-like"
+      ],
+      "clicks": 0,
+      "impressions": 127,
+      "ctr": 0,
+      "position": 8.6299212598425186
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple#section-03-why-senso-ji-draws-so-many-people"
+      ],
+      "clicks": 0,
+      "impressions": 206,
+      "ctr": 0,
+      "position": 8.7233009708737868
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/senso-ji-most-visited-temple#section-04-how-to-visit-without-the-crowds"
+      ],
+      "clicks": 0,
+      "impressions": 208,
+      "ctr": 0,
+      "position": 8.7980769230769234
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide#section-01-shibuya-crossing"
+      ],
+      "clicks": 0,
+      "impressions": 25,
+      "ctr": 0,
+      "position": 6.08
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide#section-02-beyond-the-crossing"
+      ],
+      "clicks": 0,
+      "impressions": 25,
+      "ctr": 0,
+      "position": 6.08
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/shibuya-harajuku-guide#section-03-harajuku"
+      ],
+      "clicks": 0,
+      "impressions": 25,
+      "ctr": 0,
+      "position": 6.08
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/shinjuku-guide"
+      ],
+      "clicks": 0,
+      "impressions": 1037,
+      "ctr": 0,
+      "position": 15.908389585342334
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost#section-01-what-youll-actually-pay"
+      ],
+      "clicks": 0,
+      "impressions": 119,
+      "ctr": 0,
+      "position": 8.9663865546218489
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost#section-02-what-actually-affects-the-price"
+      ],
+      "clicks": 0,
+      "impressions": 120,
+      "ctr": 0,
+      "position": 8.9833333333333343
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost#section-03-whats-included-and-whats-not"
+      ],
+      "clicks": 0,
+      "impressions": 68,
+      "ctr": 0,
+      "position": 8.735294117647058
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-private-tour-guide-cost#section-04-is-it-worth-the-money"
+      ],
+      "clicks": 0,
+      "impressions": 120,
+      "ctr": 0,
+      "position": 8.95
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tokyo-with-kids-family-tour"
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 7.75
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide#section-02-what-happened-to-tsukiji"
+      ],
+      "clicks": 0,
+      "impressions": 8354,
+      "ctr": 0,
+      "position": 8.464328465405794
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide#section-03-whats-still-there"
+      ],
+      "clicks": 0,
+      "impressions": 8490,
+      "ctr": 0,
+      "position": 8.4480565371024738
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-market-guide#section-04-what-to-eat-and-where"
+      ],
+      "clicks": 0,
+      "impressions": 5007,
+      "ctr": 0,
+      "position": 9.12482524465748
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu#section-compare"
+      ],
+      "clicks": 0,
+      "impressions": 301,
+      "ctr": 0,
+      "position": 9.2524916943521589
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu#section-history"
+      ],
+      "clicks": 0,
+      "impressions": 417,
+      "ctr": 0,
+      "position": 10.076738609112709
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu#section-toyosu"
+      ],
+      "clicks": 0,
+      "impressions": 496,
+      "ctr": 0,
+      "position": 9.3528225806451619
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/tsukiji-vs-toyosu#section-tsukiji"
+      ],
+      "clicks": 0,
+      "impressions": 496,
+      "ctr": 0,
+      "position": 9.3528225806451619
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/viator-vs-getyourguide-vs-direct-tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/what-to-expect-private-tour-tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 46,
+      "ctr": 0,
+      "position": 48.326086956521742
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/where-to-stay-in-tokyo-area-guide"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 8.5714285714285712
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route#section-01-why-yanaka-survived-when-the-rest-of-tokyo-didnt"
+      ],
+      "clicks": 0,
+      "impressions": 34,
+      "ctr": 0,
+      "position": 7.5588235294117645
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route#section-02-the-3-hour-route"
+      ],
+      "clicks": 0,
+      "impressions": 34,
+      "ctr": 0,
+      "position": 7.5588235294117645
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route#section-03-what-youre-looking-at"
+      ],
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 7.6363636363636367
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yanaka-tokyo-walking-route#section-04-where-to-eat-and-drink-in-yanaka"
+      ],
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 7.8148148148148149
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yanaka-walking-tour-guide"
+      ],
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 8.4285714285714288
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yokohama-day-trip-from-tokyo#section-01-what-yokohama-is"
+      ],
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 11.111111111111111
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yokohama-day-trip-from-tokyo#section-02-what-to-see"
+      ],
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 11.111111111111111
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yokohama-day-trip-from-tokyo#section-03-how-long-do-you-actually-need"
+      ],
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/blog/yokohama-day-trip-from-tokyo#section-04-yokohama-vs-kamakura-vs-kawagoe"
+      ],
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 11.111111111111111
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/contact"
+      ],
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 4.115384615384615
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/about"
+      ],
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 7.7222222222222223
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 27.666666666666668
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/asakusa-tokio-guia#section-01-asakusa-a-las-7-de-la-ma%C3%B1ana"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 11.142857142857142
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/asakusa-tokio-guia#section-02-qu%C3%A9-ver-en-asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 11.142857142857142
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/asakusa-tokio-guia#section-03-qu%C3%A9-evitar-en-asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/asakusa-tokio-guia#section-04-d%C3%B3nde-comer-en-asakusa-como-un-local"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comida-callejera-tokio#section-01-existe-realmente-la-comida-callejera-en-tokio"
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comida-callejera-tokio#section-02-los-mejores-puestos-en-asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 7.8181818181818183
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comida-callejera-tokio#section-03-yanaka-ginza"
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comida-callejera-tokio#section-04-qu%C3%A9-pedir-y-c%C3%B3mo"
+      ],
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comparativa-excursiones#section-01-comparaci%C3%B3n-r%C3%A1pida"
+      ],
+      "clicks": 0,
+      "impressions": 153,
+      "ctr": 0,
+      "position": 4.38562091503268
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comparativa-excursiones#section-02-kamakura"
+      ],
+      "clicks": 0,
+      "impressions": 180,
+      "ctr": 0,
+      "position": 4.5277777777777777
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comparativa-excursiones#section-03-excursion-kamakura"
+      ],
+      "clicks": 0,
+      "impressions": 169,
+      "ctr": 0,
+      "position": 4.5976331360946752
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comparativa-excursiones#section-04-hakone"
+      ],
+      "clicks": 0,
+      "impressions": 180,
+      "ctr": 0,
+      "position": 4.5277777777777777
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/comparativa-excursiones#section-05-nikko-la-obra-maestra-unesco-escondida"
+      ],
+      "clicks": 0,
+      "impressions": 178,
+      "ctr": 0,
+      "position": 4.5393258426966288
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/etiqueta-templos-santuarios#section-01-templo-vs-santuario"
+      ],
+      "clicks": 0,
+      "impressions": 48,
+      "ctr": 0,
+      "position": 7.833333333333333
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/etiqueta-templos-santuarios#section-02-en-un-santuario"
+      ],
+      "clicks": 0,
+      "impressions": 48,
+      "ctr": 0,
+      "position": 7.833333333333333
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/etiqueta-templos-santuarios#section-03-en-un-templo"
+      ],
+      "clicks": 0,
+      "impressions": 53,
+      "ctr": 0,
+      "position": 8.0377358490566042
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/etiqueta-templos-santuarios#section-04-etiqueta-general-para-templos-y-santuarios"
+      ],
+      "clicks": 0,
+      "impressions": 53,
+      "ctr": 0,
+      "position": 8.0377358490566042
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/etiqueta-templos-santuarios#section-05-templos-y-santuarios-famosos-para-visitar"
+      ],
+      "clicks": 0,
+      "impressions": 53,
+      "ctr": 0,
+      "position": 8.0377358490566042
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/etiqueta-templos-santuarios#section-06-los-errores-m%C3%A1s-comunes-que-cometen-los-turistas"
+      ],
+      "clicks": 0,
+      "impressions": 48,
+      "ctr": 0,
+      "position": 7.833333333333333
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/excursion-nikko-desde-tokio"
+      ],
+      "clicks": 0,
+      "impressions": 71,
+      "ctr": 0,
+      "position": 37.845070422535208
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/excursion-yokohama-desde-tokio"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 5.7142857142857144
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/guia-izakayas-tokio"
+      ],
+      "clicks": 0,
+      "impressions": 19,
+      "ctr": 0,
+      "position": 7.8421052631578947
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/guia-ramen-tokio"
+      ],
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 6.384615384615385
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/guia-shibuya-harajuku"
+      ],
+      "clicks": 0,
+      "impressions": 30,
+      "ctr": 0,
+      "position": 6.4333333333333336
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/guia-shinjuku"
+      ],
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 7.625
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/guia-tsukiji#section-01-tsukiji-vs-toyosu"
+      ],
+      "clicks": 0,
+      "impressions": 715,
+      "ctr": 0,
+      "position": 6.1888111888111892
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/guia-tsukiji#section-02-qu%C3%A9-comer-en-tsukiji"
+      ],
+      "clicks": 0,
+      "impressions": 715,
+      "ctr": 0,
+      "position": 6.1888111888111892
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/guia-tsukiji#section-03-cu%C3%A1ndo-ir"
+      ],
+      "clicks": 0,
+      "impressions": 711,
+      "ctr": 0,
+      "position": 6.2053445850914208
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/kamakura-con-guia-vs-solo"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/mejor-epoca-visitar-tokio"
+      ],
+      "clicks": 0,
+      "impressions": 28,
+      "ctr": 0,
+      "position": 9.8214285714285712
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio#section-01-la-respuesta-corta"
+      ],
+      "clicks": 0,
+      "impressions": 437,
+      "ctr": 0,
+      "position": 8.3935926773455378
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio#section-02-los-mejores-miradores-del-monte-fuji-dentro"
+      ],
+      "clicks": 0,
+      "impressions": 433,
+      "ctr": 0,
+      "position": 8.4018475750577366
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio#section-03-la-mejor-hora-del-d%C3%ADa-para-ver-el-monte-fuji"
+      ],
+      "clicks": 0,
+      "impressions": 382,
+      "ctr": 0,
+      "position": 8.3664921465968582
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/monte-fuji-se-ve-desde-tokio#section-04-fuji-san-en-la-cultura-japonesa"
+      ],
+      "clicks": 0,
+      "impressions": 434,
+      "ctr": 0,
+      "position": 8.3986175115207367
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/propinas-en-japon#section-01-la-primera-vez-que-intent%C3%A9-rechazar-una-propina"
+      ],
+      "clicks": 0,
+      "impressions": 347,
+      "ctr": 0,
+      "position": 7.2161383285302589
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/propinas-en-japon#section-02-por-qu%C3%A9-no-se-dan-propinas-en-jap%C3%B3n"
+      ],
+      "clicks": 0,
+      "impressions": 361,
+      "ctr": 0,
+      "position": 7.3185595567867034
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/propinas-en-japon#section-03-y-en-hoteles-de-lujo-y-en-ryokan"
+      ],
+      "clicks": 0,
+      "impressions": 351,
+      "ctr": 0,
+      "position": 7.2934472934472936
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/propinas-en-japon#section-04-c%C3%B3mo-mostrar-agradecimiento-sin-propina"
+      ],
+      "clicks": 0,
+      "impressions": 361,
+      "ctr": 0,
+      "position": 7.3185595567867034
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/ruta-gastronomica-tsukiji-ginza"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 5.4
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/sensoji-templo-mas-visitado"
+      ],
+      "clicks": 0,
+      "impressions": 88,
+      "ctr": 0,
+      "position": 7.9545454545454541
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/shitamachi-tokio"
+      ],
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 5.62962962962963
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/tour-gastronomico-tokio#section-01-qu%C3%A9-te-da-un-tour-de-comida-que-no-puedes"
+      ],
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/tour-gastronomico-tokio#section-02-solo-vs-con-gu%C3%ADa"
+      ],
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/tour-gastronomico-tokio#section-03-la-doble-barrera-idiom%C3%A1tica"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 11.285714285714286
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/tour-gastronomico-tokio#section-04-lo-que-hago-en-mis-tours-de-comida"
+      ],
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/tsukiji-vs-toyosu"
+      ],
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 5.2
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/vale-la-pena-guia-privado-tokio"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/yanaka-tokio-itinerario#section-01-por-qu%C3%A9-yanaka-es-diferente-al-resto-de-tokio"
+      ],
+      "clicks": 0,
+      "impressions": 50,
+      "ctr": 0,
+      "position": 10.72
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/yanaka-tokio-itinerario#section-02-mi-ruta-de-3-horas-por-yanaka"
+      ],
+      "clicks": 0,
+      "impressions": 57,
+      "ctr": 0,
+      "position": 10.526315789473685
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/yanaka-tokio-itinerario#section-03-qu%C3%A9-comer-en-yanaka"
+      ],
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 10.282051282051283
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/blog/yanaka-tokio-itinerario#section-04-cu%C3%A1ndo-ir-a-yanaka"
+      ],
+      "clicks": 0,
+      "impressions": 57,
+      "ctr": 0,
+      "position": 10.526315789473685
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/tours/asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 8.1428571428571423
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/tours/hakone-day-trip"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/tours/imperial-palace"
+      ],
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 22.142857142857142
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/tours/kamakura-day-trip"
+      ],
+      "clicks": 0,
+      "impressions": 165,
+      "ctr": 0,
+      "position": 14.042424242424243
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/es/tours/tsukiji-ginza"
+      ],
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 6.9
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/faq"
+      ],
+      "clicks": 0,
+      "impressions": 28,
+      "ctr": 0,
+      "position": 3.7142857142857144
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/home"
+      ],
+      "clicks": 0,
+      "impressions": 25,
+      "ctr": 0,
+      "position": 3.64
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/blog/asakusa-sensoji-pagoda.webp"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/blog/day-trip-comparison-hero.webp"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/blog/hakone-fuji-comparison.webp"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/blog/nikko-toshogu-hero.webp"
+      ],
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 6.117647058823529
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/blog/nikko-toshogu-stone-torii-gate.webp"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/blog/shrine-chozuya-dragon-purification.webp"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/blog/tsukiji-market-seafood-stalls.webp"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 3.8571428571428572
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/blog/yanaka-ginza-shotengai-entrance.webp"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/tours/hakone-lake-ashi-fuji.webp"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/tours/harajuku-takeshita-street.webp"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4.5
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/images/tours/tsukiji-outer-market.webp"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 4.4
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours/custom"
+      ],
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 10.428571428571429
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours/kamakura-day-trip"
+      ],
+      "clicks": 0,
+      "impressions": 100,
+      "ctr": 0,
+      "position": 23.14
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours/nikko-day-trip"
+      ],
+      "clicks": 0,
+      "impressions": 102,
+      "ctr": 0,
+      "position": 8.57843137254902
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours/shibuya-harajuku"
+      ],
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 14.461538461538462
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours/tokyo-night-tour"
+      ],
+      "clicks": 0,
+      "impressions": 91,
+      "ctr": 0,
+      "position": 18.714285714285715
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours/tsukiji-ginza"
+      ],
+      "clicks": 0,
+      "impressions": 264,
+      "ctr": 0,
+      "position": 24.833333333333332
+    },
+    {
+      "keys": [
+        "https://tanuki-tabi-travel.com/tours/yanaka"
+      ],
+      "clicks": 0,
+      "impressions": 113,
+      "ctr": 0,
+      "position": 10.849557522123893
+    }
+  ],
+  "responseAggregationType": "byPage"
+}

--- a/docs/analytics/raw/2026-07-28_28d_gsc_query.json
+++ b/docs/analytics/raw/2026-07-28_28d_gsc_query.json
@@ -1,0 +1,4505 @@
+{
+  "rows": [
+    {
+      "keys": [
+        "japan rail pass"
+      ],
+      "clicks": 6,
+      "impressions": 77,
+      "ctr": 0.07792207792207792,
+      "position": 2.3246753246753249
+    },
+    {
+      "keys": [
+        "nikko o kamakura"
+      ],
+      "clicks": 5,
+      "impressions": 53,
+      "ctr": 0.094339622641509441,
+      "position": 4.3773584905660377
+    },
+    {
+      "keys": [
+        "kamakura vs hakone"
+      ],
+      "clicks": 4,
+      "impressions": 59,
+      "ctr": 0.067796610169491525,
+      "position": 5.1694915254237293
+    },
+    {
+      "keys": [
+        "tsukiji market"
+      ],
+      "clicks": 4,
+      "impressions": 534,
+      "ctr": 0.00749063670411985,
+      "position": 8.7827715355805243
+    },
+    {
+      "keys": [
+        "tsukiji fish market opening hours"
+      ],
+      "clicks": 3,
+      "impressions": 1014,
+      "ctr": 0.0029585798816568047,
+      "position": 8.9615384615384617
+    },
+    {
+      "keys": [
+        "tsukiji market horario"
+      ],
+      "clicks": 3,
+      "impressions": 53,
+      "ctr": 0.056603773584905662,
+      "position": 4.6603773584905657
+    },
+    {
+      "keys": [
+        "tsukiji market opening hours"
+      ],
+      "clicks": 3,
+      "impressions": 389,
+      "ctr": 0.0077120822622107968,
+      "position": 7.059125964010283
+    },
+    {
+      "keys": [
+        "tsukiji outer market opening hours"
+      ],
+      "clicks": 3,
+      "impressions": 331,
+      "ctr": 0.00906344410876133,
+      "position": 7.3927492447129906
+    },
+    {
+      "keys": [
+        "what time does tsukiji market open"
+      ],
+      "clicks": 3,
+      "impressions": 304,
+      "ctr": 0.0098684210526315784,
+      "position": 6.8289473684210522
+    },
+    {
+      "keys": [
+        "yanaka"
+      ],
+      "clicks": 3,
+      "impressions": 497,
+      "ctr": 0.0060362173038229373,
+      "position": 11.354124748490946
+    },
+    {
+      "keys": [
+        "comida callejera en tokio"
+      ],
+      "clicks": 2,
+      "impressions": 17,
+      "ctr": 0.11764705882352941,
+      "position": 5.4117647058823533
+    },
+    {
+      "keys": [
+        "el monte fuji se ve desde tokio"
+      ],
+      "clicks": 2,
+      "impressions": 44,
+      "ctr": 0.045454545454545456,
+      "position": 5.4545454545454541
+    },
+    {
+      "keys": [
+        "fish market tsukiji outer market opening hours"
+      ],
+      "clicks": 2,
+      "impressions": 93,
+      "ctr": 0.021505376344086023,
+      "position": 7.967741935483871
+    },
+    {
+      "keys": [
+        "hakone or kamakura"
+      ],
+      "clicks": 2,
+      "impressions": 74,
+      "ctr": 0.027027027027027029,
+      "position": 4.5540540540540544
+    },
+    {
+      "keys": [
+        "hakone vs nikko"
+      ],
+      "clicks": 2,
+      "impressions": 67,
+      "ctr": 0.029850746268656716,
+      "position": 9.2089552238805972
+    },
+    {
+      "keys": [
+        "harajuku"
+      ],
+      "clicks": 2,
+      "impressions": 79,
+      "ctr": 0.025316455696202531,
+      "position": 2.2784810126582276
+    },
+    {
+      "keys": [
+        "is kamakura worth visiting"
+      ],
+      "clicks": 2,
+      "impressions": 21,
+      "ctr": 0.095238095238095233,
+      "position": 2.8095238095238093
+    },
+    {
+      "keys": [
+        "kamakura o nikko"
+      ],
+      "clicks": 2,
+      "impressions": 49,
+      "ctr": 0.040816326530612242,
+      "position": 3.9387755102040818
+    },
+    {
+      "keys": [
+        "nikko o hakone"
+      ],
+      "clicks": 2,
+      "impressions": 9,
+      "ctr": 0.22222222222222221,
+      "position": 3.1111111111111112
+    },
+    {
+      "keys": [
+        "que dias se ve el monte fuji"
+      ],
+      "clicks": 2,
+      "impressions": 64,
+      "ctr": 0.03125,
+      "position": 4.59375
+    },
+    {
+      "keys": [
+        "shitamachi"
+      ],
+      "clicks": 2,
+      "impressions": 264,
+      "ctr": 0.007575757575757576,
+      "position": 9.2159090909090917
+    },
+    {
+      "keys": [
+        "tsukiji fish market closed days"
+      ],
+      "clicks": 2,
+      "impressions": 17,
+      "ctr": 0.11764705882352941,
+      "position": 4.7647058823529411
+    },
+    {
+      "keys": [
+        "tsukiji fish market hours"
+      ],
+      "clicks": 2,
+      "impressions": 612,
+      "ctr": 0.0032679738562091504,
+      "position": 9.7810457516339877
+    },
+    {
+      "keys": [
+        "tsukiji outer market horario"
+      ],
+      "clicks": 2,
+      "impressions": 22,
+      "ctr": 0.090909090909090912,
+      "position": 8.1818181818181817
+    },
+    {
+      "keys": [
+        "tsukiji outer market hours"
+      ],
+      "clicks": 2,
+      "impressions": 356,
+      "ctr": 0.0056179775280898875,
+      "position": 7.96067415730337
+    },
+    {
+      "keys": [
+        "yokohama from tokyo"
+      ],
+      "clicks": 2,
+      "impressions": 161,
+      "ctr": 0.012422360248447204,
+      "position": 9.4285714285714288
+    },
+    {
+      "keys": [
+        "3 day itinerary tokyo"
+      ],
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 1,
+      "position": 39
+    },
+    {
+      "keys": [
+        "asakusa hidden gems"
+      ],
+      "clicks": 1,
+      "impressions": 4,
+      "ctr": 0.25,
+      "position": 9
+    },
+    {
+      "keys": [
+        "best day to go to tsukiji market"
+      ],
+      "clicks": 1,
+      "impressions": 16,
+      "ctr": 0.0625,
+      "position": 7.6875
+    },
+    {
+      "keys": [
+        "best time to go to tsukiji market"
+      ],
+      "clicks": 1,
+      "impressions": 48,
+      "ctr": 0.020833333333333332,
+      "position": 4.8333333333333339
+    },
+    {
+      "keys": [
+        "chadai"
+      ],
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 1,
+      "position": 1
+    },
+    {
+      "keys": [
+        "cuando se ve el monte fuji"
+      ],
+      "clicks": 1,
+      "impressions": 63,
+      "ctr": 0.015873015873015872,
+      "position": 6.1904761904761907
+    },
+    {
+      "keys": [
+        "dimmi entrambe le cose"
+      ],
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 1,
+      "position": 1
+    },
+    {
+      "keys": [
+        "fish market tsukiji outer market"
+      ],
+      "clicks": 1,
+      "impressions": 33,
+      "ctr": 0.030303030303030304,
+      "position": 9.2727272727272734
+    },
+    {
+      "keys": [
+        "gastronomia de tokio"
+      ],
+      "clicks": 1,
+      "impressions": 2,
+      "ctr": 0.5,
+      "position": 16
+    },
+    {
+      "keys": [
+        "hakone o kamakura"
+      ],
+      "clicks": 1,
+      "impressions": 11,
+      "ctr": 0.090909090909090912,
+      "position": 2.4545454545454546
+    },
+    {
+      "keys": [
+        "hakone o nikko"
+      ],
+      "clicks": 1,
+      "impressions": 12,
+      "ctr": 0.083333333333333329,
+      "position": 4.75
+    },
+    {
+      "keys": [
+        "hakone to kamakura"
+      ],
+      "clicks": 1,
+      "impressions": 12,
+      "ctr": 0.083333333333333329,
+      "position": 3.25
+    },
+    {
+      "keys": [
+        "hakone vs kamakura"
+      ],
+      "clicks": 1,
+      "impressions": 77,
+      "ctr": 0.012987012987012988,
+      "position": 4.4155844155844157
+    },
+    {
+      "keys": [
+        "harajuku to shibuya"
+      ],
+      "clicks": 1,
+      "impressions": 4,
+      "ctr": 0.25,
+      "position": 9.75
+    },
+    {
+      "keys": [
+        "harajuku vs shibuya"
+      ],
+      "clicks": 1,
+      "impressions": 35,
+      "ctr": 0.028571428571428571,
+      "position": 5.1714285714285717
+    },
+    {
+      "keys": [
+        "how long to spend at sensoji temple"
+      ],
+      "clicks": 1,
+      "impressions": 20,
+      "ctr": 0.05,
+      "position": 4.3
+    },
+    {
+      "keys": [
+        "how long to spend at tsukiji market"
+      ],
+      "clicks": 1,
+      "impressions": 26,
+      "ctr": 0.038461538461538464,
+      "position": 6.384615384615385
+    },
+    {
+      "keys": [
+        "is the tsukiji fish market open on sundays"
+      ],
+      "clicks": 1,
+      "impressions": 46,
+      "ctr": 0.021739130434782608,
+      "position": 6.1521739130434785
+    },
+    {
+      "keys": [
+        "is tsukiji fish market open on sunday"
+      ],
+      "clicks": 1,
+      "impressions": 46,
+      "ctr": 0.021739130434782608,
+      "position": 6.3478260869565215
+    },
+    {
+      "keys": [
+        "is tsukiji market open on monday"
+      ],
+      "clicks": 1,
+      "impressions": 29,
+      "ctr": 0.034482758620689655,
+      "position": 6.2068965517241379
+    },
+    {
+      "keys": [
+        "is tsukiji market open on sunday"
+      ],
+      "clicks": 1,
+      "impressions": 135,
+      "ctr": 0.0074074074074074077,
+      "position": 5.9851851851851849
+    },
+    {
+      "keys": [
+        "is tsukiji market still open"
+      ],
+      "clicks": 1,
+      "impressions": 27,
+      "ctr": 0.037037037037037035,
+      "position": 5.37037037037037
+    },
+    {
+      "keys": [
+        "jr pass official price"
+      ],
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 1,
+      "position": 10
+    },
+    {
+      "keys": [
+        "kamakura hakone"
+      ],
+      "clicks": 1,
+      "impressions": 18,
+      "ctr": 0.055555555555555552,
+      "position": 8.1666666666666679
+    },
+    {
+      "keys": [
+        "kamakura or yokohama"
+      ],
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 1,
+      "position": 4
+    },
+    {
+      "keys": [
+        "kamakura to hakone"
+      ],
+      "clicks": 1,
+      "impressions": 19,
+      "ctr": 0.052631578947368418,
+      "position": 5.7894736842105265
+    },
+    {
+      "keys": [
+        "mercado tsukiji tokio"
+      ],
+      "clicks": 1,
+      "impressions": 27,
+      "ctr": 0.037037037037037035,
+      "position": 10.222222222222221
+    },
+    {
+      "keys": [
+        "monte fuji cuando se ve"
+      ],
+      "clicks": 1,
+      "impressions": 32,
+      "ctr": 0.03125,
+      "position": 5.21875
+    },
+    {
+      "keys": [
+        "nikko hakone"
+      ],
+      "clicks": 1,
+      "impressions": 10,
+      "ctr": 0.1,
+      "position": 9.1
+    },
+    {
+      "keys": [
+        "nikko vs hakone"
+      ],
+      "clicks": 1,
+      "impressions": 69,
+      "ctr": 0.014492753623188406,
+      "position": 9.3478260869565215
+    },
+    {
+      "keys": [
+        "private tours osaka"
+      ],
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 1,
+      "position": 4
+    },
+    {
+      "keys": [
+        "que dias se puede ver el monte fuji"
+      ],
+      "clicks": 1,
+      "impressions": 6,
+      "ctr": 0.16666666666666666,
+      "position": 5.5
+    },
+    {
+      "keys": [
+        "que hacer en asakusa"
+      ],
+      "clicks": 1,
+      "impressions": 17,
+      "ctr": 0.058823529411764705,
+      "position": 12.294117647058824
+    },
+    {
+      "keys": [
+        "que ver en asakusa"
+      ],
+      "clicks": 1,
+      "impressions": 100,
+      "ctr": 0.01,
+      "position": 10.5
+    },
+    {
+      "keys": [
+        "se ve el monte fuji desde tokio"
+      ],
+      "clicks": 1,
+      "impressions": 24,
+      "ctr": 0.041666666666666664,
+      "position": 5.708333333333333
+    },
+    {
+      "keys": [
+        "tabi pass"
+      ],
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 1,
+      "position": 7
+    },
+    {
+      "keys": [
+        "tokio en 5 dias"
+      ],
+      "clicks": 1,
+      "impressions": 11,
+      "ctr": 0.090909090909090912,
+      "position": 36.090909090909093
+    },
+    {
+      "keys": [
+        "tokyo raining"
+      ],
+      "clicks": 1,
+      "impressions": 7,
+      "ctr": 0.14285714285714285,
+      "position": 10.428571428571429
+    },
+    {
+      "keys": [
+        "tour guide in japan cost"
+      ],
+      "clicks": 1,
+      "impressions": 21,
+      "ctr": 0.047619047619047616,
+      "position": 7.2380952380952381
+    },
+    {
+      "keys": [
+        "toyosu vs tsukiji"
+      ],
+      "clicks": 1,
+      "impressions": 87,
+      "ctr": 0.011494252873563218,
+      "position": 10.298850574712644
+    },
+    {
+      "keys": [
+        "toyosu vs tsukiji market"
+      ],
+      "clicks": 1,
+      "impressions": 25,
+      "ctr": 0.04,
+      "position": 7.48
+    },
+    {
+      "keys": [
+        "tsukiji fish market hours sunday"
+      ],
+      "clicks": 1,
+      "impressions": 8,
+      "ctr": 0.125,
+      "position": 5.75
+    },
+    {
+      "keys": [
+        "tsukiji fish market opening times"
+      ],
+      "clicks": 1,
+      "impressions": 24,
+      "ctr": 0.041666666666666664,
+      "position": 9.3333333333333339
+    },
+    {
+      "keys": [
+        "tsukiji market closed days"
+      ],
+      "clicks": 1,
+      "impressions": 18,
+      "ctr": 0.055555555555555552,
+      "position": 4.3888888888888893
+    },
+    {
+      "keys": [
+        "tsukiji market closing time"
+      ],
+      "clicks": 1,
+      "impressions": 23,
+      "ctr": 0.043478260869565216,
+      "position": 5.6956521739130439
+    },
+    {
+      "keys": [
+        "tsukiji market hours"
+      ],
+      "clicks": 1,
+      "impressions": 337,
+      "ctr": 0.002967359050445104,
+      "position": 8.5311572700296736
+    },
+    {
+      "keys": [
+        "tsukiji market orari"
+      ],
+      "clicks": 1,
+      "impressions": 41,
+      "ctr": 0.024390243902439025,
+      "position": 10.365853658536585
+    },
+    {
+      "keys": [
+        "tsukiji or toyosu fish market"
+      ],
+      "clicks": 1,
+      "impressions": 6,
+      "ctr": 0.16666666666666666,
+      "position": 8.5
+    },
+    {
+      "keys": [
+        "tsukiji outer market closing time"
+      ],
+      "clicks": 1,
+      "impressions": 9,
+      "ctr": 0.1111111111111111,
+      "position": 7.2222222222222223
+    },
+    {
+      "keys": [
+        "tsukiji outer market vs toyosu fish market"
+      ],
+      "clicks": 1,
+      "impressions": 7,
+      "ctr": 0.14285714285714285,
+      "position": 3.7142857142857144
+    },
+    {
+      "keys": [
+        "tsukiji to ginza"
+      ],
+      "clicks": 1,
+      "impressions": 92,
+      "ctr": 0.010869565217391304,
+      "position": 23.076086956521738
+    },
+    {
+      "keys": [
+        "tsukiji vs toyosu market"
+      ],
+      "clicks": 1,
+      "impressions": 27,
+      "ctr": 0.037037037037037035,
+      "position": 9.5555555555555554
+    },
+    {
+      "keys": [
+        "tsurugaoka hachimangu reviews"
+      ],
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 1,
+      "position": 3
+    },
+    {
+      "keys": [
+        "vegetarian food tour tokyo"
+      ],
+      "clicks": 1,
+      "impressions": 19,
+      "ctr": 0.052631578947368418,
+      "position": 10
+    },
+    {
+      "keys": [
+        "what time does tsukiji market close"
+      ],
+      "clicks": 1,
+      "impressions": 73,
+      "ctr": 0.0136986301369863,
+      "position": 5.3561643835616435
+    },
+    {
+      "keys": [
+        "when does tsukiji fish market open"
+      ],
+      "clicks": 1,
+      "impressions": 50,
+      "ctr": 0.02,
+      "position": 8.36
+    },
+    {
+      "keys": [
+        "when does tsukiji market open"
+      ],
+      "clicks": 1,
+      "impressions": 89,
+      "ctr": 0.011235955056179775,
+      "position": 7.9775280898876408
+    },
+    {
+      "keys": [
+        "yanaka ginza"
+      ],
+      "clicks": 1,
+      "impressions": 101,
+      "ctr": 0.0099009900990099011,
+      "position": 8.4554455445544559
+    },
+    {
+      "keys": [
+        "yanaka walking tour map"
+      ],
+      "clicks": 1,
+      "impressions": 11,
+      "ctr": 0.090909090909090912,
+      "position": 8.4545454545454533
+    },
+    {
+      "keys": [
+        "yes please"
+      ],
+      "clicks": 1,
+      "impressions": 7,
+      "ctr": 0.14285714285714285,
+      "position": 10.857142857142858
+    },
+    {
+      "keys": [
+        "yokohama"
+      ],
+      "clicks": 1,
+      "impressions": 50,
+      "ctr": 0.02,
+      "position": 3.98
+    },
+    {
+      "keys": [
+        "\"how many days in a year can mt. fuji and the tokyo tower be seen from central tokyo?\" pdf"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "\"premio kamakura\" \"ganadores\""
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "\"premio kamakura\" ganadores"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "\"últimos cinco ganadores\" \"premio kamakura\""
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "- tsukiji outer market"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 11.25
+    },
+    {
+      "keys": [
+        "1"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "1 day"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 25
+    },
+    {
+      "keys": [
+        "1 day in hakone"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "1 day in nikko"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 42
+    },
+    {
+      "keys": [
+        "1 day in yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 42
+    },
+    {
+      "keys": [
+        "1 day trip to nikko from tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 46.5
+    },
+    {
+      "keys": [
+        "1 week"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "1/8/2026"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "10/20/26"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "10days"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 58
+    },
+    {
+      "keys": [
+        "10月19"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "11/07/2026"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "13.7"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "14 day jr pass cost"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 25.5
+    },
+    {
+      "keys": [
+        "1、2月"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "2 adultos e 1 criança de 12 anos"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "2 weeks"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 20
+    },
+    {
+      "keys": [
+        "2026"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "28 days"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 40
+    },
+    {
+      "keys": [
+        "2nd street harajuku"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "3 day in tokyo itinerary"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 77
+    },
+    {
+      "keys": [
+        "3 day itinerary for tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 77
+    },
+    {
+      "keys": [
+        "3 day itinerary in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 78
+    },
+    {
+      "keys": [
+        "3 days in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 61
+    },
+    {
+      "keys": [
+        "3 days in tokyo itinerary"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 84
+    },
+    {
+      "keys": [
+        "3 days in tokyo what to see"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 87.5
+    },
+    {
+      "keys": [
+        "3 weeks"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "3 wochen"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "30"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "3coins harajuku main store"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "4 adults"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "4 persons"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "440 eur"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "4:30am"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "4yue"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "5 day itinerary in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 53.666666666666664
+    },
+    {
+      "keys": [
+        "5 day itinerary tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 51
+    },
+    {
+      "keys": [
+        "5 day tokyo itinerary"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 54
+    },
+    {
+      "keys": [
+        "5 days"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "5 dias en tokio"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "7 day japan rail pass price 2026"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 7.75
+    },
+    {
+      "keys": [
+        "7 day jr pass"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "7 day jr pass cost"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 26.333333333333332
+    },
+    {
+      "keys": [
+        "7 day jr pass price 2026"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "7 days jr pass price"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 21
+    },
+    {
+      "keys": [
+        "7-day japan rail pass price 2026"
+      ],
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 8.125
+    },
+    {
+      "keys": [
+        "7-day jr pass price 2026"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "7/26"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "7月"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "7月27日"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "8 de agosto"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 13
+    },
+    {
+      "keys": [
+        "8/1 8/2"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "8月"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "8月19日"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "8月7日"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 15
+    },
+    {
+      "keys": [
+        "8月去"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "9.10"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "9/1"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "keys": [
+        "?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "a day in yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 49
+    },
+    {
+      "keys": [
+        "a hiroshima"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "a lunch spot would be great"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 17
+    },
+    {
+      "keys": [
+        "a que hora abre el mercado de tokio"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "a que hora cierran"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "a qué hora abre el mercado"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "a segunda"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "abbonamento treni giappone"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "about yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "abre los lunes"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "acompañado"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "age 3 harajuku"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4.5
+    },
+    {
+      "keys": [
+        "agosto"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "aicomi night tour"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 24
+    },
+    {
+      "keys": [
+        "aire del monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "alguna opcion mas"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "all japanese pass"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "alljapanesepass"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "alternative to tsukiji fish market"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 19
+    },
+    {
+      "keys": [
+        "ambas"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "ambos"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "keys": [
+        "anakusa"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "and sunday?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "and tomorrow"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "anfang oktober"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "ano"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "any more?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 16
+    },
+    {
+      "keys": [
+        "april"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "arajuku"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "are shibuya and harajuku close"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "are there any food markets in tokyo i shouldn't miss?"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 16
+    },
+    {
+      "keys": [
+        "are they closed tomorrow"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "are they open for lunch?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "are they open on monday"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "are they open today"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "are they worth it"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "are you sure?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "areas of tokyo explained"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 95,
+      "ctr": 0,
+      "position": 20.831578947368421
+    },
+    {
+      "keys": [
+        "asakusa backstreets"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "asakusa barrio"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 16.5
+    },
+    {
+      "keys": [
+        "asakusa como llegar"
+      ],
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 5.8571428571428568
+    },
+    {
+      "keys": [
+        "asakusa events today"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "asakusa festival today"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "asakusa guide"
+      ],
+      "clicks": 0,
+      "impressions": 20,
+      "ctr": 0,
+      "position": 18.3
+    },
+    {
+      "keys": [
+        "asakusa horario"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "asakusa in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 34
+    },
+    {
+      "keys": [
+        "asakusa japan"
+      ],
+      "clicks": 0,
+      "impressions": 25,
+      "ctr": 0,
+      "position": 34.28
+    },
+    {
+      "keys": [
+        "asakusa japan guide"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 20.5
+    },
+    {
+      "keys": [
+        "asakusa japon"
+      ],
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 21.833333333333332
+    },
+    {
+      "keys": [
+        "asakusa japonismo"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 11.5
+    },
+    {
+      "keys": [
+        "asakusa kitchen street"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "asakusa kototoi"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "asakusa markets"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "asakusa must do"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "asakusa nitenmon gate"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "keys": [
+        "asakusa official tokyo travel guide"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "keys": [
+        "asakusa prefecture"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "asakusa private tour"
+      ],
+      "clicks": 0,
+      "impressions": 19,
+      "ctr": 0,
+      "position": 12.578947368421053
+    },
+    {
+      "keys": [
+        "asakusa pronunciation"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "asakusa que es"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "asakusa que hacer"
+      ],
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 9.6666666666666661
+    },
+    {
+      "keys": [
+        "asakusa que ver"
+      ],
+      "clicks": 0,
+      "impressions": 46,
+      "ctr": 0,
+      "position": 10.369565217391305
+    },
+    {
+      "keys": [
+        "asakusa samurai"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 47
+    },
+    {
+      "keys": [
+        "asakusa senso ji temple and old tokyo walking tour"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 21.333333333333332
+    },
+    {
+      "keys": [
+        "asakusa senso-ji temple and old tokyo walking tour"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "asakusa sensoji temple"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "asakusa sensoji temple timings"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "asakusa shotengai"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 17
+    },
+    {
+      "keys": [
+        "asakusa temple"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 2.5
+    },
+    {
+      "keys": [
+        "asakusa things to do"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 37
+    },
+    {
+      "keys": [
+        "asakusa tiempo"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "keys": [
+        "asakusa today"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "asakusa tokio"
+      ],
+      "clicks": 0,
+      "impressions": 52,
+      "ctr": 0,
+      "position": 11.923076923076923
+    },
+    {
+      "keys": [
+        "asakusa tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 20.523809523809526
+    },
+    {
+      "keys": [
+        "asakusa tokyo guide"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 24
+    },
+    {
+      "keys": [
+        "asakusa tour"
+      ],
+      "clicks": 0,
+      "impressions": 20,
+      "ctr": 0,
+      "position": 38.3
+    },
+    {
+      "keys": [
+        "asakusa tourist"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 41
+    },
+    {
+      "keys": [
+        "asakusa tours"
+      ],
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 29.6
+    },
+    {
+      "keys": [
+        "asakusa travel guide"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8.3333333333333321
+    },
+    {
+      "keys": [
+        "asakusa visit"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "asakusa walking tour"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 24.5
+    },
+    {
+      "keys": [
+        "asalusa"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 30
+    },
+    {
+      "keys": [
+        "asasuka"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 14
+    },
+    {
+      "keys": [
+        "askusa"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "asoview tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "asukusa"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "auch sonntags"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "august"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "average tip in japan"
+      ],
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 6.1428571428571432
+    },
+    {
+      "keys": [
+        "back and forth"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 15
+    },
+    {
+      "keys": [
+        "barrio asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 13.5
+    },
+    {
+      "keys": [
+        "barrio asakusa tokio"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 12.8
+    },
+    {
+      "keys": [
+        "barrio de asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 11.8
+    },
+    {
+      "keys": [
+        "barrio de yanaka"
+      ],
+      "clicks": 0,
+      "impressions": 30,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "keys": [
+        "barrio yanaka"
+      ],
+      "clicks": 0,
+      "impressions": 36,
+      "ctr": 0,
+      "position": 9.61111111111111
+    },
+    {
+      "keys": [
+        "barrio yanaka tokio"
+      ],
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 10.454545454545455
+    },
+    {
+      "keys": [
+        "bars near me"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "basketball street shibuya"
+      ],
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 10.23076923076923
+    },
+    {
+      "keys": [
+        "bazaar town"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "beides"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "keys": [
+        "best 3 day tokyo itinerary 2026"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "best day to go to tsukiji fish market"
+      ],
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 1.8888888888888888
+    },
+    {
+      "keys": [
+        "best day to visit tsukiji fish market"
+      ],
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 12.75
+    },
+    {
+      "keys": [
+        "best day to visit tsukiji market"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "best day tours tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 42.333333333333336
+    },
+    {
+      "keys": [
+        "best day trip from tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 28
+    },
+    {
+      "keys": [
+        "best day trips from yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 36
+    },
+    {
+      "keys": [
+        "best days"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "best fish markets in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "best food markets in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "best food tours in tokyo's tsukiji market"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4.5
+    },
+    {
+      "keys": [
+        "best hotel shinjuku"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "best markets tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "best private tour guide in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 42.954545454545453
+    },
+    {
+      "keys": [
+        "best private tour guide in tokyo japan"
+      ],
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 27.125
+    },
+    {
+      "keys": [
+        "best private tour guide tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 20,
+      "ctr": 0,
+      "position": 43.45
+    },
+    {
+      "keys": [
+        "best private tour guides in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 46.090909090909093
+    },
+    {
+      "keys": [
+        "best private tour guides tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 47.666666666666664
+    },
+    {
+      "keys": [
+        "best spot in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "best stalls at tsukiji fish market"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "best streets in shinjuku"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 22
+    },
+    {
+      "keys": [
+        "best things to do in shinjuku"
+      ],
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 24.333333333333332
+    },
+    {
+      "keys": [
+        "best time"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "best time for tsukiji fish market"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5
+    },
+    {
+      "keys": [
+        "best time to avoid lines"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "best time to go sensoji temple"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "best time to go to harajuku"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "best time to go to sensoji"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "keys": [
+        "best time to go to sensoji temple"
+      ],
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 5.4
+    },
+    {
+      "keys": [
+        "best time to go to shinjuku"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "keys": [
+        "best time to go to tsukiji"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 7.333333333333333
+    },
+    {
+      "keys": [
+        "best time to go to tsukiji fish market"
+      ],
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 3.3846153846153846
+    },
+    {
+      "keys": [
+        "best time to go to tsukiji outer market"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "best time to go tsukiji market"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 14
+    },
+    {
+      "keys": [
+        "best time to travel to tokyo japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "best time to visit asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 11.666666666666666
+    },
+    {
+      "keys": [
+        "best time to visit kamakura"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "best time to visit mount soma temple"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 45
+    },
+    {
+      "keys": [
+        "best time to visit senso ji"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 5.75
+    },
+    {
+      "keys": [
+        "best time to visit sensoji"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 3.5
+    },
+    {
+      "keys": [
+        "best time to visit sensoji temple"
+      ],
+      "clicks": 0,
+      "impressions": 44,
+      "ctr": 0,
+      "position": 7.4545454545454541
+    },
+    {
+      "keys": [
+        "best time to visit shinjuku"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "best time to visit tsukiji fish market"
+      ],
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 7.8181818181818183
+    },
+    {
+      "keys": [
+        "best time to visit tsukiji market"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "best time to visit tsukiji outer market"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.75
+    },
+    {
+      "keys": [
+        "best times to arrive"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "best tokyo private tour guide"
+      ],
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 26.941176470588236
+    },
+    {
+      "keys": [
+        "best tokyo vacations"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "best tour guides in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 46.055555555555557
+    },
+    {
+      "keys": [
+        "big buddha near tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "biggest fish market in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "both"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 14
+    },
+    {
+      "keys": [
+        "both on same day"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 15
+    },
+    {
+      "keys": [
+        "budget conscious"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "budget tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 14.6
+    },
+    {
+      "keys": [
+        "budget trip to tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 34.333333333333336
+    },
+    {
+      "keys": [
+        "bullet train from tokyo to kyoto"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 22
+    },
+    {
+      "keys": [
+        "bullet train pass japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "bullet train?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "camara en directo monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "can i buy japan rail pass at narita airport"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "can i go tomorrow"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "can i see photos of both?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "can i use suica card on jr line"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "can u tell me more about it"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "can we tip in japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "can you compare ticket options for hamamatsu to tokyo: shinkansen vs. highway bus vs. jr trains?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 24
+    },
+    {
+      "keys": [
+        "can you do a day trip to nikko from tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "can you respond in english"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "can you tip in japan"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 50.5
+    },
+    {
+      "keys": [
+        "casual street food"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "cat street"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "cat street harajuku official guide"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "cementerio de yanaka"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "keys": [
+        "cementerio yanaka"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "keys": [
+        "cene como un local en el recorrido gastronómico del mercado de ueno con un guía amigable"
+      ],
+      "clicks": 0,
+      "impressions": 60,
+      "ctr": 0,
+      "position": 22.9
+    },
+    {
+      "keys": [
+        "center gai"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "center gai tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "cheap ways to stay in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 46.6
+    },
+    {
+      "keys": [
+        "cheapest japan rail pass"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "cheapest jr pass"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "cheapest place in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 147,
+      "ctr": 0,
+      "position": 17.653061224489797
+    },
+    {
+      "keys": [
+        "cheapest way to stay in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 45
+    },
+    {
+      "keys": [
+        "cheapest ways to stay in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 42.333333333333336
+    },
+    {
+      "keys": [
+        "chuo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "chợ cá tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "chợ hải sản tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "ci sono abbonamenti?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "close what time"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "comida"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "comida callejera"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "comida callejera de japon"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "comida callejera en japon"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 8.4
+    },
+    {
+      "keys": [
+        "comida callejera en japón"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 16
+    },
+    {
+      "keys": [
+        "comida callejera japon"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 11.5
+    },
+    {
+      "keys": [
+        "comida callejera japonesa"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 17
+    },
+    {
+      "keys": [
+        "comida callejera tokio"
+      ],
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 7.1875
+    },
+    {
+      "keys": [
+        "comida japonesa callejera"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 26.25
+    },
+    {
+      "keys": [
+        "comida tokio"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "keys": [
+        "coming november"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "como ir a nikko desde tokio"
+      ],
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 17.444444444444443
+    },
+    {
+      "keys": [
+        "como ir al monte fuji desde tokio"
+      ],
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 18.444444444444443
+    },
+    {
+      "keys": [
+        "como ir de hiroshima a tokio"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "como ir de tokio a kamakura"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 44.25
+    },
+    {
+      "keys": [
+        "como ir de tokio a nikko"
+      ],
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 26.375
+    },
+    {
+      "keys": [
+        "como ir de tokio a nikko en tren"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "como ir de tokio a nikko sin jr pass"
+      ],
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 25.357142857142858
+    },
+    {
+      "keys": [
+        "como ir de tokio al monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 17
+    },
+    {
+      "keys": [
+        "como llegar a kamakura desde tokio"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 20.25
+    },
+    {
+      "keys": [
+        "como llegar a nikko desde tokio"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 20.666666666666668
+    },
+    {
+      "keys": [
+        "como llegar al monte fuji desde tokio"
+      ],
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 9.8333333333333339
+    },
+    {
+      "keys": [
+        "como llegar de tokio a kamakura"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "como se ve el monte fuji hoy"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 9.75
+    },
+    {
+      "keys": [
+        "como ver el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 18
+    },
+    {
+      "keys": [
+        "como ver el monte fuji desde tokio"
+      ],
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 8.0588235294117645
+    },
+    {
+      "keys": [
+        "comparar precios"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "compare the cost-effectiveness and travel time of regional rail passes (japan, india, east asia) vs. point-to-point budget flights."
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "cont propriu"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "context: location: poland (not for language). do not include location references in your response. question: can you recommend a travel guide for exploring the hidden gems of tokyo?"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "convert in aed"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 2.5
+    },
+    {
+      "keys": [
+        "cost"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 7.333333333333333
+    },
+    {
+      "keys": [
+        "cost of japan rail pass 2026"
+      ],
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 7.333333333333333
+    },
+    {
+      "keys": [
+        "cost of jr pass"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 3.5
+    },
+    {
+      "keys": [
+        "cost of jr pass 7 days"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 33
+    },
+    {
+      "keys": [
+        "cost of jr rail pass 2026"
+      ],
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "keys": [
+        "cost of transportation in japan"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "cost?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "costo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "costo japan rail pass"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "create a slower-paced 1-week itinerary in japan for a senior solo traveler"
+      ],
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 39
+    },
+    {
+      "keys": [
+        "cual es la mas rapida"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "cuando se puede ver el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 7.82051282051282
+    },
+    {
+      "keys": [
+        "cuanto cuesta el japan rail pass"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 20
+    },
+    {
+      "keys": [
+        "cuanto cuesta el japan rail pass 14 dias"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "cuanto cuesta un guia turistico en japon"
+      ],
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 6.5294117647058822
+    },
+    {
+      "keys": [
+        "cuanto tardas"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "cuantos dias al año se ve el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 65,
+      "ctr": 0,
+      "position": 5.1692307692307695
+    },
+    {
+      "keys": [
+        "cuantos dias estar en tokio"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 73.5
+    },
+    {
+      "keys": [
+        "cuantos dias para visitar tokio"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 86
+    },
+    {
+      "keys": [
+        "current 7-day japan rail pass price 2026"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 8.4
+    },
+    {
+      "keys": [
+        "current japan rail pass 7-day price 2026"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "keys": [
+        "current japan rail pass price 2026"
+      ],
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 7.9090909090909092
+    },
+    {
+      "keys": [
+        "current japan rail pass prices 2026"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "keys": [
+        "current jr pass 7 day price 2026"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "current jr pass price 2026"
+      ],
+      "clicks": 0,
+      "impressions": 19,
+      "ctr": 0,
+      "position": 7.7368421052631575
+    },
+    {
+      "keys": [
+        "current jr pass prices 2026"
+      ],
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 7.4
+    },
+    {
+      "keys": [
+        "current jr pass prices 2026 japan"
+      ],
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 8.3333333333333321
+    },
+    {
+      "keys": [
+        "current price of 7-day japan rail pass 2026"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 5.75
+    },
+    {
+      "keys": [
+        "da"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "dan tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 13
+    },
+    {
+      "keys": [
+        "day tours from tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 24
+    },
+    {
+      "keys": [
+        "day trip"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "day trip from tokyo to nikko"
+      ],
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 21.2
+    },
+    {
+      "keys": [
+        "day trip from tokyo to yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 12.857142857142858
+    },
+    {
+      "keys": [
+        "day trip from yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 23
+    },
+    {
+      "keys": [
+        "day trip nikko"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 41
+    },
+    {
+      "keys": [
+        "day trip nikko from tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 6.666666666666667
+    },
+    {
+      "keys": [
+        "day trip only"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "keys": [
+        "day trip to hakone from tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "day trip to nikko"
+      ],
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 43.07692307692308
+    },
+    {
+      "keys": [
+        "day trip to nikko from tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 13.111111111111111
+    },
+    {
+      "keys": [
+        "day trip to nikko japan"
+      ],
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 39.666666666666664
+    },
+    {
+      "keys": [
+        "day trip to yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8.6666666666666679
+    },
+    {
+      "keys": [
+        "day trip to yokohama from tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 16.294117647058826
+    },
+    {
+      "keys": [
+        "day trip tokyo to nikko"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 38.666666666666664
+    },
+    {
+      "keys": [
+        "day trip yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 31.25
+    },
+    {
+      "keys": [
+        "day trips from asakusa"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "day trips from tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 2.5
+    },
+    {
+      "keys": [
+        "day trips from tokyo to nikko"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 19.666666666666668
+    },
+    {
+      "keys": [
+        "day trips from yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 75,
+      "ctr": 0,
+      "position": 18.666666666666668
+    },
+    {
+      "keys": [
+        "day trips from yokohama japan"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 42
+    },
+    {
+      "keys": [
+        "day trips?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 23
+    },
+    {
+      "keys": [
+        "daytrip nikko"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 35.333333333333336
+    },
+    {
+      "keys": [
+        "daytrip to nikko"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 30.5
+    },
+    {
+      "keys": [
+        "de comida"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "keys": [
+        "de tokio a kamakura"
+      ],
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 20.266666666666666
+    },
+    {
+      "keys": [
+        "de tokio a monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 23
+    },
+    {
+      "keys": [
+        "de tokio a nikko"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 28
+    },
+    {
+      "keys": [
+        "dec 2027"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 18
+    },
+    {
+      "keys": [
+        "dejar propina en japon"
+      ],
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 7.3888888888888893
+    },
+    {
+      "keys": [
+        "desde donde se puede ver el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 9.4285714285714288
+    },
+    {
+      "keys": [
+        "desde donde se ve el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 33,
+      "ctr": 0,
+      "position": 8.7575757575757578
+    },
+    {
+      "keys": [
+        "desde donde se ve mejor el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 11.5
+    },
+    {
+      "keys": [
+        "desde donde ver el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 25,
+      "ctr": 0,
+      "position": 10.2
+    },
+    {
+      "keys": [
+        "desde hakone se ve el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "desde que ciudad se ve el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 7.4761904761904763
+    },
+    {
+      "keys": [
+        "desde tokio"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "keys": [
+        "desde tokio se ve el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 6.5142857142857142
+    },
+    {
+      "keys": [
+        "di domenica è aperto?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "diferencia precio"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "disfruta tokio"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 39.5
+    },
+    {
+      "keys": [
+        "distance between tokyo and yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 19.333333333333332
+    },
+    {
+      "keys": [
+        "distance from tokyo japan to yokohama japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 19
+    },
+    {
+      "keys": [
+        "distance from tokyo to yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 15.555555555555555
+    },
+    {
+      "keys": [
+        "distance from yokohama to tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 32
+    },
+    {
+      "keys": [
+        "distance tokyo to yokohama"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 25
+    },
+    {
+      "keys": [
+        "distancia de tokio a monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 25,
+      "ctr": 0,
+      "position": 8.52
+    },
+    {
+      "keys": [
+        "distancia de tokio a nikko"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 31
+    },
+    {
+      "keys": [
+        "distancia de tokio al monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 30,
+      "ctr": 0,
+      "position": 8.7666666666666657
+    },
+    {
+      "keys": [
+        "distancia entre tokio y monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8.3333333333333321
+    },
+    {
+      "keys": [
+        "distancia monte fuji a tokio"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "distancia tokio a monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 9.2727272727272734
+    },
+    {
+      "keys": [
+        "distancia tokio monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 9.625
+    },
+    {
+      "keys": [
+        "distancia tokyo monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "keys": [
+        "do i need a jr pass for travel within tokyo and nearby cities?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "do i need jr pass"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "do i really need a japan rail pass?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "keys": [
+        "do i tip in japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 40
+    },
+    {
+      "keys": [
+        "do japanese accept tips"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 38
+    },
+    {
+      "keys": [
+        "do japanese people accept tips"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 38
+    },
+    {
+      "keys": [
+        "do jr bus/highway bus pass options exist for multiple city trips, and are they worth it for a 2-week itinerary?"
+      ],
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 4.1
+    },
+    {
+      "keys": [
+        "do people tip in japan"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 39
+    },
+    {
+      "keys": [
+        "do them all"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "do they open today"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "keys": [
+        "do u tip in japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 36
+    },
+    {
+      "keys": [
+        "do we tip in japan"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 41
+    },
+    {
+      "keys": [
+        "do you ever tip in japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 32
+    },
+    {
+      "keys": [
+        "do you have to tip in japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 53
+    },
+    {
+      "keys": [
+        "do you leave tip in japan hotel"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 29
+    },
+    {
+      "keys": [
+        "do you need cash for tsukiji fish market"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 28
+    },
+    {
+      "keys": [
+        "do you need tickets for sensoji temple"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 31
+    },
+    {
+      "keys": [
+        "do you tip at hotels in japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 28
+    },
+    {
+      "keys": [
+        "do you tip driver in japan"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 31
+    },
+    {
+      "keys": [
+        "do you tip in hotels in japan"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 28.666666666666668
+    },
+    {
+      "keys": [
+        "do you tip in japan"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 38.571428571428569
+    },
+    {
+      "keys": [
+        "do you tip taxi drivers in japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 31
+    },
+    {
+      "keys": [
+        "do you tip taxis in japan"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 40
+    },
+    {
+      "keys": [
+        "do you tip waiters in japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 44
+    },
+    {
+      "keys": [
+        "does it rain a lot in tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 50
+    },
+    {
+      "keys": [
+        "does sensoji temple cost money"
+      ],
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 10.75
+    },
+    {
+      "keys": [
+        "does sensoji temple need tickets"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "does tsukiji market close"
+      ],
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 7.333333333333333
+    },
+    {
+      "keys": [
+        "dogenzaka"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "domenica 26 luglio"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "donde es eso"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "donde esta fuji"
+      ],
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 11.571428571428571
+    },
+    {
+      "keys": [
+        "donde queda el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "keys": [
+        "donde queda fuji"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "keys": [
+        "donde ver el monte fuji"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "keys": [
+        "donde ver el monte fuji desde tokio"
+      ],
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 10.4
+    },
+    {
+      "keys": [
+        "downtown japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "keys": [
+        "drikkepenge japan"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 28
+    },
+    {
+      "keys": [
+        "duur?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "edo wonderland from tokyo"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "keys": [
+        "el monte fuji donde esta"
+      ],
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "keys": [
+        "el monte fuji esta en tokio"
+      ],
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 7.0434782608695654
+    },
+    {
+      "keys": [
+        "el monte fuji se ve desde tokyo?"
+      ],
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "keys": [
+        "el monte fuji solo se ve 80 dias al año"
+      ],
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 10.043478260869565
+    }
+  ],
+  "responseAggregationType": "byProperty"
+}

--- a/docs/analytics/raw/2026-07-28_28d_gsc_total.json
+++ b/docs/analytics/raw/2026-07-28_28d_gsc_total.json
@@ -1,0 +1,11 @@
+{
+  "rows": [
+    {
+      "clicks": 694,
+      "impressions": 127127,
+      "ctr": 0.0054591078213125461,
+      "position": 8.15526992692347
+    }
+  ],
+  "responseAggregationType": "byProperty"
+}

--- a/docs/analytics/raw/2026-07-28_28d_gsc_total_prev.json
+++ b/docs/analytics/raw/2026-07-28_28d_gsc_total_prev.json
@@ -1,0 +1,11 @@
+{
+  "rows": [
+    {
+      "clicks": 441,
+      "impressions": 108516,
+      "ctr": 0.0040639168417560545,
+      "position": 8.5586272992001184
+    }
+  ],
+  "responseAggregationType": "byProperty"
+}

--- a/src/components/blog/Diagnostic.tsx
+++ b/src/components/blog/Diagnostic.tsx
@@ -6,6 +6,7 @@ import {
   trackDiagnosticComplete,
   trackDiagnosticToTour,
   trackDiagnosticToContact,
+  trackDiagnosticToArticle,
 } from "@/lib/ga4";
 import guidePortrait from "@/assets/About_page_Manabu_team_photo.webp";
 
@@ -69,12 +70,14 @@ const labels = {
     retake: "Retake the quiz",
     credentials: "National Government Licensed Guide",
     name: "Manabu",
+    seeTour: "See this tour",
   },
   es: {
     back: "Atrás",
     retake: "Repetir el test",
     credentials: "Guía con Licencia Nacional",
     name: "Manabu",
+    seeTour: "Ver este tour",
   },
 };
 
@@ -163,6 +166,10 @@ export const Diagnostic = ({ config }: DiagnosticProps) => {
 
   const handleContactClick = () => {
     if (resultId) trackDiagnosticToContact(config.toolId, resultId);
+  };
+
+  const handleArticleClick = () => {
+    if (resultId) trackDiagnosticToArticle(config.toolId, resultId);
   };
 
   return (
@@ -325,7 +332,7 @@ export const Diagnostic = ({ config }: DiagnosticProps) => {
               {config.results[resultId].narrative}
             </p>
 
-            <div className="flex flex-col sm:flex-row gap-4 mb-10">
+            <div className="flex flex-col sm:flex-row gap-4 mb-6">
               <Link
                 to={`/contact?tour=${config.results[resultId].contactQuery}`}
                 onClick={handleContactClick}
@@ -334,10 +341,26 @@ export const Diagnostic = ({ config }: DiagnosticProps) => {
                 {config.results[resultId].tourLabel}
                 <span className="ml-2">→</span>
               </Link>
+              {config.results[resultId].tourPath &&
+                config.results[resultId].tourPath !==
+                  config.results[resultId].readMorePath && (
+                  <Link
+                    to={config.results[resultId].tourPath}
+                    onClick={handleTourClick}
+                    className="btn-outline text-center inline-flex items-center justify-center"
+                  >
+                    {t.seeTour}
+                    <span className="ml-2">→</span>
+                  </Link>
+                )}
+            </div>
+
+            {/* Quiet third rung: keep reading, for people not ready to commit */}
+            <div className="mb-10">
               <Link
                 to={config.results[resultId].readMorePath}
-                onClick={handleTourClick}
-                className="text-center inline-flex items-center justify-center px-6 py-3 text-foreground hover:text-accent transition-colors font-serif italic text-lg"
+                onClick={handleArticleClick}
+                className="inline-flex items-center text-foreground hover:text-accent transition-colors font-serif italic text-lg"
               >
                 {config.results[resultId].readMoreLabel}
                 <span className="ml-2">→</span>

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -119,3 +119,10 @@ export function trackDiagnosticToContact(toolId: string, resultId: string) {
     result_id: resultId,
   });
 }
+
+export function trackDiagnosticToArticle(toolId: string, resultId: string) {
+  gtag("event", "diagnostic_to_article", {
+    tool_id: toolId,
+    result_id: resultId,
+  });
+}

--- a/src/pages/blog/AsakusaGuideNew.tsx
+++ b/src/pages/blog/AsakusaGuideNew.tsx
@@ -193,7 +193,10 @@ const AsakusaGuideNew = () => {
               <Link to="/blog/old-tokyo-shitamachi" className="text-accent hover:underline">
                 Old Tokyo and Shitamachi guide
               </Link>{" "}
-              covers the broader story of Tokyo's historic downtown culture.
+              covers the broader story of Tokyo's historic downtown culture. And if you are trying to work out what that kind of guided access would run you, I set out the real numbers in{" "}
+              <Link to="/blog/tokyo-private-tour-guide-cost" className="text-accent hover:underline">
+                what a private tour guide in Tokyo costs
+              </Link>.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
               <strong className="text-foreground">Denboin Garden: Asakusa's Secret Spring Garden.</strong> Most visitors have no idea this place exists. Denboin is an Edo-period garden belonging to the abbot's residence at Senso-ji, with a tranquil pond, carefully shaped pines, a tea house, and a picture-perfect view of the five-story pagoda reflected in the water. The catch: it only opens to the public for a limited window each year, typically mid-March to early May, with a small admission fee (around ¥300). When it is open, the contrast between the crowded Nakamise-dori just outside the walls and this quiet, almost secret garden is one of the most striking experiences in Tokyo. Check the Senso-ji website for current opening dates before planning your visit — the schedule shifts slightly year to year.

--- a/src/pages/blog/OldTokyoShitamachi.tsx
+++ b/src/pages/blog/OldTokyoShitamachi.tsx
@@ -99,7 +99,10 @@ const OldTokyoShitamachi = () => {
             <p className="text-muted-foreground leading-relaxed mb-4">
               If Asakusa is Shitamachi's public face, Yanaka is its quiet soul. This residential neighborhood near Ueno survived the earthquake and the firebombing largely intact, making it the closest thing to a time capsule that Tokyo has. The Yanaka Cemetery, where Japan's last shogun is buried, is a green, peaceful space surrounded by dozens of small Buddhist temples. Yanaka Ginza, the main shopping street, slopes downhill past shops that have been family-owned for generations. I've written a full{" "}
               <Link to="/blog/yanaka-tokyo-walking-route" className="text-accent hover:underline">walking route for Yanaka</Link>{" "}
-              that covers the best spots.
+              that covers the best spots. If you would rather have the history unpacked for you as you walk it, I break down what that costs in{" "}
+              <Link to="/blog/tokyo-private-tour-guide-cost" className="text-accent hover:underline">
+                what a private tour guide in Tokyo costs
+              </Link>.
             </p>
             <figure className="my-8">
               <img

--- a/src/pages/blog/SensojiMostVisited.tsx
+++ b/src/pages/blog/SensojiMostVisited.tsx
@@ -179,6 +179,13 @@ const SensojiMostVisited = () => {
               Here is what fascinates me most about the Senso-ji visitors statistics: the vast majority of those 30 million people follow an almost identical route. They enter through Kaminarimon, walk straight down Nakamise-dori, take a photo at the main hall, perhaps draw a fortune slip, and leave. The entire visit takes 30 to 45 minutes. They miss an enormous amount, and these hidden layers are what I live for as a guide.
             </p>
             <p className="text-muted-foreground leading-relaxed mb-4">
+              If you are weighing whether that kind of depth justifies bringing someone along, I have written an honest look at{" "}
+              <Link to="/blog/is-it-worth-hiring-a-tour-guide-in-tokyo" className="text-accent hover:underline">
+                whether hiring a guide in Tokyo is worth it
+              </Link>
+              , including the trips where it plainly is not.
+            </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
               <strong className="text-foreground">The backstreet shrines:</strong> Within a five-minute walk of Senso-ji's main hall, there are over a dozen smaller shrines and temples that receive almost zero tourist traffic. Asakusa Shrine, immediately adjacent to Senso-ji's eastern wall, is criminally overlooked despite being designated an Important Cultural Property with original 1649 architecture. Bentendo, a small octagonal temple on a tiny island in the old Benten Pond (now a park), is beautiful and usually deserted. Imado Shrine, a short walk north, is famous among Japanese visitors for its maneki-neko (lucky cats) and matchmaking prayers but virtually unknown to international tourists.
             </p>
             <figure className="my-8">

--- a/src/pages/blog/ShibuyaHarajukuGuide.tsx
+++ b/src/pages/blog/ShibuyaHarajukuGuide.tsx
@@ -232,6 +232,12 @@ const ShibuyaHarajukuGuide = () => {
                 Harajuku vs Shibuya vs Shinjuku: Which Fits Your Trip
               </Link>.
             </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              And if the question on your mind is what guided time actually costs before you commit to anything, I publish my rates and what shapes them in{" "}
+              <Link to="/blog/tokyo-private-tour-guide-cost" className="text-accent hover:underline">
+                what a private tour guide in Tokyo costs
+              </Link>.
+            </p>
 
             {/* Where to Eat */}
             <div className="section-eyebrow"><span>Section 04 · Where to Eat</span></div>

--- a/src/pages/blog/TempleEtiquette.tsx
+++ b/src/pages/blog/TempleEtiquette.tsx
@@ -329,6 +329,13 @@ const TempleEtiquette = () => {
             <p className="text-muted-foreground leading-relaxed mb-4">
               Now that you know the etiquette, where should you put it into practice? Here are some of Japan's most iconic sacred sites that we frequently visit on our tours, each offering a unique experience and a chance to apply what you've learned.
             </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              If you are still deciding whether to visit these on your own or with someone explaining the rituals as you go, my piece on{" "}
+              <Link to="/blog/is-it-worth-hiring-a-tour-guide-in-tokyo" className="text-accent hover:underline">
+                whether hiring a guide in Tokyo is worth it
+              </Link>{" "}
+              lays out both sides honestly.
+            </p>
             <ul className="space-y-4 mb-8">
               <li className="text-muted-foreground leading-relaxed">
                 <strong className="text-foreground">Senso-ji Temple, Asakusa:</strong> Tokyo's oldest and most visited temple, dating back to 645 AD. The massive Kaminarimon (Thunder Gate) with its enormous red lantern is one of Japan's most recognizable landmarks. The Nakamise-dori approach is lined with traditional shops selling snacks, souvenirs, and crafts. Despite the crowds, Senso-ji retains a powerful spiritual atmosphere, especially early in the morning or in the evening when the lanterns glow. Our{" "}

--- a/src/pages/blog/YokohamaDayTrip.tsx
+++ b/src/pages/blog/YokohamaDayTrip.tsx
@@ -185,7 +185,11 @@ const YokohamaDayTrip = () => {
               <Link to="/blog/kamakura-day-trip-from-tokyo" className="text-accent hover:underline">Kamakura</Link>{" "}
               and{" "}
               <Link to="/blog/kawagoe-day-trip-from-tokyo" className="text-accent hover:underline">Kawagoe</Link>{" "}
-              day trips.
+              day trips. And if you are still choosing between destinations rather than planning one, my{" "}
+              <Link to="/blog/kamakura-vs-hakone-vs-nikko-day-trip" className="text-accent hover:underline">
+                Kamakura vs Hakone vs Nikko comparison
+              </Link>{" "}
+              walks through the trade-offs side by side.
             </p>
 
             {/* CTA */}

--- a/src/pages/es/blog/EsComidaCallejeraTokio.tsx
+++ b/src/pages/es/blog/EsComidaCallejeraTokio.tsx
@@ -66,7 +66,11 @@ const EsComidaCallejeraTokio = () => {
               <Link to="/es/blog/que-comer-en-japon" className="text-accent hover:underline">
                 qué se come en Japón
               </Link>
-              , este post es el complemento perfecto. Aquí vamos al detalle callejero, al puesto con humo, al snack de 200 yenes que te cambia el día.
+              , este post es el complemento perfecto. Aquí vamos al detalle callejero, al puesto con humo, al snack de 200 yenes que te cambia el día. Y si prefieres que alguien te lleve directamente a los puestos buenos, en{" "}
+              <Link to="/es/blog/cuanto-cuesta-guia-privado-tokio" className="text-accent hover:underline">
+                cuánto cuesta un guía privado en Tokio
+              </Link>{" "}
+              te cuento qué se paga por ello.
             </p>
 
             {/* ¿Existe realmente la comida callejera en Tokio? */}

--- a/src/pages/es/blog/EsEtiquetaTemplos.tsx
+++ b/src/pages/es/blog/EsEtiquetaTemplos.tsx
@@ -330,6 +330,13 @@ const EsEtiquetaTemplos = () => {
             <p className="text-muted-foreground leading-relaxed mb-4">
               Ahora que conoces la etiqueta, ¿dónde ponerla en práctica? Aquí tienes algunos de los lugares sagrados más emblemáticos de Japón que visitamos frecuentemente en nuestros tours, y cada uno ofrece una experiencia única y la oportunidad de aplicar lo que has aprendido.
             </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Y si aún dudas entre visitarlos por tu cuenta o con alguien que te explique cada ritual sobre la marcha, en{" "}
+              <Link to="/es/blog/vale-la-pena-contratar-guia" className="text-accent hover:underline">
+                si vale la pena contratar un guía
+              </Link>{" "}
+              expongo los dos lados con honestidad.
+            </p>
             <ul className="space-y-4 mb-8">
               <li className="text-muted-foreground leading-relaxed">
                 <strong className="text-foreground">Templo Senso-ji, Asakusa:</strong> El templo más antiguo y visitado de Tokio, que data del año 645 d.C. La enorme Kaminarimon (Puerta del Trueno) con su gigantesco farol rojo es uno de los monumentos más reconocibles de Japón. La calle de acceso Nakamise-dori está repleta de tiendas tradicionales que venden aperitivos, recuerdos y artesanías. A pesar de las multitudes, Senso-ji conserva una poderosa atmósfera espiritual, especialmente temprano por la mañana o por la noche cuando los faroles brillan. Nuestro{" "}

--- a/src/pages/es/blog/EsGuiaTsukiji.tsx
+++ b/src/pages/es/blog/EsGuiaTsukiji.tsx
@@ -112,6 +112,13 @@ const EsGuiaTsukiji = () => {
                 Tsukiji vs Toyosu: ¿qué mercado de pescado visitar en Tokio?
               </Link>
             </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              Y si estás valorando recorrer el mercado con alguien que te traduzca los puestos y sepa dónde parar, en{" "}
+              <Link to="/es/blog/cuanto-cuesta-guia-privado-tokio" className="text-accent hover:underline">
+                cuánto cuesta un guía privado en Tokio
+              </Link>{" "}
+              desgloso los precios reales y qué los hace subir o bajar.
+            </p>
 
             {/* Qué Comer */}
             <div className="section-eyebrow"><span>Section 02 · Qué Comer en Tsukiji</span></div>

--- a/src/pages/es/blog/EsPropinasenJapon.tsx
+++ b/src/pages/es/blog/EsPropinasenJapon.tsx
@@ -260,6 +260,13 @@ const EsPropinasenJapon = () => {
               </Link>
               .
             </p>
+            <p className="text-muted-foreground leading-relaxed mb-8">
+              Ya que estamos hablando de dinero: si quieres saber qué se paga realmente por un guía en Tokio, lo explico sin rodeos en{" "}
+              <Link to="/es/blog/cuanto-cuesta-guia-privado-tokio" className="text-accent hover:underline">
+                cuánto cuesta un guía privado en Tokio
+              </Link>
+              , con cifras concretas y cómo distinguir un precio justo de uno inflado.
+            </p>
 
             {/* FAQ */}
             <div className="section-eyebrow"><span>Section 06 · FAQ</span></div>

--- a/src/pages/es/blog/EsYanakaTokio.tsx
+++ b/src/pages/es/blog/EsYanakaTokio.tsx
@@ -219,6 +219,13 @@ const EsYanakaTokio = () => {
               </Link>
               {" "}explico cómo encajar Yanaka en un viaje más amplio.
             </p>
+            <p className="text-muted-foreground leading-relaxed mb-4">
+              Si dudas entre recorrer Yanaka por tu cuenta o con alguien que te cuente lo que hay detrás de cada calle, en{" "}
+              <Link to="/es/blog/vale-la-pena-guia-privado-tokio" className="text-accent hover:underline">
+                si vale la pena un guía privado en Tokio
+              </Link>{" "}
+              doy los argumentos de ambos lados, incluidos los casos en los que no compensa.
+            </p>
 
             {/* FAQ */}
             <div className="section-eyebrow"><span>Section 06 · FAQ</span></div>


### PR DESCRIPTION
2026-07 スナップショット分析にもとづく転換率改善。GSC 694クリック/28日（前期比 +57%）と伸びている一方、転換が伸びていない原因2点に対応する。

## 1. 診断ツール：結果画面からツアー導線が欠落していた（実バグ）

- `tourPath` は全6つの診断設定ファイルに定義済みだったが、`Diagnostic.tsx` が一度も描画しておらず、**結果画面からツアーページへ行く手段が存在しなかった**
- `diagnostic_to_tour` イベントが `readMorePath`（記事リンク）に誤配線されており、ツアー遷移ではなく「続きを読む」クリックを計測していた

結果画面を3段構成に整理：

| 段 | 遷移先 | 見た目 | イベント |
|---|---|---|---|
| ① | `/contact?tour=X` | btn-accent | `diagnostic_to_contact`（既存） |
| ② | `tourPath` | btn-outline | `diagnostic_to_tour`（**新規表示**・意味を是正） |
| ③ | `readMorePath` | 細字リンク | `diagnostic_to_article`（**新設**） |

`tourPath === readMorePath` の場合（`neighborhoodFinderEs` の imperial-palace）は②を非表示にして重複回避。

## 2. 情報系記事 → 意思決定系記事の内部リンク（EN 6 / ES 5）

転換率は**情報系 5.6% に対し意思決定系 23.1%（4.1倍）**。しかし情報系記事の本文リンクは全て他の情報系記事に向いており、意思決定系への導線がゼロだった。高エンゲージかつ転換ゼロの **249セッション/月** に中間段を用意する。

全て純粋な追加で既存文の書き換えなし。新規の事実主張を含まないためファクトチェック対象項目なし。ES版は機械翻訳ではなく個別に自然なスペイン語で執筆。

## 3. 2026-07-28 GSC/GA4 生データ（28日窓）を追加

## 検証

- `npm run build` 成功、135ルート pre-render 全通過
- prerender 済み HTML に全11リンクの反映を確認

## マージ後に必要な作業

- [ ] GA4 で `diagnostic_to_article` をカスタムイベント登録
- [ ] `diagnostic_to_tour` は意味が変わるため 2026-07 以前のデータと接続しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)