### PR TITLE
docs(analytics): 2026-07-28 スナップショット（28日）

### DIFF
--- a/docs/analytics/snapshots/2026-07-28_28d.md
+++ b/docs/analytics/snapshots/2026-07-28_28d.md
@@ -1,0 +1,392 @@
+# Analytics Snapshot — 2026-07-28（直近28日）
+
+> このスナップショットは**マスタ参照用**。新規施策を検討する際は、まずこのファイルで「現状の集客構造・勝ちパターン・損失ポイント」を確認してから立案すること。次回スナップショットは同じ構造で作成し、KPIセクションを差分比較する。
+>
+> 前回スナップショット: `2026-04-20_28d.md`（約3.5か月前）。その間 2026-05-05 / 05-06 の生データは取得済みだがスナップショット未作成。
+
+## メタデータ
+
+| 項目 | 値 |
+|------|-----|
+| 生成日 | 2026-08-01 |
+| データ期間（当期） | 2026-07-01 〜 2026-07-28（28日） |
+| データ期間（前期） | 2026-06-03 〜 2026-06-30（28日） |
+| GSC プロパティ | https://tanuki-tabi-travel.com/ |
+| GA4 プロパティID | 465121981 |
+| 取得方法 | `gcloud auth application-default` + REST API（`docs/analytics/fetch-snapshot.sh`） |
+| 生データ | `docs/analytics/raw/2026-07-28_28d_*.json`（14ファイル） |
+
+---
+
+## 1. KPIスナップショット（差分比較用）
+
+| 指標 | 前回SS<br>2026-04-20 | 前28日<br>06-03〜06-30 | 当28日<br>07-01〜07-28 | 前期比 | 解釈 |
+|------|------|------|------|------|------|
+| GSC impressions | 135,376 | 108,516 | 127,127 | +17% | 4月ピークからは減、直近は回復基調 |
+| GSC clicks | 293 | 441 | **694** | **+57%** | 4月比 +137%。継続的に伸長 |
+| GSC CTR | 0.22% | 0.41% | **0.55%** | +34% | 4月0.22%から2.5倍。**最も改善した指標** |
+| GSC avg position | 6.3 | 8.56 | 8.16 | ↑改善 | 4月比では悪化（裾野拡大の希釈） |
+| GA4 users | 497 | 779 | **1,152** | +48% | 4月比 +132% |
+| GA4 sessions | 625 | 998 | **1,538** | +54% | 同上 |
+| GA4 engaged sessions | 248 | 436 | 675 | +55% | エンゲージ率 43.7% → 43.9%（維持） |
+| GA4 pageviews | 885 | 1,463 | 2,089 | +43% | セッションあたりPV 1.47→1.36 |
+| GA4 avg session | 127s | 179s | **199s** | +11% | 4月の劣化（-31%）から完全回復 |
+| GA4 bounce rate | 60.3% | 56.3% | 56.1% | ほぼ横ばい | 4月比で改善 |
+| form_submit | 12 | — | **15** | — | 実際の問い合わせ件数 |
+| book_now_click | 13 | — | 16 | — | |
+| tour_page_view | 149 | — | 205 | — | |
+| blog_to_tour_click | **1** | — | **50** | — | **4月の計測不全は解消済み**（Click Delegate が機能） |
+
+### 収益感応度
+
+- `form_submit` 15件/28日 ≈ **月16件**（4月13件から +23%）
+- 仮に 20% 成約・平均単価 ¥45,000 → **約 ¥144,000/月** の売上換算
+- セッションは +146%（625→1,538）伸びたが form_submit は +25%（12→15）。**トラフィック成長が収益に転化していない**のが当期最大の構造課題
+
+### ⚠ 「conversions」指標の読み方（重要）
+
+GA4 の `conversions` は key event 6種の合計であり、**予約数ではない**。当期340件の内訳:
+
+```
+tour_page_view 205 + contact_page_view 54 + blog_to_tour_click 50
++ book_now_click 16 + form_submit 15 = 340
+```
+
+`tour_page_view` が6割を占めるため、実質「ツアーページ閲覧数」に近い。
+**実リードは `form_submit` の15件のみ**。以降の本ドキュメントで「転換」と書いた場合は
+すべてこのマイクロ転換を指す。
+
+---
+
+## 2. 勝ちパターン（Winners）
+
+**基準**: 「集客が事業に転化している」ページ・クエリ。新規施策の**テンプレートとして再利用する対象**。
+
+### 2-1. 意思決定支援型が情報型の4.1倍転換する（当期の最重要発見）
+
+GA4 landing page をクラスタ分類した結果:
+
+| クラスタ | セッション | 転換/セッション | 平均滞在 |
+|---|---|---|---|
+| 情報系（Tsukiji時間・浅草・寺社作法等） | 662 | 5.6% | 248s |
+| **意思決定系（vs比較・料金・ガイド要否）** | 376 | **23.1%** | 215s |
+| ホーム/ツアーページ | 113 | 61.9% | 196s |
+
+4月スナップショットの CSO 観点「意思決定支援プラットフォームへの再定義」は**データで裏付けられた**。
+
+### 2-2. 高転換ページ
+
+| ページ | セッション | 転換 | 転換率 | 平均滞在 |
+|--------|-----------|------|--------|---------|
+| /es/blog/comparativa-excursiones | 58 | 37 | **63.8%** | 501s |
+| /blog/tokyo-private-tour-guide-cost | 42 | 20 | 47.6% | 209s |
+| /blog/hakone-day-trip-guide-vs-solo | 13 | 5 | 38.5% | 174s |
+| /blog/yanaka-tokyo-walking-route | 24 | 9 | 37.5% | 281s |
+| /blog/is-it-worth-hiring-a-tour-guide-in-tokyo | 25 | 6 | 24.0% | — |
+| /blog/kamakura-vs-hakone-vs-nikko-day-trip | 78 | 11 | 14.1% | 228s |
+
+**ES版比較記事が全ページ中トップ**（滞在501秒はサイト平均の2.5倍）。
+
+### 2-3. スペイン語版の効率が英語版の2.3倍
+
+| 言語 | ページ数 | clicks | imp | CTR |
+|---|---|---|---|---|
+| EN | 74 | 514 | 110,730 | 0.46% |
+| **ES** | 39 | 181 | 17,075 | **1.06%** |
+
+国別でも Spain 転換率 30.1%（US 14.9%、Singapore 10.1%）。**記事数は半分なのに効率は2倍以上**。
+
+### 2-4. 新チャネル「AI Assistant」の出現
+
+5月時点で存在しなかったチャネルが立ち上がった。
+
+| source / medium | セッション | エンゲージ |
+|---|---|---|
+| chatgpt.com / ai-assistant | 44 | 25 |
+| copilot.com / (not set) | 4 | 2 |
+| claude.ai / ai-assistant | 3 | 1 |
+
+AI Assistant 計47セッション・エンゲージ率55.3%（サイト平均43.9%を上回る）。着地先は `/`(8)、`/es`(7)、`/blog/private-mount-fuji-tour-2026`(4)、`/blog/tokyo-private-tour-guide-cost`(3, 滞在638秒) と**商用ページ直撃**。
+
+⚠ 母数47は小さく、転換率の高さは「元々購買意図の高い層しか来ない」ためのセレクションバイアス。過大評価しないこと。
+
+### 2-5. Tsukiji 記事が単独で最大の集客エンジンに
+
+`/blog/tsukiji-market-guide`: 215クリック（サイト全体の**31%**）、336セッション。4月の31クリックから7倍。ただし転換率6.0%（情報系クラスタの典型）。
+
+---
+
+## 3. 損失ポイント（Losers / Watchlist）
+
+### 3-1. 高エンゲージ・ゼロ転換（月249セッションの死蔵在庫）
+
+| ページ | セッション | 平均滞在 | 転換 |
+|--------|-----------|---------|------|
+| /blog/senso-ji-most-visited-temple | 67 | **443s** | 0 |
+| /es/blog/guia-tsukiji | 46 | 165s | 0 |
+| /blog/japan-temple-shrine-etiquette | 17 | 251s | 0 |
+| /blog/asakusa-guide | 16 | 251s | 0 |
+| /blog/shibuya-harajuku-guide | 16 | 118s | 0 |
+| /blog/yokohama-day-trip-from-tokyo | 14 | 307s | 0 |
+| /blog/old-tokyo-shitamachi | 12 | 267s | 0 |
+| /es/blog/comida-callejera-tokio | 10 | **1,047s** | 0 |
+
+**Senso-ji は滞在443秒（サイト平均の2.2倍）で転換ゼロ**。読まれているのに動線に乗っていない。
+
+**重要**: CTA設置数は転換率と相関しないことを全記事照合で確認済み。
+`tsukiji-market-guide` は InlineCTA×4＋診断＋関連ツアーを備えて6.0%、
+`yanaka-tokyo-walking-route` は InlineCTA 0 で37.5%、`tokyo-private-tour-guide-cost` は
+InlineCTA 0 で47.6%。**差はCTAの数ではなく検索意図**。CTA増設は打ち手にならない。
+
+これら情報系記事の本文リンクは**すべて他の情報系記事に向いており**、意思決定系へのリンクがゼロだった（当期に修正、後述）。
+
+### 3-2. JR Pass：構造的天井（対応不要と再確認）
+
+`/blog/japan-rail-pass-worth-it`: 39,812imp / 30クリック / **0.08%** / 順位7.61。
+
+サイト全体の表示の**31%を占めながらクリックは4.3%**。2026-07-19 の原因分析どおり、真因は title/meta ではなく「順位7位台 × DR 0.8」の構造的制約。当期も横ばいで、**天井に達している判断は維持**。
+
+参考: JR Pass を除いたサイトCTRは 664/87,315 = **0.76%**（全体0.55%）。
+
+### 3-3. 診断ツールのツアー導線が存在しなかった（当期に発見・修正）
+
+`diagnostic_complete` 16 → `diagnostic_to_contact` 2 / `diagnostic_to_tour` 1。
+
+原因調査の結果、**実装バグ**だった:
+- `tourPath` は全6つの診断設定に定義済みだったが `Diagnostic.tsx` が一度も描画しておらず、結果画面からツアーページへ行く手段が存在しなかった
+- `diagnostic_to_tour` イベントが `readMorePath`（記事リンク）に誤配線され、ツアー遷移ではなく「続きを読む」を計測していた
+
+→ 当期に修正済み（PR #133）。`diagnostic_to_tour` は**意味が変わったため 2026-07 以前と接続不可**。
+
+### 3-4. 重複コンテンツ（当期に発見・修正）
+
+`/blog/tipping-in-japan`（本文×2）と `/blog/tokyo-on-a-budget`（本文×3）が本番稼働中に重複。
+`id="section-0X-..."` 重複でHTML不正、アンカーリンク破損。
+
+原因は `$1`/`$2` を後方参照として解釈した一括置換の事故（`$18–22`→`8–22` 等、金額が破壊された破損コピーの中に無傷コピーが挿入されていた）。→ 当期に修正済み（PR #134）。全記事走査で同種の破損は他になし。
+
+### 3-5. Desktop CTR は依然低いが4月より改善
+
+| Device | Clicks | Imp | Pos | CTR |
+|--------|--------|-----|-----|-----|
+| MOBILE | 400 | 40,749 | 8.03 | **0.98%** |
+| DESKTOP | 285 | 85,677 | 8.21 | 0.33% |
+| TABLET | 9 | 701 | 8.15 | 1.28% |
+
+Desktop CTR 0.11%（4月）→ 0.33%（当期）と3倍改善。ただし Desktop は imp の67%を占めるためモバイルとの3倍差は残る。Desktop imp の大半は JR Pass 由来。
+
+### 3-6. 主力「意思決定系」記事2本の順位下落 ⚠
+
+転換率が最も高いクラスタの旗艦記事が、いずれも順位を落としている。
+
+| ページ | 4月 clicks<br>(slash合算) | 当期 clicks | 4月 pos | 当期 pos |
+|---|---|---|---|---|
+| /blog/kamakura-vs-hakone-vs-nikko-day-trip | 77 | 49（**-36%**） | 4.6 | 6.89 |
+| /blog/is-it-worth-hiring-a-tour-guide-in-tokyo | 10 | 13 | 5.5 | **14.83** |
+
+4月スナップショットで「比較記事型の成功モデル」「94%成約率の最強ページ」と位置づけた
+2本が揃って順位を落としている。**転換率の高いクラスタが縮小しつつある**という点で、
+総セッションの伸び（+146%）よりも重大なシグナルの可能性がある。
+
+候補仮説（未検証）: 競合の参入 / 内部リンクが Tsukiji 側に希釈された / 
+サイト全体の評価が情報系クエリに寄った反動 / 単なる SERP 変動。
+
+→ 次回スナップショットまでに原因調査が必要。
+
+### 3-7. 解消済み（4月からの改善）
+
+| 4月の問題 | 現状 |
+|---|---|
+| trailing slash 重複インデックス | **ほぼ解消**。残存は `/blog/tipping-in-japan/`（513imp）1件のみ |
+| `blog_to_tour_click` = 1件 | **50件/28日に回復**（Click Delegate 方式が機能） |
+| 平均滞在 -31%（127s） | **199s に回復**（4月比 +57%） |
+| Organic Social = 3 sessions | 2 sessions（**未改善**、実質ゼロのまま） |
+
+---
+
+## 4. 流入構造（参照データ）
+
+### 4-1. Channel（GA4）
+
+| Channel | Sessions | Engaged | エンゲージ率 | Conversions |
+|---------|----------|---------|---|---|
+| Organic Search | 1,083 | 552 | 51.0% | 182 |
+| Direct | 386 | 86 | 22.3% | 104 |
+| **AI Assistant** | 47 | 26 | 55.3% | 44 |
+| Referral | 12 | 6 | 50.0% | 4 |
+| Unassigned | 8 | 3 | 37.5% | 6 |
+| Organic Social | 2 | 1 | 50.0% | 0 |
+
+### 4-2. Country
+
+| 国 | GA4 Sess | GA4 Conv | 転換率 | GSC Clicks | GSC Imp | GSC CTR |
+|---|---|---|---|---|---|---|
+| Japan | 326 | 68 | 20.9% | 196 | 23,001 | 0.85% |
+| United States | 323 | 48 | 14.9% | 118 | 40,586 | **0.29%** |
+| **Spain** | 196 | 59 | **30.1%** | 106 | 6,990 | **1.52%** |
+| Singapore | 159 | 16 | 10.1% | 25 | 1,886 | 1.33% |
+| United Kingdom | 77 | 7 | 9.1% | 25 | 4,069 | 0.61% |
+| Australia | 55 | 2 | 3.6% | 28 | 3,369 | 0.83% |
+| Canada | 32 | 5 | 15.6% | 18 | 3,593 | 0.50% |
+| Mexico | 32 | 6 | 18.8% | 21 | 3,469 | 0.61% |
+| Brazil | 18 | 1 | 5.6% | 10 | 1,397 | 0.72% |
+
+**読み方**: Japan が GSC クリック1位（196件、全体の28%）。Tsukiji 記事の営業時間クエリが主因と推測され、**訪日中の旅行者＝即時性の高い見込み客**の可能性がある（要検証）。US は imp 最大だが CTR 最低。Spain は CTR・転換率とも最高。
+
+### 4-3. GSC Top 15 Pages（当期）
+
+4月比は **trailing slash 版と合算した実数**で比較する（当時は重複URLでクリックが分散していたため、非スラッシュ版のみの比較は変化を誤読する）。
+
+| Page | Clicks | Imp | Pos | CTR | 4月<br>(合算) | 差分 |
+|------|--------|-----|-----|-----|---|---|
+| /blog/tsukiji-market-guide | **215** | 33,020 | 7.10 | 0.65% | 42 | **+173** |
+| /blog/kamakura-vs-hakone-vs-nikko-day-trip | 49 | 3,380 | 6.89 | 1.45% | 77 | **-28** ⚠ |
+| /es/blog/guia-tsukiji | 39 | 2,353 | 6.75 | 1.66% | 11 | +28 |
+| /es/blog/comparativa-excursiones | 36 | 706 | 5.08 | **5.10%** | 9 | +27 |
+| /blog/japan-rail-pass-worth-it | 30 | **39,812** | 7.61 | **0.08%** | 38 | -8 |
+| /es/blog/monte-fuji-se-ve-desde-tokio | 29 | 5,741 | 7.69 | 0.51% | 12 | +17 |
+| /blog/senso-ji-most-visited-temple | 20 | 6,194 | 6.57 | 0.32% | 圏外 | +20 |
+| /blog/tsukiji-vs-toyosu | 18 | 2,571 | 8.63 | 0.70% | 圏外 | +18 |
+| /blog/yanaka-tokyo-walking-route | 18 | 1,699 | 8.95 | 1.06% | 圏外 | +18 |
+| /blog/tokyo-private-tour-guide-cost | 16 | 4,096 | 7.07 | 0.39% | 5 | +11 |
+| /es/blog/propinas-en-japon | 14 | 1,873 | 6.01 | 0.75% | 圏外 | +14 |
+| /blog/is-it-worth-hiring-a-tour-guide-in-tokyo | 13 | 1,508 | 14.83 | 0.86% | 10 | +3 |
+| /es/blog/etiqueta-templos-santuarios | 13 | 543 | 6.26 | 2.39% | 圏外 | +13 |
+| /es/blog/nikko-con-guia-vs-solo | 13 | 1,031 | 8.60 | 1.26% | 圏外 | +13 |
+| /blog/shibuya-harajuku-guide | 12 | 2,275 | 8.03 | 0.53% | 5 | +7 |
+
+**4月の救出施策は機能した**: TsukijiVsToyosu（圏外→18）、Nikko Guided vs Solo（圏外→13）はいずれも stranded 状態から回復。
+
+**⚠ 要注意: 主力比較記事の失速**
+`/blog/kamakura-vs-hakone-vs-nikko-day-trip` は 77 → 49（**-36%**）と唯一の大幅減。
+順位は 4.6 → 6.89 に悪化しており、順位下落が原因。4月時点で「比較記事型の成功モデル」
+と位置づけた記事なので、次回までに原因調査が必要（競合の参入 / 内部リンク希釈 /
+Tsukiji 記事への評価集中の反動などが候補）。
+`is-it-worth-hiring-a-tour-guide-in-tokyo` も順位14.83と低く（4月5.5）、
+4月に「94%成約率の最強ページ」とした資産が2本とも順位を落としている点は看過できない。
+
+### 4-4. 注記：アンカーURL（`#section-…`）の扱い
+
+GSC page ディメンションに `#` 付きURLが92本・98,001imp・1クリックで現れるが、これは Google の「セクションへのリンク」表示による別行計上であり、**サイト全体CTRの分母には入っていない**（クリーンURL合計127,805 ≒ 全体127,127）。低CTRの原因と誤読しないこと。
+
+---
+
+## 5. 役員5観点ネクストアクション
+
+当期の構造は「**トラフィックは伸びたが低意図クエリに偏っており、収益に転化していない**」。セッション +146% に対し form_submit +25%。
+
+### CEO（経営・収益）
+
+| 優先 | アクション | 根拠 |
+|------|-----------|------|
+| 高 | KPI を「セッション数」から「**意思決定系クラスタのセッション数**」に変更 | 情報系5.6% vs 意思決定系23.1%。総セッションを追うと判断を誤る |
+| 高 | ES版への投資比率を上げる | 記事数が英語の半分で CTR 2.3倍・転換率2倍 |
+| 中 | JR Pass は引き続き事業KPI対象外（4月決定を維持） | 39,812imp/30clk。DR0.8では構造的に取れない |
+
+### CTO（技術・計測）
+
+| 優先 | アクション | 根拠 |
+|------|-----------|------|
+| 中 | `/blog/tipping-in-japan/`（末尾スラッシュ）の残存を解消 | 513imp が別URL計上。他は解消済み |
+| 中 | 一括置換事故の再発防止（`$1`/`$2` 後方参照） | 2記事が本番で重複していた。sed/正規表現置換の運用ルール化 |
+| 低 | Japan からの流入326セッションの内訳調査 | 訪日中旅行者なら最優先セグメント。自己トラフィックの可能性も要否定 |
+| — | GA4 のカスタムイベント登録は**不要** | 未登録でも自動収集される。`tool_id`/`result_id` は登録済み |
+
+### COO（運用・実行）
+
+| 優先 | アクション | 工数 |
+|------|-----------|------|
+| 済 | 情報系→意思決定系の内部リンク（EN6/ES5＋tipping） | 完了（PR #133/#134） |
+| 済 | 診断ツールのツアー導線復旧 | 完了（PR #133） |
+| 済 | 重複コンテンツ除去 | 完了（PR #134） |
+| 高 | 次回スナップショット（8月下旬）で上記3件の効果判定 | 1h |
+
+### CMO（マーケ・コンテンツ）
+
+| 優先 | アクション | 根拠 |
+|------|-----------|------|
+| **最高** | **主力比較記事2本の順位下落を原因調査**（kamakura-vs-hakone-vs-nikko 4.6→6.89、is-it-worth-hiring 5.5→14.83） | 転換率23.1%クラスタの旗艦が縮小中。総セッション増より重大な可能性 |
+| 高 | **ES版の意思決定系記事を追加**（`comparativa-excursiones` の型を横展開） | 転換率63.8%・滞在501秒の最強ページ。ES意思決定系が英語版に比べ不足 |
+| 高 | Senso-ji（滞在443秒・転換0）の受け皿となる意思決定系記事の強化 | 月67セッションの最大の死蔵在庫 |
+| 中 | AI Assistant 経由の着地ページを増やす（GEO戦） | chatgpt.com 44セッションが商用ページ直撃。方針Bの実証段階 |
+| 低 | Organic Social は2セッション。4月から未改善 | 着手するか撤退するかを決める |
+
+### CSO（戦略・差別化）
+
+| 優先 | アクション | 根拠 |
+|------|-----------|------|
+| 戦略 | 「意思決定支援プラットフォーム」路線を**データで確認済み**として継続 | 4.1倍の転換率差 |
+| 戦略 | **AI Assistant を正式チャネルとしてKPI化** | 47セッション/月で定着の兆し。次期の推移が方針B継続判断の材料 |
+| 戦略 | DR 0.8 の被リンク獲得を土台施策として着手 | JR Pass 型の構造的天井を破る唯一の手段。長期 |
+| 戦略 | Tsukiji 依存リスク（全クリックの31%が1記事） | 単一記事への集中。順位変動で全体が揺れる構造 |
+
+---
+
+## 6. このスナップショットから導かれた決定事項
+
+（このセクションは決定ログとして**追記のみ**。上書き禁止）
+
+| 日付 | 決定 | 実行担当（観点） |
+|------|------|----------------|
+| 2026-04-20 | まず計測（CTO）→記事改修（COO）→比較記事展開（CMO）の順で着手 | 全観点 |
+| 2026-04-20 | 前回Action Plan の施策B-1/B-2/B-4/C-2/C-3/D/E は当月停止、5月に再計画 | COO |
+| 2026-04-20 | `blog_to_tour_click` をグローバルClick Delegate方式で全リンクカバー（`src/lib/ga4.ts` + `src/main.tsx`）。RelatedTourCardsの明示呼び出しは削除し二重発火防止。次回スナップショットで月30〜80件のベースラインを確認 | CTO |
+| 2026-04-20 | `JapanRailPass.tsx` / `EsJapanRailPass.tsx` に QuickAnswer を追加（`jr pass price increase 2026` の596imp/pos2.1/1clkゼロクリック対策）。answerで「2026に値上げなし」を即答、hookで「12ルート中7つは損する」と独自価値提示 | COO |
+| 2026-04-20 | `TsukijiMarketGuide.tsx` は既にQuickAnswer+中盤InlineCTA+末尾RelatedTourCards完備。追加改修せず、新Click Delegateによる計測回収で効果測定する方針 | COO |
+| 2026-04-20 | `TsukijiVsToyosu`（EN/ES両方、3/31公開）が GSC URL Inspection で `"URL is unknown to Google"`。内部リンク不足が原因。**新規執筆より先に既存資産の救出を優先**（→ `comparison-article-playbook.md`） | CMO |
+| 2026-04-20 | 比較記事の型を3種（2-way比較 / Worth-it型 / 比較テーブル型）に統一、情報提供型の新規執筆は停止 | CMO+CSO |
+| 2026-04-20 | 次の新規1本は「Nikko Day Trip: Guided vs Solo」に決定（型再利用 + Nikko ¥80k最高単価 + 現在順位48〜54位で上昇余地最大） | CMO |
+| 2026-04-20 | `TsukijiVsToyosu` 救出実装: `TsukijiMarketGuide.tsx` / `TsukijiGuide.tsx` / ES版2本から内部リンク追加。GSC UI 側の Request Indexing は Manabu 手動タスクとして残す | CMO+COO |
+| 2026-04-20 | `NikkoDayTripGuideVsSolo.tsx` および `EsNikkoConGuiaVsSolo.tsx` を作成・公開。AppRoutes / prerender / sitemap / BlogIndex（EN+ES）すべて登録済み。NikkoDayTrip 記事（EN+ES）から内部リンクも追加。ファクトチェック済み数値（Tobu特急¥6,680RT、Toshogu¥1,600、Kegon滝エレベーター¥570等）を反映 | CMO |
+| 2026-04-20 | `KamakuraDayTripGuideVsSolo.tsx` と `EsKamakuraConGuiaVsSolo.tsx` を作成・公開。Day Trip Guided vs Solo トリロジー完成（Hakone✓ / Nikko✓ / Kamakura✓）。訴求軸は Nikko と逆で「Solo 極端に安い（¥4k）、Guided は価値で売る」。JR運賃¥1,900RT、Hasedera紫陽花整理券¥500等をファクトチェック済 | CMO |
+| 2026-04-20 | `LicensedVsUnlicensedTourGuidesJapan.tsx`（EN新規）を作成、`EsGuiaLicenciaOficialJapon.tsx`（ES既存）と hreflang ペア化。既存ES記事の数値も公式ソースに合わせて修正（登録ガイド数 26,000 → 27,950人、資格名 通訳案内士 → 全国通訳案内士、合格率更新）。既存ES記事はBlogIndex・sitemap未登録の「第2の stranded article」だったため救出 | CMO |
+| 2026-04-20 | `IsItWorthHiringGuide.tsx` / `KamakuraDayTrip.tsx` / `EsValeLaPenaGuia.tsx` / `EsKamakuraDesdeTokio.tsx` から新記事への内部リンク追加（ハブ→ハブ化、TsukijiVsToyosuの stranded 再発防止の横展開） | COO |
+| 2026-08-01 | **転換率は検索意図で決まり、CTA設置数とは無相関**と確定（情報系5.6% vs 意思決定系23.1%）。全記事のCTA構成を照合して検証済み。以降「CTAを増やす」型の施策は採用しない | CSO+CMO |
+| 2026-08-01 | 情報系記事→意思決定系記事の内部リンクを EN6本／ES5本＋tipping-in-japan に追加（PR #133/#134）。高エンゲージ・転換ゼロの月249セッションに中間段を用意する狙い | COO |
+| 2026-08-01 | 診断ツールの実装バグを修正（PR #133）。`tourPath` が全6設定に定義済みなのに未描画で、結果画面からツアーページへの導線が存在しなかった。`diagnostic_to_tour` は readMorePath に誤配線されていたため是正し、記事リンク用に `diagnostic_to_article` を新設。**`diagnostic_to_tour` は意味が変わったため 2026-07 以前と接続不可** | CTO |
+| 2026-08-01 | `tipping-in-japan`（本文×2）と `tokyo-on-a-budget`（本文×3）の重複コンテンツを除去（PR #134）。原因は `$1`/`$2` を後方参照として解釈した一括置換事故。全記事走査で同種の破損は他になしを確認 | CTO+COO |
+| 2026-08-01 | GA4 のカスタムイベント**登録は不要**と確認（Admin API で検証）。未登録でも自動収集され、`tool_id`/`result_id`/`question_id` はカスタムディメンション登録済み。`diagnostic_to_article`・`diagnostic_to_tour` は key event に**しない**（クリック先で `tour_page_view` が発火し二重計上になるため） | CTO |
+| 2026-08-01 | `conversions` 指標は key event 6種の合計（実質ツアーページ閲覧数）であり予約数ではないと明文化。**実リードは `form_submit` のみ、月16件規模**。以降の分析で混同しないこと | CEO+CTO |
+| 2026-08-01 | AI Assistant（chatgpt.com 中心、47セッション/月）を正式チャネルとしてKPI化。方針B（GEO戦）の継続投資判断は次期の推移で行う | CSO |
+| 2026-08-01 | 次の最優先施策は **ES版の意思決定系記事の追加**（`comparativa-excursiones` 型の横展開）に決定。転換率63.8%・滞在501秒、かつES全体でCTR2.3倍・転換率2倍という効率差が根拠 | CMO |
+| 2026-08-01 | 主力比較記事2本（`kamakura-vs-hakone-vs-nikko-day-trip` 順位4.6→6.89・クリック-36%、`is-it-worth-hiring-a-tour-guide-in-tokyo` 順位5.5→14.83）の順位下落を検出。**転換率最高クラスタの旗艦が縮小**しており、ES新規執筆と並行して原因調査を行う。総セッション+146%という数字に隠れて見落とされやすい点を明記 | CMO+CSO |
+| 2026-08-01 | GSC のページ間比較は **trailing slash 版と合算**して行うルールとする。4月時点は重複URLでクリックが分散しており、非スラッシュ版のみの単純比較は変化を誤読する（例: kamakura記事は非スラッシュ比較だと -9 だが実際は -28） | CTO |
+
+---
+
+## 7. 次回スナップショット取得手順
+
+```bash
+# 0. gcloud の Python パスが壊れている場合の回避策
+export CLOUDSDK_PYTHON=/usr/local/bin/python3
+export PATH="$HOME/google-cloud-sdk/bin:$PATH"
+
+# 1. 認証（初回のみ）
+gcloud auth application-default login \
+  --scopes=openid,https://www.googleapis.com/auth/userinfo.email,\
+https://www.googleapis.com/auth/cloud-platform,\
+https://www.googleapis.com/auth/webmasters.readonly,\
+https://www.googleapis.com/auth/analytics.readonly
+
+# 2. データ取得（デフォルト = 3日前を終点に28日）
+bash docs/analytics/fetch-snapshot.sh
+
+# 3. 本ファイルをコピーし日付を更新
+cp docs/analytics/snapshots/2026-07-28_28d.md \
+   docs/analytics/snapshots/YYYY-MM-DD_28d.md
+
+# 4. KPI表（セクション1）を diff で更新
+# 5. Winners / Losers / Watchlist を当期データで書き換え
+# 6. 決定事項（セクション6）に当期の意思決定を「追記」（上書き禁止）
+```
+
+### 次回の重点確認項目（当期施策の効果判定）
+
+| 指標 | 当期ベースライン | 期待する動き |
+|---|---|---|
+| 情報系クラスタの転換率 | 5.6% | 内部リンク追加で上昇するか |
+| `blog_to_tour_click` | 50/28日 | 増加するか |
+| `diagnostic_to_tour` | 実質ゼロ（新規計測） | ツアー導線復旧で発生するか |
+| `diagnostic_to_article` | 0（新設） | ベースライン取得 |
+| AI Assistant セッション | 47/28日 | 定着するか一過性か |
+| `form_submit` | 15/28日 | 最終的にここが動くか |


### PR DESCRIPTION
前回スナップショット（2026-04-20）から約3.5か月ぶり。README のセクション構成を踏襲し、セクション6の決定ログは**4月分を全て保持したうえで**当期分を追記。

## KPI ハイライト

| 指標 | 4月SS | 当期 | |
|---|---|---|---|
| GSC clicks | 293 | **694** | +137% |
| GSC CTR | 0.22% | **0.55%** | 2.5倍 |
| GA4 sessions | 625 | **1,538** | +146% |
| form_submit（実リード） | 12 | 15 | **+25%のみ** |

**トラフィック成長が収益に転化していない**のが当期の構造課題。

## 主な発見

- **意思決定系クラスタは情報系の4.1倍転換**（23.1% vs 5.6%）。CTA設置数とは無相関であることを全記事照合で確認
- 新チャネル **AI Assistant**（chatgpt.com 中心、47セッション/月）の出現
- ES版は記事数が英語の半分で **CTR 2.3倍・転換率2倍**
- 高エンゲージ・転換ゼロの死蔵在庫が月249セッション

## 4月からの改善（解消済み）

trailing slash 重複 / `blog_to_tour_click` 計測不全（1→50件）/ 平均滞在の劣化（127s→199s）はいずれも解消を確認。

## ⚠ 新たに検出した要注意事項

主力の意思決定系記事2本が順位下落：

| ページ | clicks | 順位 |
|---|---|---|
| kamakura-vs-hakone-vs-nikko-day-trip | 77→49（**-36%**） | 4.6→6.89 |
| is-it-worth-hiring-a-tour-guide-in-tokyo | 10→13 | 5.5→**14.83** |

転換率が最も高いクラスタの旗艦が縮小しており、総セッション+146%という数字に隠れて見落とされやすい。次回までに原因調査が必要。

## 計測上の注意を明文化

- `conversions` は key event 6種の合計（実質ツアーページ閲覧数）で**予約数ではない**。実リードは `form_submit` のみ、月16件規模
- GSC のページ間比較は **trailing slash 版と合算**して行う（4月は重複URLでクリックが分散しており単純比較は変化を誤読する。例: kamakura記事は非スラッシュ比較だと-9だが実際は-28）
- アンカーURL（`#section-…`）98,001imp はサイト全体CTRの分母に入っていない

## 検証

全29項目の数値を `docs/analytics/raw/2026-07-28_28d_*.json` と照合済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)